### PR TITLE
[codex] Add direct workout and log score fields

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -14,8 +14,7 @@ class LogsController < ApplicationController
 
   # GET /logs/new
   def new
-    @log = @workout.logs.build
-    @log.build_metric(measurement: @workout.log_metric_measurement)
+    @log = @workout.logs.build(score_type: @workout.log_metric_measurement)
     @log.build_movement_logs
   end
 
@@ -80,12 +79,14 @@ class LogsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def log_params
     params.expect(log: [
+                    :score_type,
+                    :score_value,
                     {
                       movement_logs_attributes: [[
                         :id,
                         :movement_id,
                         { metrics_attributes: [[:id, :measurement, :value, :_destroy]] }
-                      ]], metric_attributes: [:id, :measurement, :value]
+                      ]]
                     }
                   ])
   end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -14,7 +14,6 @@ class WorkoutsController < ApplicationController
   # GET /workouts/new
   def new
     @workout = Workout.new
-    @workout.build_metric
   end
 
   # GET /workouts/1/edit
@@ -73,9 +72,9 @@ class WorkoutsController < ApplicationController
                        { metrics_attributes: [metric_params] }]
 
     params.expect(workout: [:name, :rounds, :time, :interval, :notes, :time_cap,
+                            :score_type,
                             { segments_attributes: [[:id, :rounds, :time, :interval, :position, :_destroy,
                                                      { exercises_attributes: [exercise_params] }]] },
-                            { exercises_attributes: [exercise_params],
-                              metric_attributes: [:id, :measurement] }])
+                            { exercises_attributes: [exercise_params] }])
   end
 end

--- a/app/helpers/metrics_helper.rb
+++ b/app/helpers/metrics_helper.rb
@@ -15,9 +15,10 @@ module MetricsHelper
   end
 
   def log_score_msg(log)
-    return unless log.metric
+    return unless log.score_measurement
 
-    amrap_score_msg(log) || rep_score_msg(log.metric) || metric_unit_msg(log.metric)
+    score_metric = Metric.new(measurement: log.score_measurement, value: log.score_value)
+    amrap_score_msg(log) || rep_score_msg(score_metric) || metric_unit_msg(score_metric)
   end
 
   def amrap_score_msg(log)

--- a/app/helpers/workouts_helper.rb
+++ b/app/helpers/workouts_helper.rb
@@ -6,7 +6,7 @@ module WorkoutsHelper
     return "EMOM #{workout.time}" if workout.emom?
     return timed_rounds_objective(workout) if workout.timed_rounds?
 
-    "#{workout.interval} for #{workout.metric.measurement}"
+    "#{workout.interval} for #{workout.score_measurement}"
   end
 
   def generate_workout_name
@@ -26,7 +26,7 @@ module WorkoutsHelper
   end
 
   def timed_rounds_objective(workout)
-    if workout.metric&.rep?
+    if workout.score_measurement == 'rep'
       "#{pluralize workout.rounds, 'round'}, complete as many reps as possible in #{pluralize workout.time, 'minute'} of"
     else
       "#{workout.rounds} #{workout.time}-minute rounds"

--- a/app/models/concerns/log_scoring.rb
+++ b/app/models/concerns/log_scoring.rb
@@ -12,10 +12,10 @@ module LogScoring
 
   def amrap_score_parts
     return nil unless rep_scored_amrap_log?
-    return nil unless metric&.value.present? && reps_per_round.present? && reps_per_round.positive?
+    return nil unless score_value.present? && reps_per_round.present? && reps_per_round.positive?
 
-    rounds, reps = metric.value.divmod(reps_per_round)
-    { rounds: rounds, reps: reps, total: metric.value }
+    rounds, reps = score_value.divmod(reps_per_round)
+    { rounds: rounds, reps: reps, total: score_value }
   end
 
   private
@@ -24,28 +24,28 @@ module LogScoring
     return unless rep_scored_amrap_log?
 
     round_total = submitted_amrap_reps_per_round || workout.amrap_reps_per_round
-    normalized_value = normalize_amrap_score_value(metric.value_before_type_cast, round_total)
+    normalized_value = normalize_amrap_score_value(score_value_before_type_cast, round_total)
 
-    return if errors[:base].any? || errors[:metric].any?
+    return if errors[:base].any? || errors[:score_value].any?
 
-    metric.value = normalized_value
+    self.score_value = normalized_value
     self.reps_per_round = round_total if round_total.present?
   end
 
   def calculate_set_based_lifting_score
-    return unless workout&.set_based_lifting? && metric&.weight?
+    return unless workout&.set_based_lifting? && score_measurement == 'weight'
 
     score = workout.lifting_score(movement_logs)
     return unless score
 
-    metric.measurement = score.measurement
-    metric.value = score.value
+    self.score_type = score.measurement
+    self.score_value = score.value
   end
 
   def convert_fixed_amrap_round_score_to_reps
-    return unless workout&.fixed_rep_amrap? && metric&.round?
+    return unless workout&.fixed_rep_amrap? && score_measurement == 'round'
 
-    metric.measurement = :rep
+    self.score_type = :rep
   end
 
   def normalize_amrap_score_value(raw_value, round_total)
@@ -63,20 +63,20 @@ module LogScoring
 
   def normalize_rounds_plus_reps(rounds, reps, round_total)
     if round_total.blank?
