### PR TITLE
[codex] Add direct workout and log score fields

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -15,7 +15,7 @@ class LogsController < ApplicationController
   # GET /logs/new
   def new
     @log = @workout.logs.build
-    @log.build_metric(measurement: @workout.log_metric_measurement)
+    @log.score_type = @workout.log_metric_measurement
     @log.build_movement_logs
   end
 
@@ -85,8 +85,10 @@ class LogsController < ApplicationController
                         :id,
                         :movement_id,
                         { metrics_attributes: [[:id, :measurement, :value, :_destroy]] }
-                      ]], metric_attributes: [:id, :measurement, :value]
-                    }
+                      ]]
+                    },
+                    :score_type,
+                    :score_value
                   ])
   end
 end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -14,7 +14,7 @@ class WorkoutsController < ApplicationController
   # GET /workouts/new
   def new
     @workout = Workout.new
-    @workout.build_metric
+    @workout.score_type = :time
   end
 
   # GET /workouts/1/edit
@@ -72,10 +72,9 @@ class WorkoutsController < ApplicationController
     exercise_params = [:id, :reps, :movement_id, :position, :distance_units_per_rep, :_destroy,
                        { metrics_attributes: [metric_params] }]
 
-    params.expect(workout: [:name, :rounds, :time, :interval, :notes, :time_cap,
+    params.expect(workout: [:name, :rounds, :time, :interval, :notes, :time_cap, :score_type,
                             { segments_attributes: [[:id, :rounds, :time, :interval, :_destroy,
                                                      { exercises_attributes: [exercise_params] }]] },
-                            { exercises_attributes: [exercise_params],
-                              metric_attributes: [:id, :measurement] }])
+                            { exercises_attributes: [exercise_params] }])
   end
 end

--- a/app/helpers/metrics_helper.rb
+++ b/app/helpers/metrics_helper.rb
@@ -15,9 +15,10 @@ module MetricsHelper
   end
 
   def log_score_msg(log)
-    return unless log.metric
+    metric = log.score_metric || log.metric
+    return unless metric
 
-    amrap_score_msg(log) || rep_score_msg(log.metric) || metric_unit_msg(log.metric)
+    amrap_score_msg(log) || rep_score_msg(metric) || metric_unit_msg(metric)
   end
 
   def amrap_score_msg(log)

--- a/app/helpers/workouts_helper.rb
+++ b/app/helpers/workouts_helper.rb
@@ -6,7 +6,7 @@ module WorkoutsHelper
     return "EMOM #{workout.time}" if workout.emom?
     return timed_rounds_objective(workout) if workout.timed_rounds?
 
-    "#{workout.interval} for #{workout.metric.measurement}"
+    "#{workout.interval} for #{workout.score_type}"
   end
 
   def generate_workout_name
@@ -26,7 +26,7 @@ module WorkoutsHelper
   end
 
   def timed_rounds_objective(workout)
-    if workout.metric&.rep?
+    if workout.score_type == 'rep'
       "#{pluralize workout.rounds, 'round'}, complete as many reps as possible in #{pluralize workout.time, 'minute'} of"
     else
       "#{workout.rounds} #{workout.time}-minute rounds"

--- a/app/models/concerns/log_scoring.rb
+++ b/app/models/concerns/log_scoring.rb
@@ -12,10 +12,10 @@ module LogScoring
 
   def amrap_score_parts
     return nil unless rep_scored_amrap_log?
-    return nil unless metric&.value.present? && reps_per_round.present? && reps_per_round.positive?
+    return nil unless score_value.present? && reps_per_round.present? && reps_per_round.positive?
 
-    rounds, reps = metric.value.divmod(reps_per_round)
-    { rounds: rounds, reps: reps, total: metric.value }
+    rounds, reps = score_value.divmod(reps_per_round)
+    { rounds: rounds, reps: reps, total: score_value }
   end
 
   private
@@ -24,28 +24,28 @@ module LogScoring
     return unless rep_scored_amrap_log?
 
     round_total = submitted_amrap_reps_per_round || workout.amrap_reps_per_round
