### PR TITLE
[codex] Disable Active Storage variants

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ module WodTracker
     # serve it directly instead of reparsing it through SassC.
     config.assets.css_compressor = nil
 
+    config.active_storage.variant_processor = :disabled
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
## Summary

Disables Active Storage image variant processing globally by setting `config.active_storage.variant_processor = :disabled`.

## Why

Production logs were warning that image variants require the `image_processing` gem. This app does not currently define image variant usage in app code, so disabling variant generation removes the warning without adding a new image-processing dependency.

## Impact

Normal Active Storage blob serving remains unaffected. Future thumbnail or preview features that depend on generated variants will need to either install `image_processing` or remove this disabled setting.

## Validation

- `rvm 3.4.9@wod-tracker do bundle exec rails runner 'puts Rails.application.config.active_storage.variant_processor.inspect'` returned `:disabled`.