-      errors.add(:metric, 'rounds plus reps requires a fixed reps-per-round total')
-      return metric.value
+      errors.add(:score_value, 'rounds plus reps requires a fixed reps-per-round total')
+      return score_value
     end
 
     (rounds * round_total) + reps
   end
 
   def invalid_amrap_score_value
-    errors.add(:metric, 'score must be total reps or rounds plus reps')
-    metric.value
+    errors.add(:score_value, 'score must be total reps or rounds plus reps')
+    score_value
   end
 
   def rep_scored_amrap_log?
-    workout&.rep_scored_amrap? && metric&.rep?
+    workout&.rep_scored_amrap? && score_measurement == 'rep'
   end
 
   def submitted_amrap_reps_per_round

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -2,7 +2,7 @@ module WorkoutScoring
   extend ActiveSupport::Concern
 
   def rep_scored_amrap?
-    amrap? && (metric&.rep? || fixed_rep_amrap?)
+    amrap? && (score_measurement == 'rep' || fixed_rep_amrap?)
   end
 
   def fixed_rep_amrap?
@@ -11,7 +11,7 @@ module WorkoutScoring
 
   def set_based_lifting?
     set_based_lifting_structure? &&
-      metric&.weight? &&
+      score_measurement == 'weight' &&
       top_level_exercises.any?(&:load_bearing?)
   end
 
@@ -51,7 +51,7 @@ module WorkoutScoring
   def log_metric_measurement
     return :rep if fixed_rep_amrap?
 
-    metric.measurement
+    score_measurement
   end
 
   private

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -7,14 +7,32 @@ class Log < ApplicationRecord
   has_many :exercises, through: :workout
   has_many :movement_logs, dependent: :destroy
 
-  accepts_nested_attributes_for :metric
   accepts_nested_attributes_for :movement_logs, allow_destroy: true
 
-  validates :metric, presence: true
+  enum :score_type, Metric.measurements, prefix: :score
+
+  validates :score_type, presence: true
 
   def build_movement_logs
     workout.exercises_for_log_recording.each do |exercise|
       build_movement_log_for(exercise)
+    end
+  end
+
+  def score_measurement
+    score_type || metric&.measurement
+  end
+
+  def score_value
+    super || metric&.value
+  end
+
+  def score_value=(new_value)
+    if new_value.is_a?(String) && new_value.include?(':')
+      minutes, seconds = new_value.split(':', 2)
+      super((minutes.to_i.minute + seconds.to_i.second).second)
+    else
+      super
     end
   end
 

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -11,11 +11,12 @@ class Workout < ApplicationRecord
   has_many :programs, through: :schedules
   has_rich_text :notes
 
-  accepts_nested_attributes_for :metric
   accepts_nested_attributes_for :exercises, allow_destroy: true
   accepts_nested_attributes_for :segments, allow_destroy: true
 
-  validates :name, :metric, presence: true
+  enum :score_type, Metric.measurements, prefix: :score
+
+  validates :name, :score_type, presence: true
 
   def self.search_by_name(name)
     return all unless name
@@ -59,6 +60,10 @@ class Workout < ApplicationRecord
     return nil unless interval?
 
     interval.split('-').sum(&:to_i)
+  end
+
+  def score_measurement
+    score_type || metric&.measurement
   end
 
   # Time cap that formats the seconds DB value to "Minutes:Seconds"

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -10,13 +10,12 @@
   .row.col
     p = workout_objective @workout
   .row
-    = f.simple_fields_for :metric do |metric_form|
-      = metric_form.input :measurement, as: :hidden
-      - if @workout.set_based_lifting?
-        .col
-          p.form-text Score will be calculated from the heaviest successful set.
-      - else
-        .col = metric_form.input :value, as: :group, prepend: @log.metric.measurement, label: false
+    = f.input :score_type, as: :hidden
+    - if @workout.set_based_lifting?
+      .col
+        p.form-text Score will be calculated from the heaviest successful set.
+    - else
+      .col = f.input :score_value, as: :group, prepend: @log.score_measurement, label: false
   h2.mt-3 Exercise Recordings
   = f.simple_fields_for :movement_logs do |ml_form|
     .card.mb-3

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -5,8 +5,7 @@
     .col-sm-4 = f.input :rounds
     .col-sm-4 = f.input :time, as: :group, append: 'minutes'
     .col-sm-4 = f.input :interval, placeholder: '21-15-9...'
-    = f.simple_fields_for :metric do |metric_form|
-      .col-12 = metric_form.input :measurement, collection: Metric.workout_measurements, label: 'For'
+    .col-12 = f.input :score_type, collection: Metric.workout_measurements, label: 'For'
     .col-12 = f.input :time_cap
     .col-12
       = f.label :notes, class: 'form-label'