-    normalized_value = normalize_amrap_score_value(metric.value_before_type_cast, round_total)
+    normalized_value = normalize_amrap_score_value(score_value_before_type_cast, round_total)
 
     return if errors[:base].any? || errors[:metric].any?
 
-    metric.value = normalized_value
+    self.score_value = normalized_value
     self.reps_per_round = round_total if round_total.present?
   end
 
   def calculate_set_based_lifting_score
-    return unless workout&.set_based_lifting? && metric&.weight?
+    return unless workout&.set_based_lifting? && score_type == 'weight'
 
     score = workout.lifting_score(movement_logs)
     return unless score
 
-    metric.measurement = score.measurement
-    metric.value = score.value
+    self.score_type = score.measurement
+    self.score_value = score.value
   end
 
   def convert_fixed_amrap_round_score_to_reps
-    return unless workout&.fixed_rep_amrap? && metric&.round?
+    return unless workout&.fixed_rep_amrap? && score_type == 'round'
 
-    metric.measurement = :rep
+    self.score_type = :rep
   end
 
   def normalize_amrap_score_value(raw_value, round_total)
@@ -64,7 +64,7 @@ module LogScoring
   def normalize_rounds_plus_reps(rounds, reps, round_total)
     if round_total.blank?
       errors.add(:metric, 'rounds plus reps requires a fixed reps-per-round total')
-      return metric.value
+      return score_value
     end
 
     (rounds * round_total) + reps
@@ -72,11 +72,11 @@ module LogScoring
 
   def invalid_amrap_score_value
     errors.add(:metric, 'score must be total reps or rounds plus reps')
-    metric.value
+    score_value
   end
 
   def rep_scored_amrap_log?
-    workout&.rep_scored_amrap? && metric&.rep?
+    workout&.rep_scored_amrap? && score_type == 'rep'
   end
 
   def submitted_amrap_reps_per_round

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -2,7 +2,7 @@ module WorkoutScoring
   extend ActiveSupport::Concern
 
   def rep_scored_amrap?
-    amrap? && (metric&.rep? || fixed_rep_amrap?)
+    amrap? && (score_type == 'rep' || fixed_rep_amrap?)
   end
 
   def fixed_rep_amrap?
@@ -11,7 +11,7 @@ module WorkoutScoring
 
   def set_based_lifting?
     set_based_lifting_structure? &&
-      metric&.weight? &&
+      score_type == 'weight' &&
       top_level_exercises.any?(&:load_bearing?)
   end
 
@@ -51,7 +51,7 @@ module WorkoutScoring
   def log_metric_measurement
     return :rep if fixed_rep_amrap?
 
-    metric.measurement
+    score_type
   end
 
   private

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -10,7 +10,11 @@ class Log < ApplicationRecord
   accepts_nested_attributes_for :metric
   accepts_nested_attributes_for :movement_logs, allow_destroy: true
 
-  validates :metric, presence: true
+  enum :score_type, Metric.measurements, prefix: :score
+
+  before_validation :copy_legacy_metric_score
+
+  validates :score_type, presence: true
 
   def build_movement_logs
     workout.exercises_for_log_recording.each do |exercise|
@@ -18,7 +22,40 @@ class Log < ApplicationRecord
     end
   end
 
+  def score_type
+    super || metric&.measurement
+  end
+
+  def score_value
+    super || metric&.value
+  end
+
+  def score_value=(new_value)
+    super
+    return unless new_value.is_a?(String)
+
+    if new_value.include? ':'
+      minutes, seconds = new_value.split(':', 2)
+      super((minutes.to_i.minute + seconds.to_i.second).second)
+    elsif score_type == 'time'
+      super(new_value.to_i)
+    end
+  end
+
+  def score_metric
+    return unless score_type
+
+    Metric.new(measurement: score_type, value: score_value)
+  end
+
   private
