### PR TITLE
Add exercise prescription columns and backfill (#1650)

### DIFF
--- a/db/migrate/20260612130000_add_exercise_prescription_fields.rb
+++ b/db/migrate/20260612130000_add_exercise_prescription_fields.rb
@@ -1,0 +1,193 @@
+class AddExercisePrescriptionFields < ActiveRecord::Migration[8.1]
+  # Mirrors Metric.measurements so the backfill can read legacy rows without the model.
+  CALORIE = 0
+  REP = 1
+  ROUND = 2
+  SECONDS = 3
+  INCH = 4
+  FOOT = 5
+  METER = 6
+  LB = 7
+  KG = 8
+  TIME = 9
+  WEIGHT = 10
+  HEIGHT = 11
+  DISTANCE = 12
+
+  # Exercise enum ints (the enums themselves are declared on the model in a later phase).
+  LOAD_UNITS = { lb: 0, kg: 1 }.freeze
+  DISTANCE_UNITS = { meter: 0, foot: 1, inch: 2 }.freeze
+
+  PRESCRIPTION_COLUMNS = %i[
+    reps duration_seconds
+    load female_load male_load load_unit
+    distance female_distance male_distance distance_unit
+    calories female_calories male_calories
+    notes
+  ].freeze
+
+  class MigrationMetric < ActiveRecord::Base
+    self.table_name = 'metrics'
+  end
+
+  class MigrationExercise < ActiveRecord::Base
+    self.table_name = 'exercises'
+  end
+
+  class MigrationWorkout < ActiveRecord::Base
+    self.table_name = 'workouts'
+  end
+
+  def up
+    add_column :exercises, :reps, :integer
+    add_column :exercises, :duration_seconds, :integer
+    add_column :exercises, :load, :integer
+    add_column :exercises, :female_load, :integer
+    add_column :exercises, :male_load, :integer
+    add_column :exercises, :load_unit, :integer
+    add_column :exercises, :distance, :integer
+    add_column :exercises, :female_distance, :integer
+    add_column :exercises, :male_distance, :integer
+    add_column :exercises, :distance_unit, :integer
+    add_column :exercises, :calories, :integer
+    add_column :exercises, :female_calories, :integer
+    add_column :exercises, :male_calories, :integer
+    add_column :exercises, :notes, :string
+
+    MigrationExercise.reset_column_information
+    backfill
+  end
+
+  def down
+    PRESCRIPTION_COLUMNS.each { |column| remove_column :exercises, column }
+  end
+
+  private
+
+  def backfill
+    workout_names = MigrationWorkout.pluck(:id, :name).to_h
+    mapped = 0
+    notes = 0
+    unmapped = 0
+
+    metrics_by_exercise = MigrationMetric.where(measurable_type: 'Exercise').group_by(&:measurable_id)
+    metrics_by_exercise.each do |exercise_id, metrics|
+      exercise = MigrationExercise.find_by(id: exercise_id)
+      next unless exercise
+
+      attrs = {}
+      filled = []
+
+      metrics.sort_by(&:id).each do |metric|
+        status, reason = apply_metric(metric, attrs, filled)
+        case status
+        when :note then mapped += 1; notes += 1
+        when :mapped then mapped += 1
+        when :unmapped then unmapped += 1
+        end
+        audit(status, reason, metric, exercise_id, workout_names[exercise.workout_id]) if reason
+      end
+
+      MigrationExercise.where(id: exercise_id).update_all(attrs) if attrs.any?
+    end
+
+    say "Backfill: #{mapped} mapped, #{notes} notes, #{unmapped} unmapped"
+  end
+
+  # Returns [status, reason]. status is :mapped, :note, or :unmapped; reason is nil unless audited.
+  def apply_metric(metric, attrs, filled)
+    case metric.measurement
+    when REP then apply_reps(metric, attrs, filled)
+    when CALORIE then apply_calories(metric, attrs, filled)
+    when SECONDS, TIME then apply_duration(metric, attrs, filled)
+    when LB, KG, WEIGHT then apply_load(metric, attrs, filled)
+    when METER, FOOT, INCH, DISTANCE, HEIGHT then apply_distance(metric, attrs, filled)
+    else
+      [:unmapped, "unexpected measurement #{metric.measurement}"]
+    end
+  end
+
+  def apply_reps(metric, attrs, filled)
+    return [:unmapped, 'sex-specific reps unsupported'] if sex_specific?(metric)
+    return [:unmapped, 'duplicate reps'] if filled.include?(:reps)
+
+    filled << :reps
+    attrs[:reps] = metric.value || 0 # blank rep metric means "max reps"
+    [:mapped, nil]
+  end
+
+  def apply_calories(metric, attrs, filled)
+    return [:unmapped, 'duplicate calories'] if filled.include?(:calories)
+
+    filled << :calories
+    if positive?(metric.value)
+      attrs[:calories] = metric.value
+    elsif sex_specific?(metric)
+      attrs[:female_calories] = metric.female_value if positive?(metric.female_value)
+      attrs[:male_calories] = metric.male_value if positive?(metric.male_value)
+    else
+      attrs[:calories] = 0 # blank calorie metric means "max calories"
+    end
+    [:mapped, nil]
+  end
+
+  def apply_duration(metric, attrs, filled)
+    return [:unmapped, 'duplicate duration'] if filled.include?(:duration)
+
+    filled << :duration
+    attrs[:duration_seconds] = metric.value if positive?(metric.value)
+    [:mapped, nil]
+  end
+
+  def apply_load(metric, attrs, filled)
+    return [:unmapped, 'duplicate load'] if filled.include?(:load)
+
+    filled << :load
+    attrs[:load_unit] = LOAD_UNITS[metric.measurement == KG ? :kg : :lb]
+    attrs[:load] = metric.value if positive?(metric.value)
+    attrs[:female_load] = metric.female_value if positive?(metric.female_value)
+    attrs[:male_load] = metric.male_value if positive?(metric.male_value)
+
+    return [:note, 'implicit unit assumed lb — verify; possible bodyweight artifact'] if metric.measurement == WEIGHT
+
+    [:mapped, nil]
+  end
+
+  def apply_distance(metric, attrs, filled)
+    return [:unmapped, 'duplicate length'] if filled.include?(:distance)
+
+    filled << :distance
+    unit = distance_unit_for(metric.measurement)
+    attrs[:distance_unit] = DISTANCE_UNITS[unit] if unit
+    attrs[:distance] = metric.value if positive?(metric.value)
+    attrs[:female_distance] = metric.female_value if positive?(metric.female_value)
+    attrs[:male_distance] = metric.male_value if positive?(metric.male_value)
+
+    return [:note, 'unitless height enum mapped to distance'] if metric.measurement == HEIGHT
+
+    [:mapped, nil]
+  end
+
+  def distance_unit_for(measurement)
+    case measurement
+    when METER then :meter
+    when FOOT then :foot
+    when INCH then :inch
+    end # DISTANCE and HEIGHT have no unit
+  end
+
+  def audit(status, reason, metric, exercise_id, workout_name)
+    label = status == :unmapped ? 'UNMAPPED' : 'NOTE'
+    say "#{label} metric ##{metric.id} (exercise ##{exercise_id}, workout '#{workout_name}'): " \
+        "measurement=#{metric.measurement} value=#{metric.value.inspect} " \
+        "female=#{metric.female_value.inspect} male=#{metric.male_value.inspect} — #{reason}"
+  end
+
+  def sex_specific?(metric)
+    metric.female_value.present? || metric.male_value.present?
+  end
+
+  def positive?(value)
+    value.is_a?(Integer) && value.positive?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,10 +53,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_000000) do
   end
 
   create_table "exercises", force: :cascade do |t|
