### PR TITLE
Backfill score_type for rows without a legacy score metric

### DIFF
--- a/db/migrate/20260611120000_add_direct_score_fields.rb
+++ b/db/migrate/20260611120000_add_direct_score_fields.rb
@@ -1,4 +1,8 @@
 class AddDirectScoreFields < ActiveRecord::Migration[8.1]
+  # Mirrors Metric.measurements for rows that have no legacy score metric
+  ROUND_SCORE = 2
+  TIME_SCORE = 9
+
   class MigrationMetric < ActiveRecord::Base
     self.table_name = 'metrics'
   end
@@ -19,16 +23,10 @@ class AddDirectScoreFields < ActiveRecord::Migration[8.1]
     MigrationWorkout.reset_column_information
     MigrationLog.reset_column_information
 
-    MigrationMetric.where(measurable_type: 'Workout').find_each do |metric|
-      MigrationWorkout.where(id: metric.measurable_id).update_all(score_type: metric.measurement)
-    end
-
-    MigrationMetric.where(measurable_type: 'Log').find_each do |metric|
-      MigrationLog.where(id: metric.measurable_id).update_all(
-        score_type: metric.measurement,
-        score_value: metric.value
-      )
-    end
+    backfill_workouts_from_metrics
+    backfill_logs_from_metrics
+    backfill_workouts_without_score_metric
+    backfill_logs_without_score_metric
 
     change_column_null :workouts, :score_type, false
     change_column_null :logs, :score_type, false
@@ -60,5 +58,37 @@ class AddDirectScoreFields < ActiveRecord::Migration[8.1]
     remove_column :logs, :score_value
     remove_column :logs, :score_type
     remove_column :workouts, :score_type
+  end
+
+  private
+
+  def backfill_workouts_from_metrics
+    MigrationMetric.where(measurable_type: 'Workout').find_each do |metric|
+      MigrationWorkout.where(id: metric.measurable_id).update_all(score_type: metric.measurement)
+    end
+  end
+
+  def backfill_logs_from_metrics
+    MigrationMetric.where(measurable_type: 'Log').find_each do |metric|
+      MigrationLog.where(id: metric.measurable_id).update_all(
+        score_type: metric.measurement,
+        score_value: metric.value
+      )
+    end
+  end
+
+  def backfill_workouts_without_score_metric
+    MigrationWorkout
+      .where(score_type: nil, rounds: nil, interval: nil)
+      .where.not(time: nil)
+      .update_all(score_type: ROUND_SCORE)
+    MigrationWorkout.where(score_type: nil).update_all(score_type: TIME_SCORE)
+  end
+
+  def backfill_logs_without_score_metric
+    MigrationLog.where(score_type: nil).find_each do |log|
+      workout_score = MigrationWorkout.where(id: log.workout_id).pick(:score_type)
+      MigrationLog.where(id: log.id).update_all(score_type: workout_score || TIME_SCORE)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the production deploy failure from #1642:

```
PG::NotNullViolation: ERROR:  column "score_type" of relation "workouts" contains null values
```

The `AddDirectScoreFields` migration only backfilled `score_type` from legacy `Metric` rows, but production has workouts (and potentially logs) with no metric at all, so `change_column_null` aborted. The migration ran in a transaction, so production rolled back cleanly and will rerun the fixed migration on the next deploy.

## Changes

- Backfill workouts without a score metric by structure before enforcing `NOT NULL`: AMRAP-shaped workouts (`time` set, no `rounds`/`interval`) score by `round`; all others default to `time`, per the scoring conventions in `cf/docs/programming.md`.
- Backfill logs without a score metric from their workout's just-backfilled `score_type`, defaulting to `time` if the log has no workout.
- Extracted the existing metric-based backfill loops into private methods to keep `up` under the RuboCop AbcSize limit.

No schema change: `db/schema.rb` already declares `score_type` as `null: false` on both tables.

## Validation

- Replicated the prod failure locally: rolled the migration down, inserted a metric-less AMRAP workout, plain workout, and log via raw SQL, migrated up. Previously aborted at `change_column_null`; now succeeds with the AMRAP getting `round`, the plain workout `time`, the log inheriting `time`, and zero NULLs remaining.
- `bundle exec rails test test/models/workout_test.rb test/models/log_test.rb test/models/log_amrap_test.rb` — 22 runs, 0 failures.
- `bundle exec rubocop db/migrate/20260611120000_add_direct_score_fields.rb` — remaining offenses are pre-existing patterns (`update_all` in migration, `down` size).

## Note

After this backfill, rolling the migration back will create `Metric` rows for workouts/logs that never had one, since `down` restores metrics from all non-nil score types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)