+
+  def copy_legacy_metric_score
+    return unless metric
+
+    self.score_type ||= metric.measurement
+    self.score_value ||= metric.value
+  end
 
   def build_movement_log_for(exercise)
     movement_log = movement_logs.build(movement: exercise.movement)

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -15,7 +15,11 @@ class Workout < ApplicationRecord
   accepts_nested_attributes_for :exercises, allow_destroy: true
   accepts_nested_attributes_for :segments, allow_destroy: true
 
-  validates :name, :metric, presence: true
+  enum :score_type, Metric.measurements, prefix: :score
+
+  before_validation :copy_legacy_metric_score_type
+
+  validates :name, :score_type, presence: true
 
   def self.search_by_name(name)
     return all unless name
@@ -73,5 +77,15 @@ class Workout < ApplicationRecord
     else
       self.time_cap_seconds = time_cap
     end
+  end
+
+  def score_type
+    super || metric&.measurement
+  end
+
+  private
+
+  def copy_legacy_metric_score_type
+    self.score_type ||= metric.measurement if metric&.measurement
   end
 end

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -10,13 +10,12 @@
   .row.col
     p = workout_objective @workout
   .row
-    = f.simple_fields_for :metric do |metric_form|
-      = metric_form.input :measurement, as: :hidden
-      - if @workout.set_based_lifting?
-        .col
-          p.form-text Score will be calculated from the heaviest successful set.
-      - else
-        .col = metric_form.input :value, as: :group, prepend: @log.metric.measurement, label: false
+    = f.input :score_type, as: :hidden
+    - if @workout.set_based_lifting?
+      .col
+        p.form-text Score will be calculated from the heaviest successful set.
+    - else
+      .col = f.input :score_value, as: :group, prepend: @log.score_type, label: false
   h2.mt-3 Exercise Recordings
   = f.simple_fields_for :movement_logs do |ml_form|
     .card.mb-3

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -5,8 +5,7 @@
     .col-sm-4 = f.input :rounds
     .col-sm-4 = f.input :time, as: :group, append: 'minutes'
     .col-sm-4 = f.input :interval, placeholder: '21-15-9...'
-    = f.simple_fields_for :metric do |metric_form|
-      .col-12 = metric_form.input :measurement, collection: Metric.workout_measurements, label: 'For'
+    .col-12 = f.input :score_type, collection: Metric.workout_measurements, label: 'For'
     .col-12 = f.input :time_cap
     .col-12
       = f.label :notes, class: 'form-label'

--- a/db/migrate/20260606120000_add_direct_score_fields_to_workouts_and_logs.rb
+++ b/db/migrate/20260606120000_add_direct_score_fields_to_workouts_and_logs.rb
@@ -1,0 +1,30 @@
+class AddDirectScoreFieldsToWorkoutsAndLogs < ActiveRecord::Migration[8.1]
+  def up
+    add_column :workouts, :score_type, :integer
+    add_column :logs, :score_type, :integer
+    add_column :logs, :score_value, :integer
+
+    execute <<~SQL.squish
+      UPDATE workouts
+      SET score_type = metrics.measurement
+      FROM metrics
+      WHERE metrics.measurable_type = 'Workout'
+        AND metrics.measurable_id = workouts.id
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE logs
+      SET score_type = metrics.measurement,
+          score_value = metrics.value
+      FROM metrics
+      WHERE metrics.measurable_type = 'Log'
+        AND metrics.measurable_id = logs.id
+    SQL
+  end
+
+  def down
+    remove_column :logs, :score_value
+    remove_column :logs, :score_type
+    remove_column :workouts, :score_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_04_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_06_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_120000) do
   create_table "logs", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "reps_per_round"
+    t.integer "score_type"
+    t.integer "score_value"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.bigint "workout_id"
@@ -168,6 +170,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_120000) do
     t.string "interval"
     t.string "name"
     t.integer "rounds"
+    t.integer "score_type"
     t.integer "time"
     t.integer "time_cap_seconds"
     t.datetime "updated_at", precision: nil, null: false

