### PR TITLE
Support fixed-rep AMRAP logging and scoring

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -15,7 +15,7 @@ class LogsController < ApplicationController
   # GET /logs/new
   def new
     @log = @workout.logs.build
-    @log.build_metric(measurement: @workout.metric.measurement)
+    @log.build_metric(measurement: @workout.log_metric_measurement)
     @log.build_movement_logs
   end
 

--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -14,6 +14,8 @@ module MeasurableHelper
     return measurable.movement.name unless rep_metric
 
     movement_name = measurable.movement.name
+    return "max reps #{movement_name}" if max_rep_metric?(rep_metric)
+
     [metric_unit_msg(rep_metric), movement_name_for_rep_metric(movement_name, rep_metric)].compact_blank.join(' ')
   end
 
@@ -83,6 +85,8 @@ module MeasurableHelper
 
     false
   end
+
+  def max_rep_metric?(metric) = metric.rep? && metric.value.blank? && !metric.sex_specific?
 
   def duration_movement_msg(measurable, rep_metric, duration_metric)
     movement_name = duration_pluralize_movement?(rep_metric) ? measurable.movement.name.pluralize : measurable.movement.name

--- a/app/helpers/workouts_helper.rb
+++ b/app/helpers/workouts_helper.rb
@@ -2,9 +2,9 @@ module WorkoutsHelper
   def workout_objective(workout)
     return "#{pluralize workout.rounds, 'set'} for load" if workout.set_based_lifting?
     return for_time_objective(workout) if workout.rounds_for_time?
-    return "As many rounds as possible in #{pluralize workout.time, 'minute'}" if workout.amrap?
+    return amrap_objective(workout) if workout.amrap?
     return "EMOM #{workout.time}" if workout.emom?
-    return "#{workout.rounds} #{workout.time}-minute rounds" if workout.timed_rounds?
+    return timed_rounds_objective(workout) if workout.timed_rounds?
 
     "#{workout.interval} for #{workout.metric.measurement}"
   end
@@ -17,5 +17,19 @@ module WorkoutsHelper
     return 'For Time' if workout.rounds == 1
 
     "#{pluralize workout.rounds, 'round'} for time"
+  end
+
+  def amrap_objective(workout)
+    score = workout.fixed_rep_amrap? ? 'rounds and reps' : 'rounds'
+
+    "As many #{score} as possible in #{pluralize workout.time, 'minute'}"
+  end
+
+  def timed_rounds_objective(workout)
+    if workout.metric&.rep?
+      "#{pluralize workout.rounds, 'round'}, complete as many reps as possible in #{pluralize workout.time, 'minute'} of"
+    else
+      "#{workout.rounds} #{workout.time}-minute rounds"
+    end
   end
 end

--- a/app/models/concerns/log_scoring.rb
+++ b/app/models/concerns/log_scoring.rb
@@ -6,6 +6,7 @@ module LogScoring
 
   included do
     before_validation :calculate_set_based_lifting_score
+    before_validation :convert_fixed_amrap_round_score_to_reps
     before_validation :normalize_amrap_score
   end
 
@@ -39,6 +40,12 @@ module LogScoring
 
     metric.measurement = score.measurement
     metric.value = score.value
+  end
+
+  def convert_fixed_amrap_round_score_to_reps
+    return unless workout&.fixed_rep_amrap? && metric&.round?
+
+    metric.measurement = :rep
   end
 
   def normalize_amrap_score_value(raw_value, round_total)

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -2,14 +2,16 @@ module WorkoutScoring
   extend ActiveSupport::Concern
 
   def rep_scored_amrap?
-    amrap? && metric&.rep?
+    amrap? && (metric&.rep? || fixed_rep_amrap?)
+  end
+
+  def fixed_rep_amrap?
+    amrap? && fixed_amrap_reps_per_round.present?
   end
 
   def set_based_lifting?
-    rounds.present? &&
-      rounds.positive? &&
-      time.blank? &&
-      interval.blank? &&
+    set_based_lifting_structure? &&
+      metric&.weight? &&
       top_level_exercises.any?(&:load_bearing?)
   end
 
@@ -41,7 +43,27 @@ module WorkoutScoring
   end
 
   def amrap_reps_per_round