--- a/db/migrate/20260611120000_add_direct_score_fields.rb
+++ b/db/migrate/20260611120000_add_direct_score_fields.rb
@@ -1,0 +1,64 @@
+class AddDirectScoreFields < ActiveRecord::Migration[8.1]
+  class MigrationMetric < ActiveRecord::Base
+    self.table_name = 'metrics'
+  end
+
+  class MigrationWorkout < ActiveRecord::Base
+    self.table_name = 'workouts'
+  end
+
+  class MigrationLog < ActiveRecord::Base
+    self.table_name = 'logs'
+  end
+
+  def up
+    add_column :workouts, :score_type, :integer
+    add_column :logs, :score_type, :integer
+    add_column :logs, :score_value, :integer
+
+    MigrationWorkout.reset_column_information
+    MigrationLog.reset_column_information
+
+    MigrationMetric.where(measurable_type: 'Workout').find_each do |metric|
+      MigrationWorkout.where(id: metric.measurable_id).update_all(score_type: metric.measurement)
+    end
+
+    MigrationMetric.where(measurable_type: 'Log').find_each do |metric|
+      MigrationLog.where(id: metric.measurable_id).update_all(
+        score_type: metric.measurement,
+        score_value: metric.value
+      )
+    end
+
+    change_column_null :workouts, :score_type, false
+    change_column_null :logs, :score_type, false
+  end
+
+  def down
+    MigrationWorkout.reset_column_information
+    MigrationLog.reset_column_information
+
+    MigrationWorkout.where.not(score_type: nil).find_each do |workout|
+      metric = MigrationMetric.where(
+        measurable_type: 'Workout',
+        measurable_id: workout.id
+      ).first_or_initialize
+      metric.measurement = workout.score_type
+      metric.save!
+    end
+
+    MigrationLog.where.not(score_type: nil).find_each do |log|
+      metric = MigrationMetric.where(
+        measurable_type: 'Log',
+        measurable_id: log.id
+      ).first_or_initialize
+      metric.measurement = log.score_type
+      metric.value = log.score_value
+      metric.save!
+    end
+
+    remove_column :logs, :score_value
+    remove_column :logs, :score_type
+    remove_column :workouts, :score_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -70,6 +70,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_010000) do
   create_table "logs", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "reps_per_round"
+    t.integer "score_type", null: false
+    t.integer "score_value"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.bigint "workout_id"
@@ -172,6 +174,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_010000) do
     t.string "interval"
     t.string "name"
     t.integer "rounds"
+    t.integer "score_type", null: false
     t.integer "time"
     t.integer "time_cap_seconds"
     t.datetime "updated_at", precision: nil, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -104,7 +104,7 @@ cfj = Program.find_or_create_by(name: 'Crossfit Journal')
 # On the call of "rotate," the athlete(s) must move to the next station immediately for a good score.
 # One point is given for each rep, except on the rower where each calorie is 1 point.
 fight_gone_bad = Workout.find_or_create_by(name: 'Fight Gone Bad') do |workout|
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   workout.rounds = 3
   workout.time = 18
   workout.notes = 'In this workout you move from each of 5 stations after a minute.'\
@@ -156,7 +156,7 @@ cfj.schedules.find_or_initialize_by(workout: fight_gone_bad).update(posted_at: '
 # 100 sit-ups
 # 100 squats
 angie = Workout.find_or_create_by(name: 'Angie') do |workout|
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 100)
   end
@@ -183,7 +183,7 @@ cfj.schedules.find_or_initialize_by(workout: angie).update(posted_at: '30-01-201
 # Rest precisely 3 minutes between each round
 barbara = Workout.find_or_create_by(name: 'Barbara') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 20)
   end
@@ -213,7 +213,7 @@ cfj.schedules.find_or_initialize_by(workout: barbara).update(posted_at: '29-01-2
 chelsea = Workout.find_or_create_by(name: 'Chelsea') do |workout|
   workout.rounds = 30
   workout.time = 30
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 5)
   end
@@ -235,7 +235,7 @@ cfj.schedules.find_or_initialize_by(workout: chelsea).update(posted_at: '28-01-2
 # 15 squats
 cindy = Workout.find_or_create_by(name: 'Cindy') do |workout|
   workout.time = 20
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 5)
   end
@@ -256,7 +256,7 @@ cfj.schedules.find_or_initialize_by(workout: cindy).update(posted_at: '27-01-201
 # Handstand push-ups
 diane = Workout.find_or_create_by(name: 'Diane') do |workout|
   workout.interval = '21-15-9'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: deadlift, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :lb, female_value: 155, male_value: 225)
@@ -275,7 +275,7 @@ cfj.schedules.find_or_initialize_by(workout: diane).update(posted_at: '26-01-201
 # Ring dips
 elizabeth = Workout.find_or_create_by(name: 'Elizabeth') do |workout|
   workout.interval = '21-15-9'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: clean, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
@@ -294,7 +294,7 @@ cfj.schedules.find_or_initialize_by(workout: elizabeth).update(posted_at: '25-01
 # Pull-ups
 fran = Workout.find_or_create_by(name: 'Fran') do |workout|
   workout.interval = '21-15-9'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: thruster, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
@@ -312,7 +312,7 @@ cfj.schedules.find_or_initialize_by(workout: fran).update(posted_at: '24-01-2018
 # 135-lb. clean and jerks
 grace = Workout.find_or_create_by(name: 'Grace') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: cleanjerk, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 30)
     e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
@@ -329,7 +329,7 @@ end
 # 12 pull-ups
 helen = Workout.find_or_create_by(name: 'Helen') do |workout|
   workout.rounds = 3
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 400)
@@ -351,7 +351,7 @@ cfj.schedules.find_or_initialize_by(workout: helen).update(posted_at: '22-01-201
 # 135-lb. snatches
 isabel = Workout.find_or_create_by(name: 'Isabel') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: snatch, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 30)
     e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
@@ -368,7 +368,7 @@ cfj.schedules.find_or_initialize_by(workout: isabel).update(posted_at: '21-01-20
 # 30 pull-ups
 jackie = Workout.find_or_create_by(name: 'Jackie') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: row, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 1000)
@@ -390,7 +390,7 @@ cfj.schedules.find_or_initialize_by(workout: jackie).update(posted_at: '20-01-20
 # 150 wall-ball shots, 20-lb. ball
 karen = Workout.find_or_create_by(name: 'Karen') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: wallball, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 150)
     e.metrics.build(measurement: :lb, female_value: 14, male_value: 20)
@@ -408,7 +408,7 @@ cfj.schedules.find_or_initialize_by(workout: karen).update(posted_at: '19-01-201
 # 3/4 body-weight cleans
 linda = Workout.find_or_create_by(name: 'Linda') do |workout|
   workout.interval = '10-9-8-7-6-5-4-3-2-1'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: deadlift, position: 1)  do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :weight, value: '1 1/2 body weight')