--- a/test/controllers/logs_controller_test.rb
+++ b/test/controllers/logs_controller_test.rb
@@ -9,25 +9,29 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create log with nested movement metrics' do
-    assert_difference('Metric.count', 2) do
-      assert_difference(['Log.count', 'MovementLog.count'], 1) do
-        post workout_logs_url(@workout), params: { log: {
-          metric_attributes: { measurement: :time, value: '5:30' },
-          movement_logs_attributes: {
-            '0' => {
-              movement_id: movements(:pullup).id,
-              metrics_attributes: {
-                '0' => { measurement: :rep, value: 45 }
+    assert_difference('Metric.where(measurable_type: "Log").count', 0) do
+      assert_difference('Metric.count', 1) do
+        assert_difference(['Log.count', 'MovementLog.count'], 1) do
+          post workout_logs_url(@workout), params: { log: {
+            score_type: :time,
+            score_value: '5:30',
+            movement_logs_attributes: {
+              '0' => {
+                movement_id: movements(:pullup).id,
+                metrics_attributes: {
+                  '0' => { measurement: :rep, value: 45 }
+                }
               }
             }
-          }
-        } }
+          } }
+        end
       end
     end
 
-    assert_redirected_to log_url(Log.last)
-    assert_equal movements(:pullup), Log.last.movement_logs.first.movement
-    assert_equal 45, Log.last.movement_logs.first.metrics.find_by!(measurement: :rep).value
+    assert_equal ['time', 330, nil], [Log.last.score_type, Log.last.score_value, Log.last.metric]
+    assert_equal [movements(:pullup), 45],
+                 [Log.last.movement_logs.first.movement,
+                  Log.last.movement_logs.first.metrics.find_by!(measurement: :rep).value]
   end
 
   test 'should not show another user log' do
@@ -44,7 +48,7 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should not update another user log' do
     patch workout_log_url(logs(:brooke_fran).workout, logs(:brooke_fran)), params: {
-      log: { metric_attributes: { measurement: :time, value: '4:59' } }
+      log: { score_type: :time, score_value: '4:59' }
     }
 
     assert_response :not_found
@@ -61,56 +65,60 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
   test 'creates amrap log from rounds plus reps score' do
     assert_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {
-        metric_attributes: { measurement: :rep, value: '20+2' }
+        score_type: :rep,
+        score_value: '20+2'
       } }
     end
 
     assert_redirected_to log_url(Log.last)
-    assert_equal 502, Log.last.metric.value
+    assert_equal 502, Log.last.score_value
     assert_equal 25, Log.last.reps_per_round
   end
 
   test 'new log for fixed-rep round-scored amrap uses rep score input' do
     workout = workouts(:amrap_couplet)
-    workout.metric.update!(measurement: :round)
+    workout.update!(score_type: :round)
 
     get new_workout_log_url(workout)
 
     assert_response :success
-    assert_select 'input[name="log[metric_attributes][measurement]"][value="rep"]'
+    assert_select 'input[name="log[score_type]"][value="rep"]'
   end
 
   test 'creates fixed-rep amrap log from stale round score submission' do
     workout = workouts(:amrap_couplet)
-    workout.metric.update!(measurement: :round)
+    workout.update!(score_type: :round)
 
     assert_difference('Log.count') do
       post workout_logs_url(workout), params: { log: {
-        metric_attributes: { measurement: :round, value: '20+2' }
+        score_type: :round,
+        score_value: '20+2'
       } }
     end
 
     assert_redirected_to log_url(Log.last)
-    assert_equal 'rep', Log.last.metric.measurement
-    assert_equal 502, Log.last.metric.value
+    assert_equal 'rep', Log.last.score_type
+    assert_equal 502, Log.last.score_value
     assert_equal 25, Log.last.reps_per_round
   end
 
   test 'creates amrap log from raw total reps' do
     assert_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {
-        metric_attributes: { measurement: :rep, value: '202' }
+        score_type: :rep,
+        score_value: '202'
       } }
     end
 
-    assert_equal 202, Log.last.metric.value
+    assert_equal 202, Log.last.score_value
     assert_equal 25, Log.last.reps_per_round
   end
 
   test 'does not create amrap log from invalid rounds plus reps score' do
     assert_no_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {
-        metric_attributes: { measurement: :rep, value: '2.5' }
+        score_type: :rep,
+        score_value: '2.5'
       } }
     end
 

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -24,30 +24,33 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
         name: @workout.name,
         rounds: @workout.rounds,
         notes: '<div>Use the prescribed loading.</div>',
