### PR TITLE
[codex] Reduce production JavaScript size

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,14 @@ import "./controllers"
 
 import * as bootstrap from "bootstrap"
 import LocalTime from "local-time"
-import "@fortawesome/fontawesome-free/js/all"
+import { dom, library } from "@fortawesome/fontawesome-svg-core"
+import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit"
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
+import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
+import { faTrashAlt } from "@fortawesome/free-solid-svg-icons/faTrashAlt"
+import { faUser } from "@fortawesome/free-solid-svg-icons/faUser"
+import { faCheckSquare } from "@fortawesome/free-regular-svg-icons/faCheckSquare"
 
 LocalTime.start()
+library.add(faCheckSquare, faEdit, faExternalLinkAlt, faPlus, faTrashAlt, faUser)
+dom.watch()

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "yarn": "1.22.22"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
+    "build": "esbuild app/javascript/*.* --bundle --minify --outdir=app/assets/builds",
     "build:css": "sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^7.2.0",
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/free-regular-svg-icons": "^7.2.0",
+    "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.23",
     "@popperjs/core": "^2.11.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,10 +132,31 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
   integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
 
-"@fortawesome/fontawesome-free@^7.2.0":
+"@fortawesome/fontawesome-common-types@7.2.0":
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz#188c1053ce422ad1f934d7df242a973fcb89636d"
-  integrity sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz#ae54831ab5974bc1a64e8b07410f2da2b4abf87f"
+  integrity sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==
+
+"@fortawesome/fontawesome-svg-core@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz#813550a5e8946a798e170d3f7331a685f8f8a550"
+  integrity sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.2.0"
+
+"@fortawesome/free-regular-svg-icons@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.2.0.tgz#9f2f0af03b851e8b261514dd495cf30653de2fbd"
+  integrity sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.2.0"
+
+"@fortawesome/free-solid-svg-icons@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz#9c761f7ab393e281f750c54d9ed1ebbcd4d581fa"
+  integrity sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.2.0"
 
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"


### PR DESCRIPTION
## Summary

Closes #1610.

- Minifies the production JavaScript build and stops emitting sourcemaps by default.
- Replaces the full Font Awesome JS bundle import with explicit registration for the icons used by the app.
- Swaps `@fortawesome/fontawesome-free` for the smaller SVG core plus free solid/regular icon packages needed by those imports.

## Validation

- `yarn install`
- `yarn build` emits `app/assets/builds/application.js` at 604,952 bytes with no `.map` file
- `git diff --check`

## Notes

Local HTTPS and SSH pushes were unavailable in this environment, so the branch was published through the GitHub connector after matching the locally verified tree.