### PR TITLE
Add CrossFit docs and update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,36 @@
+# CrossFit Knowledge Management
+
+## Knowledge Sources
+
+Before implementing CrossFit domain logic:
+
+1. Read relevant docs in `cf/docs/`.
+2. Use source references only when documentation is missing or needs verification.
+3. Prefer project documentation over assumptions.
+
+## Documentation Maintenance
+
+The files in `cf/docs/` may start sparse. Treat them as living project knowledge: update them when development clarifies terminology, movement standards, programming rules, or architectural/domain decisions.
+
+When CrossFit domain knowledge is discovered or clarified:
+
+- Update the appropriate file in `cf/docs/`.
+- Prefer updating an existing file over creating a new one.
+- Keep documentation concise and factual.
+
+## Architectural Decisions
+
+Project-specific decisions belong in:
+
+- `cf/docs/decisions.md`
+
+When a domain decision is made that affects future development:
+
+1. Add an entry to `decisions.md`.
+2. Include the rationale.
+3. Reference the decision when implementing related features.
+
+
 # Agent Guidelines
 
 Derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.

--- a/cf/docs/decisions.md
+++ b/cf/docs/decisions.md
@@ -1,0 +1,1 @@
+# Decisions

--- a/cf/docs/movement-standards.md
+++ b/cf/docs/movement-standards.md
@@ -1,0 +1,1 @@
+# Movement Standards

--- a/cf/docs/programming.md
+++ b/cf/docs/programming.md
@@ -1,0 +1,1 @@
+# Programming

--- a/cf/docs/references.md
+++ b/cf/docs/references.md
@@ -1,0 +1,13 @@
+# References
+
+## CrossFit Level 1 Training Guide
+
+Source:
+https://library.crossfit.com/free/pdf/CFJ_English_Level1_TrainingGuide.pdf
+
+Use this document as the authoritative reference.
+
+## CrossFit Level 2 Training Guide
+
+Source:
+https://library.crossfit.com/free/pdf/CFJ_English_L2_TrainingGuide.pdf

--- a/cf/docs/terminology.md
+++ b/cf/docs/terminology.md
@@ -1,0 +1,1 @@
+# Terminology


### PR DESCRIPTION
Introduce initial CrossFit documentation and guidance. Adds new files under cf/docs/: decisions.md, movement-standards.md, programming.md, references.md (includes CrossFit Level 1/2 training guide links), and terminology.md. Updates AGENTS.md with a CrossFit Knowledge Management section that describes sourcing, documentation maintenance, and how to record architectural/domain decisions (pointing to decisions.md). Purpose: centralize domain knowledge and provide clear guidance for developers/agents to keep the docs up to date.