### PR TITLE
Clean up segment modeling

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -41,7 +41,7 @@ class SchedulesController < ApplicationController
         workout: [
           :metric,
           :rich_text_notes,
-          { exercises: [:movement, :metrics, { segment: [:metric, :exercises] }] }
+          { exercises: [:movement, :metrics, { segment: :exercises }] }
         ]
       )
   end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -73,7 +73,8 @@ class WorkoutsController < ApplicationController
 
     params.expect(workout: [:name, :rounds, :time, :interval, :notes, :time_cap,
                             :score_type,
-                            { segments_attributes: [[:id, :rounds, :time, :interval, :position, :_destroy,
+                            { segments_attributes: [[:id, :name, :rounds, :time_seconds, :interval_scheme,
+                                                     :rest_seconds, :notes, :position, :_destroy,
                                                      { exercises_attributes: [exercise_params] }]] },
                             { exercises_attributes: [exercise_params] }])
   end

--- a/app/helpers/segments_helper.rb
+++ b/app/helpers/segments_helper.rb
@@ -1,11 +1,26 @@
 module SegmentsHelper
   def segment_objective(segment, then_prefix: false)
     msg = then_prefix ? 'Then, ' : ''
-    return "#{msg}#{pluralize segment.rounds, 'round'} of" if segment.rounds.positive?
-    return "#{msg}As many rounds as possible in #{pluralize segment.time, 'minute'}" if segment.amrap?
-    return "#{msg}EMOM #{segment.time}" if segment.emom?
-    return "#{msg}#{segment.rounds} #{segment.time}-minute rounds" if segment.timed_rounds?
 
-    "#{msg}#{segment.interval} for #{segment.metric.measurement}"
+    "#{msg}#{segment_prescription(segment)}"
+  end
+
+  private
+
+  def segment_prescription(segment)
+    return "#{segment.interval_scheme} of" if segment.interval?
+    return "#{pluralize segment.rounds, 'round'} of" if segment.rounds?
+    return "As many rounds as possible in #{segment_duration(segment)}" if segment.amrap?
+    return "EMOM #{segment.time_seconds / 60}" if segment.emom?
+    return "#{segment.rounds} #{segment.time_seconds / 60}-minute rounds" if segment.timed_rounds?
+
+    "#{segment.name.presence || 'Segment'}:"
+  end
+
+  def segment_duration(segment)
+    seconds = segment.time_seconds
+    return pluralize(seconds / 60, 'minute') if (seconds % 60).zero?
+
+    pluralize(seconds, 'second')
   end
 end

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -1,6 +1,5 @@
 class Segment < ApplicationRecord
   belongs_to :workout
-  has_one :metric, as: :measurable, dependent: :destroy
   has_many :exercises, dependent: :destroy
 
   accepts_nested_attributes_for :exercises, allow_destroy: true
@@ -15,17 +14,39 @@ class Segment < ApplicationRecord
   validate :position_unique_within_workout_parts
 
   def rounds?
-    rounds.present? && time.blank? && interval.blank?
+    rounds.present? && time_seconds.blank? && interval_scheme.blank?
   end
 
   def amrap?
-    time.present? && rounds.blank? && interval.blank?
+    time_seconds.present? && rounds.blank? && interval_scheme.blank?
+  end
+
+  def emom?
+    time_seconds.present? && rounds.present? && (time_seconds % (60 * rounds)).zero?
+  end
+
+  def timed_rounds?
+    rounds.present? && time_seconds.present? && interval_scheme.nil?
+  end
+
+  def interval?
+    interval_scheme.present?
   end
 
   def reps_from_interval
     return nil unless interval?
 
-    interval.split('-').sum(&:to_i)
+    interval_scheme.split('-').sum(&:to_i)
+  end
+
+  # Time is a number of seconds or a string in the format "Minutes:Seconds" or "Hours:Minutes:Seconds"
+  def time_seconds=(value)
+    if value.is_a?(String) && value.include?(':')
+      parts = value.split(':').map(&:to_i)
+      super(parts.reverse.each_with_index.sum { |part, index| part * (60**index) })
+    else
+      super
+    end
   end
 
   private

--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -2,10 +2,14 @@
   = f.hidden_field :_destroy
   .card-body
     .form-row
+      .col = f.input :name
       .col = f.input :rounds
-      .col = f.input :time
-      .col = f.input :interval
+      .col = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200'
+      .col = f.input :interval_scheme, placeholder: '21-15-9...'
       .col-4.col-md-2 = f.input :position
+    .form-row
+      .col = f.input :rest_seconds
+      .col = f.input :notes
     .row
       .col#segmented_exercises data-controller="nested-form" data-nested-form-placeholder-value="CHILD_EXERCISE" data-nested-form-position-exercises-value="true"
         .fields data-nested-form-target="container"

--- a/db/migrate/20260612000000_restructure_segments_as_structural_blocks.rb
+++ b/db/migrate/20260612000000_restructure_segments_as_structural_blocks.rb
@@ -1,0 +1,71 @@
+class RestructureSegmentsAsStructuralBlocks < ActiveRecord::Migration[8.1]
+  class MigrationSegment < ActiveRecord::Base
+    self.table_name = 'segments'
+    self.record_timestamps = false
+  end
+
+  class MigrationMetric < ActiveRecord::Base
+    self.table_name = 'metrics'
+  end
+
+  def up
+    add_column :segments, :name, :string unless column_exists?(:segments, :name)
+    add_column :segments, :time_seconds, :integer unless column_exists?(:segments, :time_seconds)
+    add_column :segments, :interval_scheme, :string unless column_exists?(:segments, :interval_scheme)
+    add_column :segments, :rest_seconds, :integer unless column_exists?(:segments, :rest_seconds)
+    add_column :segments, :notes, :text unless column_exists?(:segments, :notes)
+
+    backfill_structural_fields
+    delete_segment_metrics
+
+    remove_column :segments, :time if column_exists?(:segments, :time)
+    remove_column :segments, :interval if column_exists?(:segments, :interval)
+  end
+
+  def down
+    add_column :segments, :time, :integer unless column_exists?(:segments, :time)
+    add_column :segments, :interval, :integer unless column_exists?(:segments, :interval)
+
+    restore_legacy_fields
+
+    remove_column :segments, :notes if column_exists?(:segments, :notes)
+    remove_column :segments, :rest_seconds if column_exists?(:segments, :rest_seconds)
+    remove_column :segments, :interval_scheme if column_exists?(:segments, :interval_scheme)
+    remove_column :segments, :time_seconds if column_exists?(:segments, :time_seconds)
+    remove_column :segments, :name if column_exists?(:segments, :name)
+  end
+
+  private
+
+  def backfill_structural_fields
+    say_with_time 'Backfilling segment time_seconds and interval_scheme' do
+      MigrationSegment.where.not(time: nil).find_each do |segment|
+        segment.update!(time_seconds: segment.time * 60)
+      end
+
+      MigrationSegment.where.not(interval: nil).find_each do |segment|
+        segment.update!(interval_scheme: segment.interval.to_s)
+      end
+    end
+  end
+
+  # Deleted segment metrics are not restorable on rollback.
+  def delete_segment_metrics
+    say_with_time 'Deleting segment-scoped metrics' do
+      MigrationMetric.where(measurable_type: 'Segment').delete_all
+    end
+  end
+
+  # Dash-style interval schemes cannot round-trip into the legacy integer column and are dropped.
+  def restore_legacy_fields
+    say_with_time 'Restoring segment time and interval from structural fields' do
+      MigrationSegment.where.not(time_seconds: nil).find_each do |segment|
+        segment.update!(time: segment.time_seconds / 60)
+      end
+
+      MigrationSegment.where("interval_scheme ~ '^[0-9]+$'").find_each do |segment|
+        segment.update!(interval: segment.interval_scheme.to_i)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -126,10 +126,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
 
   create_table "segments", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.integer "interval"
+    t.string "interval_scheme"
+    t.string "name"
+    t.text "notes"
     t.integer "position", null: false
+    t.integer "rest_seconds"
     t.integer "rounds"
-    t.integer "time"
+    t.integer "time_seconds"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "workout_id"
     t.index ["position", "workout_id"], name: "index_segments_on_position_and_workout_id", unique: true

--- a/test/helpers/segments_helper_test.rb
+++ b/test/helpers/segments_helper_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class SegmentsHelperTest < ActionView::TestCase
+  test 'renders rounds-only segments as rounds of' do
+    assert_equal '10 rounds of', segment_objective(Segment.new(rounds: 10))
+  end
+
+  test 'prefixes subsequent segments with then' do
+    assert_equal 'Then, 10 rounds of', segment_objective(Segment.new(rounds: 10), then_prefix: true)
+  end
+
+  test 'renders amrap segments with whole-minute durations in minutes' do
+    assert_equal 'As many rounds as possible in 10 minutes', segment_objective(Segment.new(time_seconds: 600))
+  end
+
+  test 'renders amrap segments with partial-minute durations in seconds' do
+    assert_equal 'As many rounds as possible in 90 seconds', segment_objective(Segment.new(time_seconds: 90))
+  end
+
+  test 'renders emom segments with their duration in minutes' do
+    assert_equal 'EMOM 10', segment_objective(Segment.new(time_seconds: 600, rounds: 10))
+  end
+
+  test 'renders timed rounds segments with their duration in minutes' do
+    assert_equal '4 25-minute rounds', segment_objective(Segment.new(time_seconds: 1500, rounds: 4))
+  end
+
+  test 'renders interval segments as their scheme' do
+    assert_equal '21-15-9 of', segment_objective(Segment.new(interval_scheme: '21-15-9'))
+  end
+
+  test 'falls back to the segment name' do
+    assert_equal 'Skill work:', segment_objective(Segment.new(name: 'Skill work'))
+  end
+
+  test 'falls back to a generic label for empty segments' do
+    assert_equal 'Segment:', segment_objective(Segment.new)
+  end
+end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -47,6 +47,17 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 5, log.movement_logs.first.metrics.find(&:rep?).value
   end
 
+  test 'multiplies prescribed reps by segment rounds for segment exercises' do
+    exercises(:segmented_hspu).metrics.create!(measurement: :rep, value: 10)
+
+    log = workouts(:segmented).logs.build(user: users(:mathew), score_type: :time)
+    log.build_movement_logs
+
+    hspu_log = log.movement_logs.find { |movement_log| movement_log.movement == movements(:hspu) }
+
+    assert_equal 100, hspu_log.metrics.find(&:rep?).value
+  end
+
   test 'calculates set-based lifting score from heaviest successful set' do
     log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs

--- a/test/models/segment_test.rb
+++ b/test/models/segment_test.rb
@@ -38,4 +38,31 @@ class SegmentTest < ActiveSupport::TestCase
     assert_not exercise.valid?
     assert_includes exercise.errors[:position], 'has already been taken'
   end
+
+  test 'identifies emom segments by whole-minute rounds' do
+    assert_predicate Segment.new(time_seconds: 600, rounds: 10), :emom?
+    assert_not_predicate Segment.new(time_seconds: 630, rounds: 10), :emom?
+  end
+
+  test 'identifies timed rounds segments' do
+    assert_predicate Segment.new(time_seconds: 1500, rounds: 4), :timed_rounds?
+    assert_not_predicate Segment.new(rounds: 4), :timed_rounds?
+  end
+
+  test 'identifies interval segments by their scheme' do
+    assert_predicate Segment.new(interval_scheme: '21-15-9'), :interval?
+    assert_not_predicate Segment.new, :interval?
+  end
+
+  test 'sums interval scheme reps' do
+    assert_equal 45, Segment.new(interval_scheme: '21-15-9').reps_from_interval
+    assert_nil Segment.new.reps_from_interval
+  end
+
+  test 'parses duration strings into time seconds' do
+    assert_equal 1200, Segment.new(time_seconds: '20:00').time_seconds
+    assert_equal 3630, Segment.new(time_seconds: '1:00:30').time_seconds
+    assert_equal 90, Segment.new(time_seconds: '90').time_seconds
+    assert_equal 90, Segment.new(time_seconds: 90).time_seconds
+  end
 end


### PR DESCRIPTION
Closes #1623

## Summary

Treats segments as ordered structural workout blocks and removes the remaining dependency on `Segment#metric`.

- **Migration**: adds `name`, `time_seconds`, `interval_scheme`, `rest_seconds`, and `notes` to `segments`; backfills `time_seconds = time * 60` and `interval_scheme = interval.to_s`; deletes `Metric` rows where `measurable_type = 'Segment'`; drops the legacy `time` (minutes) and `interval` (integer) columns. Rollback restores the legacy columns where values can round-trip.
- **Segment model**: drops `has_one :metric`; adds `emom?`, `timed_rounds?`, and `interval?` predicates and updates `rounds?`/`amrap?`/`reps_from_interval` to the new columns; `time_seconds=` accepts raw seconds, `MM:SS`, or `HH:MM:SS`.
- **Helper**: `segment_objective` no longer reads `segment.metric.measurement`. Interval segments render unit-agnostically (`"21-15-9 of"` — each exercise interprets the scheme as its own reps/calories), and empty segments fall back to their name instead of crashing.
- **Forms/controllers**: segment form exposes the new fields, `workout_params` permits them, and the schedules eager-load no longer references segment metrics.

## Bug fixes along the way

- Logging a segment exercise with a valued rep metric previously raised `NoMethodError` (`segment.timed_rounds?` was undefined); it now correctly computes `value * segment.rounds` (covered by a new log test).
- `segment_objective` previously crashed on segments with nil `rounds` or no metric row.

## Behavior changes

- Rounds+time segments now render via the EMOM/timed-rounds branches instead of short-circuiting to "N rounds of".
- Segment-scoped metric rows are deleted irreversibly by the migration.

## Pre-deploy check

Confirm in production (both expected to be 0 — the integer `interval` column could never hold dash schemes):

```ruby
Segment.where.not(interval: nil).count
Metric.where(measurable_type: 'Segment').count
```

## Testing

- New `test/helpers/segments_helper_test.rb` covering all rendering branches
- Predicate and time-parsing tests in `test/models/segment_test.rb`; segment-rounds logging test in `test/models/log_test.rb`
- `rails test test/models test/helpers test/controllers` — 106 runs, 0 failures
- `test/system/workout_segment_positions_test.rb` passes (exercises the rewritten form partial)
- RuboCop clean; migration verified to round-trip (migrate → rollback → migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)