### PR TITLE
Add Action Text for workout notes

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,4 +1,5 @@
 @import "bootstrap/scss/bootstrap";
+@import "trix/dist/trix";
  // TomSelect Fix https://github.com/orchidjs/tom-select/pull/601
 $select-color-dropdown-border-top: $input-border-color;
 $select-color-dropdown: $body-bg;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,7 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
+import "trix"
+import "@rails/actiontext"
 import "./controllers"
 
 import * as bootstrap from "bootstrap"

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -9,6 +9,7 @@ class Workout < ApplicationRecord
   has_many :movement_logs, through: :logs
   has_many :schedules, dependent: :destroy
   has_many :programs, through: :schedules
+  has_rich_text :notes
 
   accepts_nested_attributes_for :metric
   accepts_nested_attributes_for :exercises, allow_destroy: true

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -12,8 +12,9 @@
           = schedule.workout.name
         i.col.text-end
           = link_to schedule.program.name, schedule.program
-      .row
-        p.col #{schedule.workout.notes}
+      - if schedule.workout.notes.present?
+        .row
+          .col = schedule.workout.notes
       .row
         p.col #{workout_objective schedule.workout}
       .row

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -8,7 +8,9 @@
     = f.simple_fields_for :metric do |metric_form|
       .col-12 = metric_form.input :measurement, collection: Metric.workout_measurements, label: 'For'
     .col-12 = f.input :time_cap
-    .col = f.input :notes
+    .col-12
+      = f.label :notes, class: 'form-label'
+      = f.rich_text_area :notes
   hr
   h3 Exercises
   #exercises

--- a/app/views/workouts/show.html.slim
+++ b/app/views/workouts/show.html.slim
@@ -32,9 +32,9 @@
         p
           b Time cap:
           span  #{@workout.time_cap}
-      - unless @workout.notes.blank?
+      - if @workout.notes.present?
         b Notes
-        .notes = simple_format @workout.notes
+        .notes = @workout.notes
       .d-grid.gap-2
         = link_to 'Schedule', nil, class: 'btn btn-secondary', "data-bs-toggle": "modal", "data-bs-target": "#scheduleModal" if can? :create, Schedule
         = link_to 'Log', new_workout_log_path(@workout), class: 'btn btn-outline-primary'

--- a/db/migrate/20260604120000_migrate_workout_notes_to_rich_text.rb
+++ b/db/migrate/20260604120000_migrate_workout_notes_to_rich_text.rb
@@ -1,0 +1,49 @@
+class MigrateWorkoutNotesToRichText < ActiveRecord::Migration[8.1]
+  class MigrationWorkout < ActiveRecord::Base
+    self.table_name = 'workouts'
+  end
+
+  class MigrationRichText < ActiveRecord::Base
+    self.table_name = 'action_text_rich_texts'
+  end
+
+  def up
+    MigrationWorkout.where.not(notes: [nil, '']).find_each do |workout|
+      rich_text = MigrationRichText.find_or_initialize_by(
+        record_type: 'Workout',
+        record_id: workout.id,
+        name: 'notes'
+      )
+
+      next if rich_text.persisted? && rich_text.body.present?
+
+      rich_text.update!(
+        body: rich_text_body(workout.notes),
+        created_at: workout.created_at,
+        updated_at: workout.updated_at
+      )
+    end
+
+    remove_column :workouts, :notes
+  end
+
+  def down
+    add_column :workouts, :notes, :text
+    MigrationWorkout.reset_column_information
+
+    MigrationRichText.where(record_type: 'Workout', name: 'notes').find_each do |rich_text|
+      workout = MigrationWorkout.find_by(id: rich_text.record_id)
+      workout&.update!(notes: ActionText::Content.new(rich_text.body).to_plain_text)
+    end
+
+    MigrationRichText.where(record_type: 'Workout', name: 'notes').delete_all
+  end
+
+  private
+
+  def rich_text_body(notes)
+    notes.to_s.split(/\r?\n\r?\n/).map do |paragraph|
+      "<div>#{ERB::Util.html_escape(paragraph).gsub(/\r?\n/, '<br>')}</div>"
+    end.join
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -167,7 +167,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_130000) do
     t.datetime "created_at", precision: nil, null: false
     t.string "interval"
     t.string "name"
-    t.text "notes"
     t.integer "rounds"
     t.integer "time"
     t.integer "time_cap_seconds"

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.23",
     "@popperjs/core": "^2.11.8",
+    "@rails/actiontext": "^8.1.300",
     "@rails/activestorage": "^8.1.300",
     "@rails/request.js": "^0.0.13",
     "bootstrap": "^5.3.8",
     "esbuild": "^0.28.0",
     "local-time": "^3.0.3",
     "sass": "^1.100.0",