-        metric_attributes: { measurement: :round }
+        score_type: :round
       } }
     end
 
     assert_redirected_to workout_url(Workout.last)
+    assert_equal ['round', nil], [Workout.last.score_type, Workout.last.metric]
     assert_equal 'Use the prescribed loading.', Workout.last.notes.to_plain_text.strip
   end
 
   test 'should create workout with nested exercise metrics' do
-    assert_difference('Metric.count', 2) do
-      assert_difference(['Workout.count', 'Exercise.count'], 1) do
-        post workouts_url, params: { workout: {
-          name: 'Nested Workout',
-          metric_attributes: { measurement: :time },
-          exercises_attributes: {
-            '0' => {
-              movement_id: movements(:pullup).id,
-              position: 1,
-              metrics_attributes: {
-                '0' => { measurement: :rep, value: 10 }
+    assert_difference('Metric.where(measurable_type: "Workout").count', 0) do
+      assert_difference('Metric.count', 1) do
+        assert_difference(['Workout.count', 'Exercise.count'], 1) do
+          post workouts_url, params: { workout: {
+            name: 'Nested Workout',
+            score_type: :time,
+            exercises_attributes: {
+              '0' => {
+                movement_id: movements(:pullup).id,
+                position: 1,
+                metrics_attributes: {
+                  '0' => { measurement: :rep, value: 10 }
+                }
               }
             }
-          }
-        } }
+          } }
+        end
       end
     end
 
@@ -57,22 +60,24 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create workout with nested sex-specific exercise metrics' do
-    assert_difference('Metric.count', 3) do
-      assert_difference(['Workout.count', 'Exercise.count'], 1) do
-        post workouts_url, params: { workout: {
-          name: 'Sex Specific Workout',
-          metric_attributes: { measurement: :time },
-          exercises_attributes: {
-            '0' => {
-              movement_id: movements(:thruster).id,
-              position: 1,
-              metrics_attributes: {
-                '0' => { measurement: :rep, value: 1 },
-                '1' => { measurement: :lb, female_value: 65, male_value: 95 }
+    assert_difference('Metric.where(measurable_type: "Workout").count', 0) do
+      assert_difference('Metric.count', 2) do
+        assert_difference(['Workout.count', 'Exercise.count'], 1) do
+          post workouts_url, params: { workout: {
+            name: 'Sex Specific Workout',
+            score_type: :time,
+            exercises_attributes: {
+              '0' => {
+                movement_id: movements(:thruster).id,
+                position: 1,
+                metrics_attributes: {
+                  '0' => { measurement: :rep, value: 1 },
+                  '1' => { measurement: :lb, female_value: 65, male_value: 95 }
+                }
               }
             }
-          }
-        } }
+          } }
+        end
       end
     end
 

--- a/test/fixtures/logs.yml
+++ b/test/fixtures/logs.yml
@@ -3,12 +3,16 @@
 brooke_fran:
   workout: fran
   user: brooke
+  score_type: time
 
 matt_murph:
   workout: murph
   user: mathew
+  score_type: time
 
 matt_amrap:
   workout: amrap_couplet
   user: mathew
+  score_type: rep
+  score_value: 202
   reps_per_round: 25

--- a/test/fixtures/workouts.yml
+++ b/test/fixtures/workouts.yml
@@ -3,26 +3,33 @@
 fran:
   name: Fran
   interval: 21-15-9
+  score_type: time
 
 murph:
   name: Murph
   rounds: 1
+  score_type: time
 
 segmented:
   name: Segmented
+  score_type: time
 
 amrap_couplet:
   name: AMRAP Couplet
   time: 10
+  score_type: rep
 
 amrap_mixed:
   name: AMRAP Mixed
   time: 20
+  score_type: rep
 
 amrap_unknown_distance:
   name: AMRAP Unknown Distance
   time: 12
+  score_type: rep
 
 back_squat_5x5:
   name: Back Squat 5x5
   rounds: 5
+  score_type: weight

--- a/test/helpers/metrics_helper_test.rb
+++ b/test/helpers/metrics_helper_test.rb
@@ -7,14 +7,13 @@ class MetricsHelperTest < ActionView::TestCase
 
   test 'renders exact amrap scores as completed rounds and total reps' do
     log = logs(:matt_amrap)
-    log.metric.value = 200
+    log.score_value = 200
 
     assert_equal '8 rounds (200 reps)', log_score_msg(log)
   end
 
   test 'renders unknown amrap round size as total reps' do
-    log = workouts(:amrap_unknown_distance).logs.build(reps_per_round: nil)
-    log.build_metric(measurement: :rep, value: 202)
+    log = workouts(:amrap_unknown_distance).logs.build(score_type: :rep, score_value: 202, reps_per_round: nil)
 
     assert_equal '202 reps', log_score_msg(log)
   end

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -16,7 +16,7 @@ class WorkoutsHelperTest < ActionView::TestCase
   test 'renders timed rep-scored rounds as round amraps' do
     workout = workouts(:back_squat_5x5)
     workout.update!(time: 3)
-    workout.metric.update!(measurement: :rep)
+    workout.update!(score_type: :rep)
 
     assert_equal '5 rounds, complete as many reps as possible in 3 minutes of', workout_objective(workout)
   end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -2,75 +2,67 @@ require 'test_helper'
 
 class LogTest < ActiveSupport::TestCase
   test 'normalizes rounds plus reps to total reps' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20+2')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20+2')
 
     assert log.valid?
-    assert_equal 502, log.metric.value
+    assert_equal 502, log.score_value
     assert_equal 25, log.reps_per_round
   end
 
   test 'normalizes fixed-rep amrap round score submissions to reps' do
     workout = workouts(:amrap_couplet)
-    workout.metric.update!(measurement: :round)
-    log = workout.logs.build(user: users(:mathew))
-    log.build_metric(measurement: :round, value: '20+2')
+    workout.update!(score_type: :round)
+    log = workout.logs.build(user: users(:mathew), score_type: :round, score_value: '20+2')
 
     assert log.valid?
-    assert_equal 'rep', log.metric.measurement
-    assert_equal 502, log.metric.value
+    assert_equal 'rep', log.score_type
+    assert_equal 502, log.score_value
     assert_equal 25, log.reps_per_round
   end
 
   test 'normalizes overflow reps into total reps' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20+27')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20+27')
 
     assert log.valid?
-    assert_equal 527, log.metric.value
+    assert_equal 527, log.score_value
   end
 
   test 'normalizes rounds plus reps using submitted scaled movement recordings' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20+2')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20+2')
     log.build_movement_logs
 
     pushup_recording = log.movement_logs.find { |movement_log| movement_log.movement == movements(:pushup) }
     pushup_recording.metrics.find(&:rep?).value = 5
 
     assert log.valid?
-    assert_equal 302, log.metric.value
+    assert_equal 302, log.score_value
     assert_equal 15, log.reps_per_round
   end
 
   test 'accepts raw total reps' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '202')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '202')
 
     assert log.valid?
