### PR TITLE
[codex] Preload schedule index associations

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -7,7 +7,8 @@ class SchedulesController < ApplicationController
 
     @dates = @schedules.posted_dates.page(params[:page]).per(1)
     @date = @dates.first.posted_at
-    @schedules = @schedules.where(posted_at: @date.beginning_of_day...@date.end_of_day)
+    @schedules = schedules_for_date
+    @logged_workout_ids = logged_workout_ids_for(@schedules)
   end
 
   # POST /schedules
@@ -30,5 +31,23 @@ class SchedulesController < ApplicationController
   # Only allow a list of trusted parameters through.
   def schedule_params
     params.expect(schedule: [:workout_id, :program_id, :posted_at])
+  end
+
+  def schedules_for_date
+    @schedules
+      .where(posted_at: @date.beginning_of_day...@date.end_of_day)
+      .includes(
+        :program,
+        workout: [
+          :metric,
+          :rich_text_notes,
+          { exercises: [:movement, :metrics, { segment: [:metric, :exercises] }] }
+        ]
+      )
+  end
+
+  def logged_workout_ids_for(schedules)
+    workout_ids = schedules.map(&:workout_id)
+    Current.user.logs.where(workout_id: workout_ids).distinct.pluck(:workout_id)
   end
 end

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -19,10 +19,10 @@
         p.col #{workout_objective schedule.workout}
       .row
         ul.list-unstyled.col
-          = render partial: 'exercises/exercises', object: schedule.workout.exercises.order(:position)
+          = render partial: 'exercises/exercises', object: schedule.workout.exercises
       .row
         .col-12
           .d-grid
             = link_to 'Log', new_workout_log_path(schedule.workout), class: 'btn btn-outline-primary'
-            - if Current.user.logged_workout? schedule.workout
+            - if @logged_workout_ids.include?(schedule.workout_id)
               / = link_to 'See Previous Results', new_workout_log_path(schedule.workout), class: 'btn btn-block btn-secondary'

--- a/test/controllers/schedules_controller_test.rb
+++ b/test/controllers/schedules_controller_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class SchedulesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:mathew)
+  end
+
+  test 'index batches logged workout lookup for rendered schedules' do
+    Schedule.create!(
+      program: programs(:crossfit),
+      workout: workouts(:murph),
+      posted_at: schedules(:one).posted_at
+    )
+
+    query_counts = count_matching_queries(logs: /FROM "logs"/, exercises: /FROM "exercises"/) do
+      get schedules_url
+    end
+
+    assert_response :success
+    assert_equal 1, query_counts[:logs]
+    assert_equal 1, query_counts[:exercises]
+  end
+
+  private
+
+  def count_matching_queries(patterns, &)
+    counts = patterns.transform_values { 0 }
+    callback = lambda do |_name, _started, _finished, _unique_id, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      patterns.each { |name, pattern| counts[name] += 1 if payload[:sql].match?(pattern) }
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &)
+
+    counts
+  end
+end


### PR DESCRIPTION
## Summary
- Preload the schedule index associations used by the rendered page: program, workout metric/notes, exercises, movements, exercise metrics, and segment data.
- Precompute logged workout IDs for the displayed schedules and use that set in the view instead of calling `Current.user.logged_workout?` per schedule.
- Use the preloaded exercise association directly in the schedule view so rendering does not issue ordered exercise queries per workout.
- Add a controller regression test that renders multiple schedules and verifies the logged-workout lookup and exercise loading stay batched.

Fixes #1609.

## Validation
- `rvm 3.4.9@wod-tracker do bundle exec rails test test/controllers/schedules_controller_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rubocop app/controllers/schedules_controller.rb test/controllers/schedules_controller_test.rb`
- `git diff --check`

Note: `gh` is not installed in this shell, and HTTPS git push was not credentialed, so the branch was published through the installed GitHub connector.