### PR TITLE
[codex] Update net-imap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       prism (~> 1.5)
     msgpack (1.8.1)
     nested_form (0.3.2)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
## Summary
- Update `net-imap` from `0.6.3` to `0.6.4` in `Gemfile.lock`.
- Resolves the vulnerable dependency reported in #1607.

## Validation
- `rvm 3.4.9@wod-tracker do bundle exec bundle-audit check --update`
- `rvm 3.4.9@wod-tracker do bundle exec rails test`

Closes #1607.