-    assert_equal 202, log.metric.value
+    assert_equal 202, log.score_value
     assert_equal 25, log.reps_per_round
   end
 
   test 'rejects malformed amrap score input' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20.5')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20.5')
 
     assert_not log.valid?
     assert_includes log.errors[:metric], 'score must be total reps or rounds plus reps'
   end
 
   test 'rejects negative amrap score input' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: -1)
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: -1)
 
     assert_not log.valid?
     assert_includes log.errors[:metric], 'score must be total reps or rounds plus reps'
   end
 
   test 'rejects rounds plus reps when round size is unknown' do
-    log = workouts(:amrap_unknown_distance).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '2+5')
+    log = workouts(:amrap_unknown_distance).logs.build(user: users(:mathew), score_type: :rep, score_value: '2+5')
 
     assert_not log.valid?
     assert_includes log.errors[:metric], 'rounds plus reps requires a fixed reps-per-round total'
@@ -83,8 +75,7 @@ class LogTest < ActiveSupport::TestCase
   end
 
   test 'builds one movement recording per set for set-based lifting workouts' do
-    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :weight)
+    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs
 
     assert_equal 5, log.movement_logs.size
@@ -99,10 +90,9 @@ class LogTest < ActiveSupport::TestCase
   test 'builds timed round movement recordings with per-round prescribed reps' do
     workout = workouts(:back_squat_5x5)
     workout.update!(time: 3)