-    "tom-select": "^2.6.1"
+    "tom-select": "^2.6.1",
+    "trix": "^2.1.19"
   },
   "devDependencies": {}
 }

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -19,15 +19,17 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create workout' do
-    assert_difference('Workout.count') do
+    assert_difference(['Workout.count', 'ActionText::RichText.count']) do
       post workouts_url, params: { workout: {
         name: @workout.name,
         rounds: @workout.rounds,
+        notes: '<div>Use the prescribed loading.</div>',
         metric_attributes: { measurement: :round }
       } }
     end
 
     assert_redirected_to workout_url(Workout.last)
+    assert_equal 'Use the prescribed loading.', Workout.last.notes.to_plain_text.strip
   end
 
   test 'should create workout with nested exercise metrics' do
@@ -88,11 +90,18 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit' do
     get edit_workout_url(@workout)
     assert_response :success
+    assert_select 'trix-editor'
   end
 
   test 'should update workout' do
-    patch workout_url(@workout), params: { workout: { name: @workout.name, rounds: @workout.rounds } }
+    patch workout_url(@workout), params: { workout: {
+      name: @workout.name,
+      rounds: @workout.rounds,
+      notes: '<div>Break up the pull-ups early.</div>'
+    } }
+
     assert_redirected_to workout_url(@workout)
+    assert_equal 'Break up the pull-ups early.', @workout.reload.notes.to_plain_text.strip
   end
 
   test 'should destroy workout' do

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -65,6 +65,13 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
     assert_no_selector "#workout_#{workouts(:fran).id}"
   end
 
+  test 'edits workout notes with the rich text editor' do
+    visit edit_workout_url(workouts(:fran))
+
+    assert_selector 'trix-toolbar'
+    assert_selector 'trix-editor[input^="workout_notes_trix_input"]'
+  end
+
   test 'schedules a workout' do
     subscriptions(:one).update!(role: :owner)
     visit workout_url(workouts(:murph))

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,7 +260,14 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.0.200.tgz#1d27d9d55e45266e061190db045925e0b4d53d6b"
   integrity sha512-EDqWyxck22BHmv1e+mD8Kl6GmtNkhEPdRfGFT7kvsv1yoXd9iYrqHDVAaR8bKmU/syC5eEZ2I5aWWxtB73ukMw==
 
-"@rails/activestorage@^8.1.300":
+"@rails/actiontext@^8.1.300":
+  version "8.1.300"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-8.1.300.tgz#0b6d0a40e8ca8ba2caf5a0077e10b5503183a044"
+  integrity sha512-KPbLfZTt6aFKbdeTlU7ZzmX0uSSNhhfZx3G+2lfa6HltQ/r23HDcJnJOEVt72WKJo13IS5C5HK0sYwplVMCdNw==
+  dependencies:
+    "@rails/activestorage" ">= 8.1.0-alpha"
+
+"@rails/activestorage@>= 8.1.0-alpha", "@rails/activestorage@^8.1.300":
   version "8.1.300"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-8.1.300.tgz#624a6f291e0414c07c3d02ed3d1e6ee85c94277b"
   integrity sha512-AOv3zZrTJjQlzm4L9uzOQtCz6zaM4IqUyux6yzSqmS+PZ8EzwD1F2JAc4LlJNJAv4MSyNYriG+CaCm1QbQTjsA==
@@ -271,6 +278,11 @@
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.13.tgz#3c7cbd0303ea9ef51bd3e7acaab86e9324efc52f"
   integrity sha512-7MXmjFOPuaxpjG8brqKJG0EfIe9ak6R0wRnjCBtRuADNFbdlRxETdKx1T5NVU4Ato3iZOkEpeSUEuLboL3tCGA==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 bootstrap@^5.3.8:
   version "5.3.8"
@@ -295,6 +307,13 @@ detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
+dompurify@^3.2.5:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
+  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 esbuild@^0.28.0:
   version "0.28.0"
@@ -420,3 +439,10 @@ tom-select@^2.6.1:
   dependencies:
     "@orchidjs/sifter" "^1.1.0"
     "@orchidjs/unicode-variants" "^1.1.2"
+
+trix@^2.1.19:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-2.1.19.tgz#1eb5dfd44a41e6179df5b0c17fdea13d10ae805d"
+  integrity sha512-E7RA3EOeUiUwNJlrF5onIOkqCA06xUU6GmHOVxXyMnGMValrDK3Ce7uaMVgiVUOvVt4mzUERAHAzD10mxoLpOg==
+  dependencies:
+    dompurify "^3.2.5"


### PR DESCRIPTION
Migrate workout notes to Action Text (rich text) and integrate Trix. Adds has_rich_text :notes to Workout, a migration (MigrateWorkoutNotesToRichText) to convert existing notes into action_text_rich_texts and remove the old notes column, and updates db schema version. Wire up Trix and ActionText in the frontend (JS and stylesheet imports) and add the rich_text_area to the workout form. Update show/schedule views to render rich content only when present. Tests updated to assert rich text creation, editing UI, and note contents after create/update.