@@ -433,7 +433,7 @@ cfj.schedules.find_or_initialize_by(workout: linda).update(posted_at: '18-01-201
 # 15 pull-ups
 mary = Workout.find_or_create_by(name: 'Mary') do |workout|
   workout.time = 20
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   workout.exercises.build(movement: hspu, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 5)
   end
@@ -454,7 +454,7 @@ cfj.schedules.find_or_initialize_by(workout: mary).update(posted_at: '17-01-2018
 # 95-lb. overhead squats, 15 reps
 nancy = Workout.find_or_create_by(name: 'Nancy') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 400)
@@ -476,7 +476,7 @@ cfj.schedules.find_or_initialize_by(workout: nancy).update(posted_at: '16-01-201
 # Sit-ups
 annie = Workout.find_or_create_by(name: 'Annie') do |workout|
   workout.interval = '50-40-30-20-10'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: double_under, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
   end
@@ -495,7 +495,7 @@ cfj.schedules.find_or_initialize_by(workout: annie).update(posted_at: '15-01-201
 # 30 pull-ups
 eva = Workout.find_or_create_by(name: 'Eva') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 800)
@@ -519,7 +519,7 @@ cfj.schedules.find_or_initialize_by(workout: eva).update(posted_at: '14-01-2018'
 # 30 wall-ball shots, 20-lb. ball
 kelly = Workout.find_or_create_by(name: 'Kelly') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 400)
@@ -545,7 +545,7 @@ cfj.schedules.find_or_initialize_by(workout: kelly).update(posted_at: '13-01-201
 # Pull-ups
 lynne = Workout.find_or_create_by(name: 'Lynne') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   workout.exercises.build(movement: bench_press, position: 1) do |e|
     e.metrics.build(measurement: :rep)
     e.metrics.build(measurement: :weight, value: 'body weight')
@@ -565,7 +565,7 @@ cfj.schedules.find_or_initialize_by(workout: lynne).update(posted_at: '12-01-201
 # Max-reps pull-ups
 nicole = Workout.find_or_create_by(name: 'Nicole') do |workout|
   workout.time = 20
-  workout.build_metric(measurement: :round)
+  workout.score_type = :round
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 400)
@@ -584,7 +584,7 @@ cfj.schedules.find_or_initialize_by(workout: nicole).update(posted_at: '11-01-20
 # 135-lb. snatches
 amanda = Workout.find_or_create_by(name: 'Amanda') do |workout|
   workout.interval = '9-7-5'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: muscleup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
   end
@@ -604,7 +604,7 @@ cfj.schedules.find_or_initialize_by(workout: amanda).update(posted_at: '10-01-20
 # Use same load for each set. Rest as needed between sets.
 gwen = Workout.find_or_create_by(name: 'Gwen') do |workout|
   workout.interval = '15-12-9'
-  workout.build_metric(measurement: :weight)
+  workout.score_type = :weight
   workout.exercises.build(movement: cleanjerk, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
       e.metrics.build(measurement: :lb)
@@ -619,7 +619,7 @@ cfj.schedules.find_or_initialize_by(workout: gwen).update(posted_at: '09-01-2018
 # Burpee/Push-up/Jumping-Jack/Sit-up/Handstand
 marguerita = Workout.find_or_create_by(name: 'Marguerita') do |workout|
   workout.rounds = 50
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: burpee, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
   end
@@ -647,7 +647,7 @@ cfj.schedules.find_or_initialize_by(workout: marguerita).update(posted_at: '08-0
 # 60 squats
 candy = Workout.find_or_create_by(name: 'Candy') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 20)
   end
@@ -669,7 +669,7 @@ cfj.schedules.find_or_initialize_by(workout: candy).update(posted_at: '07-01-201
 # 60 one-legged squats, alternating legs
 maggie = Workout.find_or_create_by(name: 'Maggie') do |workout|
   workout.rounds = 5
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: hspu, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 20)
   end
@@ -699,7 +699,7 @@ cfj.schedules.find_or_initialize_by(workout: maggie).update(posted_at: '06-01-20
 hope = Workout.find_or_create_by(name: 'Hope') do |workout|
   workout.rounds = 3
   workout.time = 18
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   workout.notes = '"Hope" has the same format as Fight Gone Bad. In this'\
                   ' workout you move from each of five stations after a minute.'\
                   ' This is a five-minute round from which a one-minute break is'\
@@ -743,7 +743,7 @@ cfj.schedules.find_or_initialize_by(workout: hope).update(posted_at: '05-01-2018
 # Push-ups
 Workout.find_or_create_by(name: 'JT') do |workout|
   workout.interval = '21-15-9'
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: hspu, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
   end
@@ -764,7 +764,7 @@ end
 # 50 sit-ups
 Workout.find_or_create_by(name: 'Michael') do |workout|
   workout.rounds = 3
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 800)
@@ -787,7 +787,7 @@ end
 # Run 1 mile
 Workout.find_or_create_by(name: 'Murph') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 1600)
@@ -819,7 +819,7 @@ end
 # 50 pull-ups
 Workout.find_or_create_by(name: 'Daniel') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: pullup, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 50)
   end
@@ -859,7 +859,7 @@ end
 # 18 pull-ups
 Workout.find_or_create_by(name: 'Josh') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: ohs, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 21)
     e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
@@ -896,7 +896,7 @@ end
 # 20 muscle-ups
 Workout.find_or_create_by(name: 'Jason') do |workout|
   workout.rounds = 1
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: airsquat, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 100)
   end
@@ -934,7 +934,7 @@ end
 #    10 single-leg squats
 # Then, run 800 meters
 segmented = Workout.find_or_create_by!(name: 'CFJ-181202') do |workout|
-  workout.build_metric(measurement: :time)
+  workout.score_type = :time
   workout.exercises.build(movement: run, position: 1) do |e|
     e.metrics.build(measurement: :rep, value: 1)
     e.metrics.build(measurement: :meter, value: 800)
@@ -967,7 +967,7 @@ cfj.schedules.find_or_initialize_by(workout: segmented).update(posted_at: '02-12
 # The Tabata interval is 20 seconds of work followed by 10 seconds of rest for
 # 8 intervals. Post reps for each exercise completed
 tabata = Workout.find_or_create_by!(name: 'CFJ-181226') do |workout|
-  workout.build_metric(measurement: :rep)
+  workout.score_type = :rep
   tab1 = workout.segments.build(rounds: 8, position: 1)
   workout.exercises.build(movement: hspu, segment: tab1, position: 1) do |e|
     e.metrics.build(measurement: :seconds, value: 20)

--- a/test/controllers/logs_controller_test.rb
+++ b/test/controllers/logs_controller_test.rb
@@ -9,23 +9,28 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create log with nested movement metrics' do
-    assert_difference('Metric.count', 2) do
-      assert_difference(['Log.count', 'MovementLog.count'], 1) do
-        post workout_logs_url(@workout), params: { log: {
-          metric_attributes: { measurement: :time, value: '5:30' },
-          movement_logs_attributes: {
-            '0' => {
-              movement_id: movements(:pullup).id,
-              metrics_attributes: {
-                '0' => { measurement: :rep, value: 45 }
+    assert_no_difference('Metric.where(measurable_type: "Log").count') do
+      assert_difference('Metric.count', 1) do
+        assert_difference(['Log.count', 'MovementLog.count'], 1) do
+          post workout_logs_url(@workout), params: { log: {
+            score_type: :time,
+            score_value: '5:30',
+            movement_logs_attributes: {
+              '0' => {
+                movement_id: movements(:pullup).id,
+                metrics_attributes: {
+                  '0' => { measurement: :rep, value: 45 }
+                }
               }
             }
-          }
-        } }
+          } }
+        end
       end
     end
 
     assert_redirected_to log_url(Log.last)
+    assert_equal 'time', Log.last.score_type
+    assert_equal 330, Log.last.score_value
     assert_equal movements(:pullup), Log.last.movement_logs.first.movement
     assert_equal 45, Log.last.movement_logs.first.metrics.find_by!(measurement: :rep).value
   end
@@ -44,7 +49,7 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should not update another user log' do
     patch workout_log_url(logs(:brooke_fran).workout, logs(:brooke_fran)), params: {
-      log: { metric_attributes: { measurement: :time, value: '4:59' } }
+      log: { score_type: :time, score_value: '4:59' }
     }
 
     assert_response :not_found
@@ -61,56 +66,56 @@ class LogsControllerTest < ActionDispatch::IntegrationTest
   test 'creates amrap log from rounds plus reps score' do
     assert_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {
-        metric_attributes: { measurement: :rep, value: '20+2' }
+        score_type: :rep, score_value: '20+2'
       } }
     end
 
     assert_redirected_to log_url(Log.last)
-    assert_equal 502, Log.last.metric.value
+    assert_equal 502, Log.last.score_value
     assert_equal 25, Log.last.reps_per_round
   end
 
   test 'new log for fixed-rep round-scored amrap uses rep score input' do
     workout = workouts(:amrap_couplet)
-    workout.metric.update!(measurement: :round)
+    workout.update!(score_type: :round)
 
     get new_workout_log_url(workout)
 
     assert_response :success
-    assert_select 'input[name="log[metric_attributes][measurement]"][value="rep"]'
+    assert_select 'input[name="log[score_type]"][value="rep"]'
   end
 
   test 'creates fixed-rep amrap log from stale round score submission' do
     workout = workouts(:amrap_couplet)
-    workout.metric.update!(measurement: :round)
+    workout.update!(score_type: :round)
 
     assert_difference('Log.count') do
       post workout_logs_url(workout), params: { log: {
-        metric_attributes: { measurement: :round, value: '20+2' }
+        score_type: :round, score_value: '20+2'
       } }
     end
 
     assert_redirected_to log_url(Log.last)
-    assert_equal 'rep', Log.last.metric.measurement
-    assert_equal 502, Log.last.metric.value
+    assert_equal 'rep', Log.last.score_type
+    assert_equal 502, Log.last.score_value
     assert_equal 25, Log.last.reps_per_round
   end
 
   test 'creates amrap log from raw total reps' do
     assert_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {
-        metric_attributes: { measurement: :rep, value: '202' }
+        score_type: :rep, score_value: '202'
       } }
     end
 
-    assert_equal 202, Log.last.metric.value
+    assert_equal 202, Log.last.score_value
     assert_equal 25, Log.last.reps_per_round
   end
 
   test 'does not create amrap log from invalid rounds plus reps score' do
     assert_no_difference('Log.count') do
       post workout_logs_url(workouts(:amrap_couplet)), params: { log: {
-        metric_attributes: { measurement: :rep, value: '2.5' }
+        score_type: :rep, score_value: '2.5'
       } }
     end
 

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -19,25 +19,28 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create workout' do
-    assert_difference(['Workout.count', 'ActionText::RichText.count']) do
-      post workouts_url, params: { workout: {
-        name: @workout.name,
-        rounds: @workout.rounds,
-        notes: '<div>Use the prescribed loading.</div>',
-        metric_attributes: { measurement: :round }
-      } }
+    assert_no_difference('Metric.where(measurable_type: "Workout").count') do
+      assert_difference(['Workout.count', 'ActionText::RichText.count']) do
+        post workouts_url, params: { workout: {
+          name: @workout.name,
+          rounds: @workout.rounds,
+          notes: '<div>Use the prescribed loading.</div>',
+          score_type: :round
+        } }
+      end
     end
 
     assert_redirected_to workout_url(Workout.last)
+    assert_equal 'round', Workout.last.score_type
     assert_equal 'Use the prescribed loading.', Workout.last.notes.to_plain_text.strip
   end
 
   test 'should create workout with nested exercise metrics' do
-    assert_difference('Metric.count', 2) do
+    assert_difference('Metric.count', 1) do
       assert_difference(['Workout.count', 'Exercise.count'], 1) do
         post workouts_url, params: { workout: {
           name: 'Nested Workout',
-          metric_attributes: { measurement: :time },
+          score_type: :time,
           exercises_attributes: {
             '0' => {
               movement_id: movements(:pullup).id,
@@ -57,11 +60,11 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create workout with nested sex-specific exercise metrics' do
-    assert_difference('Metric.count', 3) do
+    assert_difference('Metric.count', 2) do
       assert_difference(['Workout.count', 'Exercise.count'], 1) do
         post workouts_url, params: { workout: {
           name: 'Sex Specific Workout',
-          metric_attributes: { measurement: :time },
+          score_type: :time,
           exercises_attributes: {
             '0' => {
               movement_id: movements(:thruster).id,

--- a/test/fixtures/logs.yml
+++ b/test/fixtures/logs.yml
@@ -3,12 +3,18 @@
 brooke_fran:
   workout: fran
   user: brooke
+  score_type: time
+  score_value: 330
 
 matt_murph:
   workout: murph
   user: mathew
+  score_type: time
+  score_value: 3600
 
 matt_amrap:
   workout: amrap_couplet
   user: mathew
+  score_type: rep
+  score_value: 202
   reps_per_round: 25

--- a/test/fixtures/workouts.yml
+++ b/test/fixtures/workouts.yml
@@ -3,26 +3,33 @@
 fran:
   name: Fran
   interval: 21-15-9
+  score_type: time
 
 murph:
   name: Murph
   rounds: 1
+  score_type: time
 
 segmented:
   name: Segmented
+  score_type: time
 
 amrap_couplet:
   name: AMRAP Couplet
   time: 10
+  score_type: rep
 
 amrap_mixed:
   name: AMRAP Mixed
   time: 20
+  score_type: rep
 
 amrap_unknown_distance:
   name: AMRAP Unknown Distance
   time: 12
+  score_type: rep
 
 back_squat_5x5:
   name: Back Squat 5x5
   rounds: 5
+  score_type: weight

--- a/test/helpers/metrics_helper_test.rb
+++ b/test/helpers/metrics_helper_test.rb
@@ -7,14 +7,13 @@ class MetricsHelperTest < ActionView::TestCase
 
   test 'renders exact amrap scores as completed rounds and total reps' do
     log = logs(:matt_amrap)
-    log.metric.value = 200
+    log.score_value = 200
 
     assert_equal '8 rounds (200 reps)', log_score_msg(log)
   end
 
   test 'renders unknown amrap round size as total reps' do
-    log = workouts(:amrap_unknown_distance).logs.build(reps_per_round: nil)
-    log.build_metric(measurement: :rep, value: 202)
+    log = workouts(:amrap_unknown_distance).logs.build(score_type: :rep, score_value: 202, reps_per_round: nil)
 
     assert_equal '202 reps', log_score_msg(log)
   end

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -15,8 +15,7 @@ class WorkoutsHelperTest < ActionView::TestCase
 
   test 'renders timed rep-scored rounds as round amraps' do
     workout = workouts(:back_squat_5x5)
-    workout.update!(time: 3)
-    workout.metric.update!(measurement: :rep)
+    workout.update!(time: 3, score_type: :rep)
 
     assert_equal '5 rounds, complete as many reps as possible in 3 minutes of', workout_objective(workout)
   end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -31,8 +31,7 @@ class ExerciseTest < ActiveSupport::TestCase
   end
 
   test 'allows segment child positions to overlap top-level positions before segment is saved' do
-    workout = Workout.new(name: 'Segmented Seed Workout', rounds: 1)
-    workout.build_metric(measurement: :time)
+    workout = Workout.new(name: 'Segmented Seed Workout', rounds: 1, score_type: :time)
     segment = workout.segments.build(rounds: 10, position: 2)
 
     workout.exercises.build(movement: movements(:run), position: 1)

--- a/test/models/log_amrap_test.rb
+++ b/test/models/log_amrap_test.rb
@@ -2,78 +2,70 @@ require 'test_helper'
 
 class LogAmrapTest < ActiveSupport::TestCase
   test 'normalizes rounds plus reps to total reps' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20+2')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20+2')
 
     assert log.valid?
-    assert_equal 502, log.metric.value
+    assert_equal 502, log.score_value
     assert_equal 25, log.reps_per_round
   end
 
   test 'normalizes fixed-rep amrap round score submissions to reps' do
     workout = workouts(:amrap_couplet)
-    workout.metric.update!(measurement: :round)
-    log = workout.logs.build(user: users(:mathew))
-    log.build_metric(measurement: :round, value: '20+2')
+    workout.update!(score_type: :round)
+    log = workout.logs.build(user: users(:mathew), score_type: :round, score_value: '20+2')
 
     assert log.valid?
-    assert_equal 'rep', log.metric.measurement
-    assert_equal 502, log.metric.value
+    assert_equal 'rep', log.score_type
+    assert_equal 502, log.score_value
     assert_equal 25, log.reps_per_round
   end
 
   test 'normalizes overflow reps into total reps' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20+27')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20+27')
 
     assert log.valid?
-    assert_equal 527, log.metric.value
+    assert_equal 527, log.score_value
   end
 
   test 'normalizes rounds plus reps using submitted scaled movement recordings' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20+2')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20+2')
     log.build_movement_logs
 
     pushup_recording = log.movement_logs.find { |movement_log| movement_log.movement == movements(:pushup) }
     pushup_recording.metrics.find(&:rep?).value = 5
 
     assert log.valid?
-    assert_equal 302, log.metric.value
+    assert_equal 302, log.score_value
     assert_equal 15, log.reps_per_round
   end
 
   test 'accepts raw total reps' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '202')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '202')
 
     assert log.valid?
-    assert_equal 202, log.metric.value
+    assert_equal 202, log.score_value
     assert_equal 25, log.reps_per_round
   end
 
   test 'rejects malformed amrap score input' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '20.5')
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '20.5')
 
     assert_not log.valid?
-    assert_includes log.errors[:metric], 'score must be total reps or rounds plus reps'
+    assert_includes log.errors[:score_value], 'score must be total reps or rounds plus reps'
   end
 
   test 'rejects negative amrap score input' do
-    log = workouts(:amrap_couplet).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: -1)
+    log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: -1)
 
     assert_not log.valid?
-    assert_includes log.errors[:metric], 'score must be total reps or rounds plus reps'
+    assert_includes log.errors[:score_value], 'score must be total reps or rounds plus reps'
   end
 
   test 'rejects rounds plus reps when round size is unknown' do
-    log = workouts(:amrap_unknown_distance).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep, value: '2+5')
+    log = workouts(:amrap_unknown_distance).logs.build(user: users(:mathew), score_type: :rep, score_value: '2+5')
 
     assert_not log.valid?
-    assert_includes log.errors[:metric], 'rounds plus reps requires a fixed reps-per-round total'
+    assert_includes log.errors[:score_value], 'rounds plus reps requires a fixed reps-per-round total'
   end
 
   test 'returns amrap score parts from snapshotted reps per round' do

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -2,8 +2,7 @@ require 'test_helper'
 
 class LogTest < ActiveSupport::TestCase
   test 'builds one movement recording per set for set-based lifting workouts' do
-    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :weight)
+    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs
 
     assert_equal 5, log.movement_logs.size
@@ -16,15 +15,13 @@ class LogTest < ActiveSupport::TestCase
   end
 
   test 'defaults sex-specific prescribed load values when building movement logs' do
-    workout = Workout.new(rounds: 1)
-    workout.build_metric(measurement: :time)
+    workout = Workout.new(rounds: 1, score_type: :time)
     workout.exercises.build(movement: movements(:back_squat), position: 1) do |exercise|
       exercise.metrics.build(measurement: :rep, value: 21)
       exercise.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
     end
 
-    log = workout.logs.build(user: users(:mathew))
-    log.build_metric(measurement: :time, value: 180)
+    log = workout.logs.build(user: users(:mathew), score_type: :time, score_value: 180)
     log.build_movement_logs
 
     lb_metric = log.movement_logs.first.metrics.find(&:lb?)
@@ -33,13 +30,17 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 'lb', lb_metric.measurement
   end
 
+  test 'parses duration score values before score type assignment' do
+    log = Log.new(workout: workouts(:fran), user: users(:mathew), score_value: '5:30', score_type: :time)
+
+    assert_equal 330, log.score_value
+  end
+
   test 'builds timed round movement recordings with per-round prescribed reps' do
     workout = workouts(:back_squat_5x5)
-    workout.update!(time: 3)
-    workout.metric.update!(measurement: :rep)
+    workout.update!(time: 3, score_type: :rep)
 
-    log = workout.logs.build(user: users(:mathew))
-    log.build_metric(measurement: :rep)
+    log = workout.logs.build(user: users(:mathew), score_type: :rep)
     log.build_movement_logs
 
     assert_equal 1, log.movement_logs.size
@@ -47,8 +48,7 @@ class LogTest < ActiveSupport::TestCase
   end
 
   test 'calculates set-based lifting score from heaviest successful set' do
-    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew))
-    log.build_metric(measurement: :weight)
+    log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs
 
     [95, 115, 135, 145, 155].each.with_index do |load, index|