-    workout.metric.update!(measurement: :rep)
+    workout.update!(score_type: :rep)
 
-    log = workout.logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep)
+    log = workout.logs.build(user: users(:mathew), score_type: :rep)
     log.build_movement_logs
 
     assert_equal 1, log.movement_logs.size
@@ -110,8 +100,7 @@ class LogTest < ActiveSupport::TestCase
   end
 
   test 'calculates set-based lifting score from heaviest successful set' do
-    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :weight)
+    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs
 
     [95, 115, 135, 145, 155].each.with_index do |load, index|
@@ -120,7 +109,7 @@ class LogTest < ActiveSupport::TestCase
     log.movement_logs[4].metrics.find(&:rep?).value = 2
 
     assert log.valid?
-    assert_equal 'lb', log.metric.measurement
-    assert_equal 145, log.metric.value
+    assert_equal 'lb', log.score_type
+    assert_equal 145, log.score_value
   end
 end

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -27,7 +27,7 @@ class WorkoutTest < ActiveSupport::TestCase
 
   test 'does not identify rep-scored rounds with load-bearing exercises as set-based lifting' do
     workout = workouts(:back_squat_5x5)
-    workout.metric.update!(measurement: :rep)
+    workout.update!(score_type: :rep)
 
     assert_not workout.set_based_lifting?
   end

--- a/test/system/lifting_workouts_test.rb
+++ b/test/system/lifting_workouts_test.rb
@@ -16,7 +16,7 @@ class LiftingWorkoutsTest < ApplicationSystemTestCase
 
     click_on 'Log'
 
-    assert_no_selector '#log_metric_attributes_value'
+    assert_no_selector '#log_score_value'
     assert_text 'Score will be calculated from the heaviest successful set.'
     assert_selector '.card.mb-3', count: 5
     movement_logs = all('.card.mb-3')

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -92,7 +92,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
     visit workout_url(workouts(:fran))
 
     click_on 'Log'
-    fill_in 'log_metric_attributes_value', with: '5:30'
+    fill_in 'log_score_value', with: '5:30'
     click_on 'Save'
 
     assert_current_path %r{/logs/\d+}
@@ -108,7 +108,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
 
     assert_equal %w[300 10 20], amrap_recording_values
 
-    fill_in 'log_metric_attributes_value', with: '1+35'
+    fill_in 'log_score_value', with: '1+35'
 
     assert_equal %w[300 10 20], amrap_recording_values
 


### PR DESCRIPTION
## Summary

- Add direct `score_type` columns to workouts and logs plus `logs.score_value`.
- Backfill direct score fields from legacy `metrics` rows for `Workout` and `Log` records.
- Move workout/log score forms, controllers, helpers, and scoring logic to direct fields while keeping legacy metric rows readable.
- Update fixtures and tests so new workout/log score writes no longer create polymorphic score metrics.

Closes #1622.

## Validation

- `rvm 3.4.9@wod-tracker do bundle exec rails test test/models/log_test.rb test/models/workout_test.rb test/helpers/metrics_helper_test.rb test/helpers/workouts_helper_test.rb test/controllers/logs_controller_test.rb test/controllers/workouts_controller_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rails test test/system/workout_workflows_test.rb test/system/lifting_workouts_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rubocop --parallel`
- `git diff --check`

Note: local `git push` was unavailable in the agent environment due missing HTTPS/SSH credentials, so the branch commit was created through the GitHub connector.