### PR TITLE
[codex] Add missing Action Text migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ WOD Tracker is a Ruby on Rails app for tracking CrossFit workouts, logs, movemen
 
 Use the project binaries and Bundler where possible.
 
+Local shells may default to another Ruby. When running Ruby, Rails, Bundler, or test commands from an agent shell, use the project RVM gemset explicitly:
+
+- `rvm 3.4.9@wod-tracker do bundle exec rails test`
+
 - Install Ruby gems: `bundle install`
 - Install JavaScript packages: `yarn install`
 - Set up a new database: `bin/rails db:setup`

--- a/db/migrate/20260604110000_create_action_text_tables.action_text.rb
+++ b/db/migrate/20260604110000_create_action_text_tables.action_text.rb
@@ -1,0 +1,16 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[8.1]
+  def change
+    return if table_exists?(:action_text_rich_texts)
+
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add the missing Action Text rich text table migration before the workout notes data migration.
- Document the explicit RVM gemset wrapper for agent-run Rails and Bundler commands.

## Root Cause

Heroku runs `bundle exec rails db:migrate` during release. The workout notes migration writes to `action_text_rich_texts`, but the repository had the table only in `db/schema.rb`; CI loaded schema, while Heroku replayed migrations and failed because no migration created that table first.

## Validation

- `rvm 3.4.9@wod-tracker do bundle exec rails test test/controllers/workouts_controller_test.rb`
- `git diff --check`

Note: the fresh worktree needed `yarn install --frozen-lockfile`, `yarn build`, and `yarn build:css` before the controller test could render layouts.