-    return nil unless rep_scored_amrap?
+    return nil unless amrap?
+
+    fixed_amrap_reps_per_round
+  end
+
+  def log_metric_measurement
+    return :rep if fixed_rep_amrap?
+
+    metric.measurement
+  end
+
+  private
+
+  def set_based_lifting_structure?
+    rounds.present? &&
+      rounds.positive? &&
+      time.blank? &&
+      interval.blank?
+  end
+
+  def fixed_amrap_reps_per_round
     return nil if top_level_exercises.empty?
 
     top_level_exercises.sum do |exercise|
@@ -51,8 +73,6 @@ module WorkoutScoring
       component[:score_reps]
     end
   end
-
-  private
 
   def successful_set_load(exercise, movement_log)
     return unless completed_prescribed_reps?(exercise, movement_log)

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -26,13 +26,9 @@ class Metric < ApplicationRecord
   end
 
   def calculated_value(workout)
-    rounds = workout.rounds
     return value unless rep?
-    return value * workout.reps_from_interval if workout.interval?
-    return nil unless value # Reps can be nil to signify max
-    return value if rounds.nil? || rounds&.zero?
 
-    value * rounds
+    calculated_rep_value(workout)
   end
 
   def value=(new_value)
@@ -53,6 +49,19 @@ class Metric < ApplicationRecord
   end
 
   private
+
+  def calculated_rep_value(workout)
+    return value * workout.reps_from_interval if workout.interval?
+    return value if fixed_timed_rounds?(workout)
+    return nil unless value # Reps can be nil to signify max
+    return value if workout.rounds.nil? || workout.rounds.zero?
+
+    value * workout.rounds
+  end
+
+  def fixed_timed_rounds?(workout)
+    workout.timed_rounds? && !workout.emom?
+  end
 
   def values_are_unambiguous
     return if valid_value_combination?

--- a/cf/docs/programming.md
+++ b/cf/docs/programming.md
@@ -19,6 +19,10 @@ Common structures include:
 - A one-round workout scored for time should render as `For Time`, not
   `1 round for time`.
 - AMRAP: complete as many rounds or reps as possible in a fixed time.
+- Fixed-rep AMRAPs such as Cindy and Mary should be logged as rounds plus
+  reps and stored as total reps with a snapshotted reps-per-round value. AMRAPs
+  with a max-rep station, such as Nicole, should not derive a fixed
+  reps-per-round total.
 - EMOM: complete prescribed work every minute on the minute.
 - Interval workouts: repeated work/rest segments or fixed interval schemes such
   as Tabata.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -234,7 +234,7 @@ cfj.schedules.find_or_initialize_by(workout: chelsea).update(posted_at: '28-01-2
 # 15 squats
 cindy = Workout.find_or_create_by(name: 'Cindy') do |workout|
   workout.time = 20
-  workout.build_metric(measurement: :round)
+  workout.build_metric(measurement: :rep)
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 5)
   end