@@ -57,7 +57,7 @@ class LogTest < ActiveSupport::TestCase
     log.movement_logs[4].metrics.find(&:rep?).value = 2
 
     assert log.valid?
-    assert_equal 'lb', log.metric.measurement
-    assert_equal 145, log.metric.value
+    assert_equal 'lb', log.score_type
+    assert_equal 145, log.score_value
   end
 end

--- a/test/models/segment_test.rb
+++ b/test/models/segment_test.rb
@@ -23,8 +23,7 @@ class SegmentTest < ActiveSupport::TestCase
   end
 
   test 'rejects duplicate positions among unsaved segments in the same workout' do
-    workout = Workout.new(name: 'Invalid Segment Positions')
-    workout.build_metric(measurement: :time)
+    workout = Workout.new(name: 'Invalid Segment Positions', score_type: :time)
     segment = workout.segments.build(position: 1)
 
     workout.segments.build(position: 1)

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -42,7 +42,7 @@ class WorkoutTest < ActiveSupport::TestCase
 
   test 'does not identify rep-scored rounds with load-bearing exercises as set-based lifting' do
     workout = workouts(:back_squat_5x5)
-    workout.metric.update!(measurement: :rep)
+    workout.update!(score_type: :rep)
 
     assert_not workout.set_based_lifting?
   end