+    t.integer "calories"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "distance"
+    t.integer "distance_unit"
     t.integer "distance_units_per_rep"
+    t.integer "duration_seconds"
+    t.integer "female_calories"
+    t.integer "female_distance"
+    t.integer "female_load"
+    t.integer "load"
+    t.integer "load_unit"
+    t.integer "male_calories"
+    t.integer "male_distance"
+    t.integer "male_load"
     t.bigint "movement_id"
+    t.string "notes"
     t.integer "position", null: false
+    t.integer "reps"
     t.bigint "segment_id"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "workout_id"

--- a/test/migrations/add_exercise_prescription_fields_test.rb
+++ b/test/migrations/add_exercise_prescription_fields_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20260612130000_add_exercise_prescription_fields').to_s
+
+# Unit-tests the backfill mapping in isolation. The mapper reads raw integer measurements
+# (like the migration's MigrationMetric), so we feed it lightweight stubs rather than real
+# Metric records.
+class AddExercisePrescriptionFieldsTest < ActiveSupport::TestCase
+  M = AddExercisePrescriptionFields
+  Stub = Struct.new(:measurement, :value, :female_value, :male_value)
+
+  # Applies one metric and returns [attrs, status, reason]. Pass `into:` to accumulate across
+  # metrics on a single exercise (for duplicate-dimension checks).
+  def apply(measurement, value: nil, female_value: nil, male_value: nil, into: nil)
+    ctx = into || { attrs: {}, filled: [] }
+    stub = Stub.new(measurement, value, female_value, male_value)
+    status, reason = M.new.send(:apply_metric, stub, ctx[:attrs], ctx[:filled])
+    [ctx[:attrs], status, reason]
+  end
+
+  test 'reps: value kept, blank becomes 0 (max), sex-specific left unmapped' do
+    assert_equal({ reps: 21 }, apply(M::REP, value: 21).first)
+    assert_equal({ reps: 0 }, apply(M::REP).first)
+    attrs, status, reason = apply(M::REP, female_value: 5, male_value: 7)
+    assert_empty attrs
+    assert_equal :unmapped, status
+    assert_match(/sex-specific reps/, reason)
+  end
+
+  test 'seconds and time map to duration_seconds' do
+    assert_equal({ duration_seconds: 60 }, apply(M::SECONDS, value: 60).first)
+    assert_equal({ duration_seconds: 90 }, apply(M::TIME, value: 90).first)
+  end
+
+  test 'load: lb/kg units, sex loads, and blank marker' do
+    assert_equal({ load_unit: M::LOAD_UNITS[:lb], load: 95 }, apply(M::LB, value: 95).first)
+    assert_equal({ load_unit: M::LOAD_UNITS[:kg], load: 60 }, apply(M::KG, value: 60).first)
+    assert_equal({ load_unit: M::LOAD_UNITS[:lb], female_load: 65, male_load: 95 },
+                 apply(M::LB, female_value: 65, male_value: 95).first)
+    assert_equal({ load_unit: M::LOAD_UNITS[:lb] }, apply(M::LB).first) # blank "record a load" marker
+  end
+
+  test 'weight assumes lb, notes, and never stores a zero load' do
+    attrs, status, reason = apply(M::WEIGHT, value: 0)
+    assert_equal({ load_unit: M::LOAD_UNITS[:lb] }, attrs)
+    assert_equal :note, status
+    assert_match(/implicit unit assumed lb/, reason)
+    assert_equal({ load_unit: M::LOAD_UNITS[:lb], load: 3 }, apply(M::WEIGHT, value: 3).first)
+  end
+
+  test 'length: meter/foot/inch units, generic distance, and unitless height note' do
+    assert_equal({ distance_unit: M::DISTANCE_UNITS[:meter], distance: 400 }, apply(M::METER, value: 400).first)
+    assert_equal({ distance_unit: M::DISTANCE_UNITS[:foot], female_distance: 9, male_distance: 10 },
+                 apply(M::FOOT, female_value: 9, male_value: 10).first)
+    assert_equal({ distance_unit: M::DISTANCE_UNITS[:inch], distance: 20 }, apply(M::INCH, value: 20).first)
+    assert_equal({ distance: 1600 }, apply(M::DISTANCE, value: 1600).first)
+    _, status, = apply(M::HEIGHT, value: 24)
+    assert_equal :note, status
+  end
+
+  test 'calories: value, blank becomes 0 (max), and sex calories' do
+    assert_equal({ calories: 20 }, apply(M::CALORIE, value: 20).first)
+    assert_equal({ calories: 0 }, apply(M::CALORIE).first)
+    assert_equal({ female_calories: 20, male_calories: 30 }, apply(M::CALORIE, female_value: 20, male_value: 30).first)
+  end
+
+  test 'a second metric in a filled dimension is unmapped' do
+    ctx = { attrs: {}, filled: [] }
+    apply(M::LB, value: 95, into: ctx)
+    _, status, reason = apply(M::KG, value: 60, into: ctx)
+    assert_equal :unmapped, status
+    assert_match(/duplicate load/, reason)
+  end
+
+  test 'an unexpected measurement (round) on an exercise is unmapped' do
+    _, status, = apply(M::ROUND, value: 5)
+    assert_equal :unmapped, status
+  end
+
+  # Completeness guard: every Metric measurement an exercise could carry must be handled by the
+  # backfill (mapped or noted), except the explicitly structural ones. A new measurement that is
+  # not handled fails this test, forcing a deliberate decision.
+  EXERCISE_UNSUPPORTED_MEASUREMENTS = %w[round].freeze # structural; live on workout/segment
+
+  test 'every Metric measurement is handled by the backfill or explicitly excluded' do
+    Metric.measurements.each do |name, int|
+      next if EXERCISE_UNSUPPORTED_MEASUREMENTS.include?(name)
+
+      _, status, reason = apply(int, value: 1)
+      assert_not_equal :unmapped, status, "Metric measurement #{name} (#{int}) is not handled: #{reason}"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1650. Phase 3 of the data-preserving schema redesign (#1624), additive sub-issue **A of 3** (data → reads → writes).

## What this does

Adds explicit, queryable prescription columns to `exercises` and backfills them from the existing polymorphic exercise `metrics` rows. **Fully additive** — no app code reads or writes the new columns yet, and `metrics` rows are never modified. Safe to merge on its own and trivially revertible.

### Columns added (all nullable)
`reps`, `duration_seconds`, `load`/`female_load`/`male_load`/`load_unit`, `distance`/`female_distance`/`male_distance`/`distance_unit`, `calories`/`female_calories`/`male_calories`, `notes`.

Enums (`load_unit`, `distance_unit`) are declared on the model in the next PR (#1651); this PR only adds the integer columns.

### Backfill rules
- **`0`-value sentinel** for open-ended "max" reps/calories (a blank rep/calorie metric today).
- **Single `distance` length dimension** carries both traveled distance and target heights (foot/inch) — no separate `height` column. Keeps `foot`/`inch` in their existing distance-family storage, so display parity is preserved and there's no height/distance classification heuristic.
- **Value columns written only when positive**, so blank "record a load" markers and the integer-cast bodyweight `weight` rows never store a stray `0` (which would trip the `> 0` validation added in #1651).
- **Bodyweight `weight` rows** map to lb with a review NOTE; their real fix (move to `notes`) lands when seeds are rewritten in #1652.
- **Audit output**: per-row `UNMAPPED` (left in `metrics`, blocker) vs `NOTE` (mapped but review-worthy), plus a `mapped/notes/unmapped` summary. Nothing is ever dropped.

## Verification
- `bin/rails db:migrate` on the seeded dataset: **179 mapped, 4 notes, 0 unmapped** (the 4 notes are bodyweight `weight` rows — Linda ×3, Lynne ×1). `db:rollback` cleanly drops the columns.
- Spot-checked backfilled data: Fran thruster (interval `reps:1` + sex `lb` loads), FGB wall-ball (`reps:0` max, target height as `distance`+foot), box jump (height as `distance`+inch), row (`calories:0` max).
- New backfill mapping test (9 runs / 42 assertions) with a **completeness guard** that fails if a future `Metric` measurement is left unhandled.
- Full non-system suite green: **115 runs, 324 assertions, 0 failures**.

## Out of scope (later sub-issues)
Reads from columns (#1651), writes/forms/**seeds** (#1652), dropping `metrics` (#1626), MovementLog (#1625).

🤖 Generated with [Claude Code](https://claude.com/claude-code)