### PR TITLE
Scope log lookup to current user; add access tests

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -70,7 +70,7 @@ class LogsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_log
-    @log = Log.find(params.expect(:id))
+    @log = Current.user.logs.find(params.expect(:id))
   end
 
   def set_workout

--- a/test/controllers/logs_controller_test.rb
+++ b/test/controllers/logs_controller_test.rb
@@ -30,6 +30,34 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 45, Log.last.movement_logs.first.metrics.find_by!(measurement: :rep).value
   end
 
+  test 'should not show another user log' do
+    get log_url(logs(:brooke_fran))
+
+    assert_response :not_found
+  end
+
+  test 'should not edit another user log' do
+    get edit_workout_log_url(logs(:brooke_fran).workout, logs(:brooke_fran))
+
+    assert_response :not_found
+  end
+
+  test 'should not update another user log' do
+    patch workout_log_url(logs(:brooke_fran).workout, logs(:brooke_fran)), params: {
+      log: { metric_attributes: { measurement: :time, value: '4:59' } }
+    }
+
+    assert_response :not_found
+  end
+
+  test 'should not destroy another user log' do
+    assert_no_difference('Log.count') do
+      delete log_url(logs(:brooke_fran))
+    end
+
+    assert_response :not_found
+  end
+
   test 'creates amrap log from rounds plus reps score' do
     assert_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {


### PR DESCRIPTION
Fixes #1606

Prevent cross-user access by scoping log lookup to Current.user.logs.find instead of unscoped Log.find. Add controller tests verifying that show, edit, update and destroy actions return 404 and do not allow operations on another user's logs.