--- a/test/system/lifting_workouts_test.rb
+++ b/test/system/lifting_workouts_test.rb
@@ -16,7 +16,7 @@ class LiftingWorkoutsTest < ApplicationSystemTestCase
 
     click_on 'Log'
 
-    assert_no_selector '#log_metric_attributes_value'
+    assert_no_selector '#log_score_value'
     assert_text 'Score will be calculated from the heaviest successful set.'
     assert_selector '.card.mb-3', count: 5
     movement_logs = all('.card.mb-3')

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -92,7 +92,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
     visit workout_url(workouts(:fran))
 
     click_on 'Log'
-    fill_in 'log_metric_attributes_value', with: '5:30'
+    fill_in 'log_score_value', with: '5:30'
     click_on 'Save'
 
     assert_current_path %r{/logs/\d+}
@@ -108,7 +108,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
 
     assert_equal %w[300 10 20], amrap_recording_values
 
-    fill_in 'log_metric_attributes_value', with: '1+35'
+    fill_in 'log_score_value', with: '1+35'
 
     assert_equal %w[300 10 20], amrap_recording_values
 


### PR DESCRIPTION
Closes #1622 

## Summary

- Add direct score columns for workouts and logs, backed by the existing `Metric.measurements` enum values.
- Backfill `workouts.score_type`, `logs.score_type`, and `logs.score_value` from legacy polymorphic score metrics.
- Switch workout/log score reads and writes to direct fields while keeping legacy metric associations available for transition fallback.
- Update seeds, fixtures, forms, controllers, helpers, and scoring tests for the new direct score path.

## Migration Notes

- `workouts.score_type` and `logs.score_type` are `NOT NULL` after backfill.
- `logs.score_value` remains nullable to preserve old `metrics.value` behavior.
- Rollback restores legacy `Workout` and `Log` metric rows from direct score fields before dropping the columns.

## Validation

- `rvm 3.4.9@wod-tracker do bundle exec rails test test/models/log_test.rb test/models/log_amrap_test.rb test/models/workout_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rails test test/helpers/workouts_helper_test.rb test/helpers/metrics_helper_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rails test test/controllers/workouts_controller_test.rb test/controllers/logs_controller_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rails test:system test/system/lifting_workouts_test.rb test/system/workout_workflows_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rails test test/models/exercise_test.rb test/models/segment_test.rb`
- `rvm 3.4.9@wod-tracker do bundle exec rails db:migrate:down VERSION=20260611120000`
- `rvm 3.4.9@wod-tracker do bundle exec rails db:migrate`
- `git diff --check`
- `ruby -c db/seeds.rb`

Note: the RVM PATH warning appears in this shell, but the commands completed successfully. One attempted parallel test run raced on the test DB; rerunning serially passed.