### PR TITLE
[codex] Improve mobile workout form usability

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -16,3 +16,53 @@ $input-border-width: $border-width;
 .fs-8 {
   font-size: 8pt;
 }
+
+.metric-fields {
+  .metric-fields__grid {
+    display: grid;
+    gap: .5rem;
+    grid-template-columns: minmax(0, 1fr) minmax(8rem, auto);
+    margin-bottom: .5rem;
+  }
+
+  .metric-fields__grid--sex-specific {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-fields__label {
+    color: $text-muted;
+    font-size: .75rem;
+    font-weight: 600;
+    line-height: 1.2;
+    margin-bottom: .25rem;
+    text-transform: uppercase;
+  }
+
+  .metric-fields__remove {
+    min-height: 2.375rem;
+  }
+
+  @include media-breakpoint-up(md) {
+    .metric-fields__grid {
+      align-items: end;
+      grid-template-columns: minmax(0, 1fr) minmax(10rem, auto);
+    }
+
+    .metric-fields__grid--sex-specific {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .metric-fields__remove {
+      min-width: 2.75rem;
+    }
+  }
+}
+
+.exercise .links {
+  position: relative;
+  z-index: 20;
+}
+
+.exercise .movement.ts-wrapper .ts-dropdown {
+  z-index: 10;
+}

--- a/app/views/application/_metric_fields.html.slim
+++ b/app/views/application/_metric_fields.html.slim
@@ -1,12 +1,20 @@
-.nested-fields
+.nested-fields.metric-fields
   = f.hidden_field :_destroy
   - sex_specific = local_assigns.fetch(:sex_specific, false)
-  .input-group.mb-3
-    = f.input_field :value, as: :string, class: 'form-control', value: f.object.time? ? seconds_to_duration_string(f.object.value) : f.object.value
+  .metric-fields__grid class=('metric-fields__grid--sex-specific' if sex_specific)
+    .metric-fields__cell
+      .metric-fields__label Value
+      = f.input_field :value, as: :string, class: 'form-control', value: f.object.time? ? seconds_to_duration_string(f.object.value) : f.object.value
+    .metric-fields__cell
+      .metric-fields__label Unit
+      = f.select :measurement, options_for_select(Metric.measurements.keys, f.object.measurement), {}, class: 'metric form-select', data: { controller: 'metric-select' }
     - if sex_specific
-      = f.input_field :female_value, as: :string, class: 'form-control', placeholder: 'Female value'
-      = f.input_field :male_value, as: :string, class: 'form-control', placeholder: 'Male value'
-    = f.select :measurement, options_for_select(Metric.measurements.keys, f.object.measurement), {}, class: 'metric form-control', data: { controller: 'metric-select' }
-    .input-group-append
-      = link_to '#', class: 'btn btn-outline-danger', data: { action: 'click->nested-form#remove' }
-        i.fas.fa-trash-alt
+      .metric-fields__cell
+        .metric-fields__label Male
+        = f.input_field :male_value, as: :string, class: 'form-control', placeholder: 'Male value'
+      .metric-fields__cell
+        .metric-fields__label Female
+        = f.input_field :female_value, as: :string, class: 'form-control', placeholder: 'Female value'
+  .d-grid.mb-3
+    = link_to '#', class: 'btn btn-outline-danger metric-fields__remove', data: { action: 'click->nested-form#remove' }, aria: { label: 'Remove metric' }
+      i.fas.fa-trash-alt

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -1,15 +1,16 @@
 = simple_form_for [@workout, @log], wrapper: :input_group do |f|
   = f.error_notification
-  .row.mt-3
+  .row.mt-3.g-2
     .col
       h1
         = @workout.name
         | &nbsp;
         = link_to workout_path(@workout)
           i.fas.fa-external-link-alt
-  .row.col
-    p = workout_objective @workout
   .row
+    .col
+      p = workout_objective @workout
+  .row.g-2
     = f.input :score_type, as: :hidden
     - if @workout.set_based_lifting?
       .col
@@ -21,7 +22,7 @@
     .card.mb-3
       .card-body
         = ml_form.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select' } }, label: false
-        .row
+        .row.g-2
           .col#metrics data-controller="nested-form" data-nested-form-placeholder-value="NEW_METRIC"
             .fields data-nested-form-target="container"
               = ml_form.simple_fields_for :metrics do |metric_form|
@@ -29,7 +30,7 @@
             template data-nested-form-target="template"
               = ml_form.simple_fields_for :metrics, Metric.new, child_index: 'NEW_METRIC' do |metric_form|
                 = render 'metric_fields', f: metric_form
-            .links.d-grid
+            .links.d-grid.gap-2
               = link_to 'Add Metric', '#', class: 'btn btn-sm btn-outline-primary', data: { action: 'click->nested-form#add' }
   .form-actions.d-grid
     = f.button :submit, 'Save', class: 'btn btn-primary'

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -4,9 +4,9 @@
 .exercise.nested-fields.card.mb-3 data-controller="exercise-form" data-action="change->exercise-form#toggleDistanceUnits nested-form:add->exercise-form#toggleDistanceUnits nested-form:remove->exercise-form#toggleDistanceUnits" data-exercise-form-distance-measurements-value=Metric::DISTANCE_MEASUREMENTS.to_json
   = f.hidden_field :_destroy
   .card-body
-    .row
-      .col = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select' } }
-      .col-4.col-md-2 = f.input :position
+    .row.g-2
+      .col-12.col-md = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select' } }
+      .col-6.col-md-2 = f.input :position
       .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
         = f.input :distance_units_per_rep, label: 'Distance units per rep'
     .row
@@ -17,7 +17,7 @@
         template data-nested-form-target="template"
           = f.simple_fields_for :metrics, Metric.new, child_index: 'NEW_METRIC' do |metric_form|
             = render 'metric_fields', f: metric_form, sex_specific: true
-        .links.d-grid
+        .links.d-grid.gap-2
           = link_to 'Add Metric', '#', class: 'btn btn-sm btn-outline-primary', data: { action: 'click->nested-form#add' }
     .row
       .col.d-grid

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -1,6 +1,6 @@
 = simple_form_for @workout, wrapper: :vertical_form do |f|
   = f.error_notification
-  .form-inputs.row
+  .form-inputs.row.g-2
     .col-12 = f.input :name, input_html: { value: f.object.name || generate_workout_name }
     .col-sm-4 = f.input :rounds
     .col-sm-4 = f.input :time, as: :group, append: 'minutes'
@@ -27,7 +27,7 @@
     template data-nested-form-template="segment" data-placeholder-value="NEW_SEGMENT"
       = f.simple_fields_for :segments, Segment.new, child_index: 'NEW_SEGMENT' do |segment_form|
         = render 'segment_fields', f: segment_form
-    .links.d-grid
+    .links.d-grid.gap-2
       = link_to 'Add Exercise', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' }
       = link_to 'Add Segment', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' }
   hr

--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -1,15 +1,15 @@
 .nested-fields.card.mb-3
   = f.hidden_field :_destroy
   .card-body
-    .form-row
-      .col = f.input :name
-      .col = f.input :rounds
-      .col = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200'
-      .col = f.input :interval_scheme, placeholder: '21-15-9...'
-      .col-4.col-md-2 = f.input :position
-    .form-row
-      .col = f.input :rest_seconds
-      .col = f.input :notes
+    .row.g-2
+      .col-12.col-lg-4 = f.input :name
+      .col-6.col-md-3.col-lg-2 = f.input :rounds
+      .col-6.col-md-3.col-lg-2 = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200'
+      .col-12.col-md-6.col-lg-3 = f.input :interval_scheme, placeholder: '21-15-9...'
+      .col-6.col-md-3.col-lg-1 = f.input :position
+    .row.g-2
+      .col-12.col-md-4 = f.input :rest_seconds
+      .col-12.col-md-8 = f.input :notes
     .row
       .col#segmented_exercises data-controller="nested-form" data-nested-form-placeholder-value="CHILD_EXERCISE" data-nested-form-position-exercises-value="true"
         .fields data-nested-form-target="container"
@@ -18,7 +18,7 @@
         template data-nested-form-target="template"
           = f.simple_fields_for :exercises, Exercise.new, child_index: 'CHILD_EXERCISE' do |exercise_form|
             = render 'exercise_fields', f: exercise_form
-        .links.d-grid
+        .links.d-grid.gap-2
           = link_to 'Add Exercise', '#', class: 'btn btn-sm btn-outline-primary', data: { action: 'click->nested-form#add' }
     .row
       .col.d-grid


### PR DESCRIPTION
## Summary
- make dense workout and log form fields stack cleanly on mobile
- replace legacy segment form rows with Bootstrap 5 responsive rows
- improve metric row layout and touch target sizing while preserving existing Stimulus behavior

## Validation
- yarn build
- yarn build:css
- rvm 3.4.9@wod-tracker do bundle exec rails test
- rvm 3.4.9@wod-tracker do bundle exec rails test test/system/workout_workflows_test.rb test/system/workout_segment_positions_test.rb test/system/sex_specific_workout_values_test.rb
- git diff --check

Note: CSS build still emits existing Sass/Bootstrap deprecation warnings.