@@ -432,7 +432,7 @@ cfj.schedules.find_or_initialize_by(workout: linda).update(posted_at: '18-01-201
 # 15 pull-ups
 mary = Workout.find_or_create_by(name: 'Mary') do |workout|
   workout.time = 20
-  workout.build_metric(measurement: :round)
+  workout.build_metric(measurement: :rep)
   workout.exercises.build(movement: hspu, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 5)
   end

--- a/test/controllers/logs_controller_test.rb
+++ b/test/controllers/logs_controller_test.rb
@@ -42,6 +42,32 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 25, Log.last.reps_per_round
   end
 
+  test 'new log for fixed-rep round-scored amrap uses rep score input' do
+    workout = workouts(:amrap_couplet)
+    workout.metric.update!(measurement: :round)
+
+    get new_workout_log_url(workout)
+
+    assert_response :success
+    assert_select 'input[name="log[metric_attributes][measurement]"][value="rep"]'
+  end
+
+  test 'creates fixed-rep amrap log from stale round score submission' do
+    workout = workouts(:amrap_couplet)
+    workout.metric.update!(measurement: :round)
+
+    assert_difference('Log.count') do
+      post workout_logs_url(workout), params: { log: {
+        metric_attributes: { measurement: :round, value: '20+2' }
+      } }
+    end
+
+    assert_redirected_to log_url(Log.last)
+    assert_equal 'rep', Log.last.metric.measurement
+    assert_equal 502, Log.last.metric.value
+    assert_equal 25, Log.last.reps_per_round
+  end
+
   test 'creates amrap log from raw total reps' do
     assert_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -34,6 +34,14 @@ class MeasurableHelperTest < ActionView::TestCase
     assert_equal '1:00 Wall-ball Shots (♀14lb + 9ft / ♂20lb + 10ft)', measurable_message(exercise)
   end
 
+  test 'renders untimed max-rep station movements with max reps prefix' do
+    toes_to_bar = Movement.create!(name: 'Toes to Bar')
+    exercise = workouts(:fran).exercises.create!(movement: toes_to_bar, position: 3)
+    exercise.metrics.create!(measurement: :rep)
+
+    assert_equal 'max reps Toes to Bar', measurable_message(exercise)
+  end
+
   test 'renders timed station movements without pluralizing fixed single-rep movements' do
     exercise = workouts(:fran).exercises.create!(movement: movements(:row), position: 3)
     exercise.metrics.create!(measurement: :rep, value: 1)

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -8,4 +8,16 @@ class WorkoutsHelperTest < ActionView::TestCase
   test 'renders set-based lifting workouts as sets for load' do
     assert_equal '5 sets for load', workout_objective(workouts(:back_squat_5x5))
   end
+
+  test 'renders fixed-rep amraps as rounds and reps' do
+    assert_equal 'As many rounds and reps as possible in 10 minutes', workout_objective(workouts(:amrap_couplet))
+  end
+
+  test 'renders timed rep-scored rounds as round amraps' do
+    workout = workouts(:back_squat_5x5)
+    workout.update!(time: 3)
+    workout.metric.update!(measurement: :rep)
+
+    assert_equal '5 rounds, complete as many reps as possible in 3 minutes of', workout_objective(workout)
+  end
 end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -10,6 +10,18 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 25, log.reps_per_round
   end
 
+  test 'normalizes fixed-rep amrap round score submissions to reps' do
+    workout = workouts(:amrap_couplet)
+    workout.metric.update!(measurement: :round)
+    log = workout.logs.build(user: users(:mathew))
+    log.build_metric(measurement: :round, value: '20+2')
+
+    assert log.valid?
+    assert_equal 'rep', log.metric.measurement
+    assert_equal 502, log.metric.value
+    assert_equal 25, log.reps_per_round
+  end
+
   test 'normalizes overflow reps into total reps' do
     log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
     log.build_metric(measurement: :rep, value: '20+27')
@@ -82,6 +94,19 @@ class LogTest < ActiveSupport::TestCase
       assert_equal 5, movement_log.metrics.find(&:rep?).value
       assert_nil movement_log.metrics.find(&:lb?).value
     end
+  end
+
+  test 'builds timed round movement recordings with per-round prescribed reps' do
+    workout = workouts(:back_squat_5x5)
+    workout.update!(time: 3)
+    workout.metric.update!(measurement: :rep)
+
+    log = workout.logs.build(user: users(:mathew))
+    log.build_metric(measurement: :rep)
+    log.build_movement_logs
+
+    assert_equal 1, log.movement_logs.size
+    assert_equal 5, log.movement_logs.first.metrics.find(&:rep?).value
   end
 
   test 'calculates set-based lifting score from heaviest successful set' do

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -24,4 +24,11 @@ class WorkoutTest < ActiveSupport::TestCase
     assert workouts(:back_squat_5x5).set_based_lifting?
     assert_not workouts(:amrap_couplet).set_based_lifting?
   end
+
+  test 'does not identify rep-scored rounds with load-bearing exercises as set-based lifting' do
+    workout = workouts(:back_squat_5x5)
+    workout.metric.update!(measurement: :rep)
+
+    assert_not workout.set_based_lifting?
+  end
 end


### PR DESCRIPTION
Add full support for fixed-rep AMRAPs: recognize fixed-rep AMRAP workouts, convert stale round-scored AMRAP submissions to rep measurement before validation, and store per-round rep snapshot. Refactor workout scoring to expose helpers (fixed_rep_amrap?, log_metric_measurement, set_based_lifting_structure?), adjust metric rep calculation for timed rounds, and normalize AMRAP input handling. Update helpers to render AMRAP and max-rep movement messages, seed data for Cindy/Mary to use rep metrics, and modify LogsController to build new logs using the workout's log_metric_measurement. Tests and docs updated to cover the new behavior.