### PR TITLE
Read exercise prescriptions from columns (metric fallback) (#1651)

### DIFF
--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -4,7 +4,7 @@ module MeasurableHelper
   end
 
   def measurable_movement_msg(measurable)
-    rep_metric = measurable.metrics.find_by(measurement: :rep)
+    rep_metric = measurable.prescription_metrics.find(&:rep?)
     duration_metric = duration_metric(measurable)
     return duration_movement_msg(measurable, rep_metric, duration_metric) if duration_metric
 
@@ -20,7 +20,7 @@ module MeasurableHelper
   end
 
   def measurable_reps_msg(measurable)
-    rep_metric = measurable.metrics.find_by(measurement: :rep)
+    rep_metric = measurable.prescription_metrics.find(&:rep?)
     metric_unit_msg(rep_metric)
   end
 
@@ -35,7 +35,7 @@ module MeasurableHelper
   def additional_metrics(measurable)
     leading_work_metric = leading_work_metric(measurable)
 
-    measurable.metrics.where.not(measurement: :rep)
+    measurable.prescription_metrics.reject(&:rep?)
               .reject { |metric| metric == leading_work_metric }
               .reject { |metric| duration_metric?(metric) }
               .select { |metric| visible_metric?(metric) }
@@ -49,7 +49,7 @@ module MeasurableHelper
   def visible_metric?(metric) = metric.value.present? || metric.sex_specific?
 
   def duration_metric(measurable)
-    measurable.metrics.find { |metric| duration_metric?(metric) && metric.value.present? }
+    measurable.prescription_metrics.find { |metric| duration_metric?(metric) && metric.value.present? }
   end
 
   def duration_metric?(metric) = metric.seconds? || metric.time?
@@ -109,8 +109,9 @@ module MeasurableHelper
   def leading_work_metric(measurable)
     return unless measurable.is_a?(Exercise)
 
-    candidate = measurable.metrics.find { |metric| leading_work_candidate?(metric) }
-    candidate if leading_work_metric_stands_alone?(candidate, measurable.metrics)
+    metrics = measurable.prescription_metrics
+    candidate = metrics.find { |metric| leading_work_candidate?(metric) }
+    candidate if leading_work_metric_stands_alone?(candidate, metrics)
   end
 
   def leading_work_candidate?(metric) = visible_metric?(metric) && leading_work_metric?(metric)

--- a/app/models/concerns/exercise_prescription.rb
+++ b/app/models/concerns/exercise_prescription.rb
@@ -1,0 +1,74 @@
+module ExercisePrescription
+  extend ActiveSupport::Concern
+
+  # Columns that indicate an exercise carries its prescription directly (not via legacy metrics).
+  DIRECT_PRESCRIPTION_COLUMNS = %i[
+    reps duration_seconds
+    load female_load male_load load_unit
+    distance female_distance male_distance distance_unit
+    calories female_calories male_calories
+  ].freeze
+
+  included do
+    enum :load_unit, { lb: 0, kg: 1 }, prefix: :load_unit
+    enum :distance_unit, { meter: 0, foot: 1, inch: 2 }, prefix: :distance_unit
+  end
+
+  # Canonical prescription, preferring the direct columns and falling back to legacy metric rows
+  # while both exist (legacy metrics are removed in a later phase). Rendering, scoring, and log
+  # recording all read this, so column-backed and metric-backed exercises behave identically.
+  # Memoized so the helper's object-identity comparisons see the same column-built instances.
+  def prescription_metrics
+    @prescription_metrics ||= build_prescription_metrics
+  end
+
+  def uses_direct_prescriptions?
+    DIRECT_PRESCRIPTION_COLUMNS.any? { |column| self[column].present? }
+  end
+
+  private
+
+  def build_prescription_metrics
+    return metrics.to_a unless uses_direct_prescriptions?
+
+    [
+      rep_prescription_metric,
+      duration_prescription_metric,
+      load_prescription_metric,
+      distance_prescription_metric,
+      calorie_prescription_metric
+    ].compact
+  end
+
+  def rep_prescription_metric
+    return if reps.nil?
+
+    Metric.new(measurement: :rep, value: reps.zero? ? nil : reps) # 0 is the "max reps" sentinel
+  end
+
+  def duration_prescription_metric
+    return if duration_seconds.blank?
+
+    Metric.new(measurement: :seconds, value: duration_seconds)
+  end
+
+  def load_prescription_metric
+    return unless load_unit.present? || load.present? || female_load.present? || male_load.present?
+
+    Metric.new(measurement: load_unit || :lb, value: load, female_value: female_load, male_value: male_load)
+  end
+
+  def distance_prescription_metric
+    return unless distance_unit.present? || distance.present? || female_distance.present? || male_distance.present?
+
+    Metric.new(measurement: distance_unit || :distance, value: distance,
+               female_value: female_distance, male_value: male_distance)
+  end
+
+  def calorie_prescription_metric
+    return unless calories.present? || female_calories.present? || male_calories.present?
+
+    Metric.new(measurement: :calorie, value: (calories&.zero? ? nil : calories), # 0 is "max calories"
+               female_value: female_calories, male_value: male_calories)
+  end
+end

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -83,7 +83,7 @@ module WorkoutScoring
   end
 
   def completed_prescribed_reps?(exercise, movement_log)
-    prescribed_reps = exercise.metrics.find(&:rep?)&.value
+    prescribed_reps = exercise.prescription_metrics.find(&:rep?)&.value
     completed_reps = movement_log.metrics.find(&:rep?)&.value
 
     prescribed_reps.present? && completed_reps.present? && completed_reps >= prescribed_reps

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,5 +1,8 @@
 class Exercise < ApplicationRecord
   include ExercisePositionValidation
+  include ExercisePrescription
+
+  SEX_PAIRED_DIMENSIONS = %i[load distance calories].freeze
 
   belongs_to :workout
   belongs_to :movement
@@ -10,9 +13,15 @@ class Exercise < ApplicationRecord
 
   accepts_nested_attributes_for :metrics, allow_destroy: true
 
+  validates :reps, :calories,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :duration_seconds, :load, :female_load, :male_load,
+            :distance, :female_distance, :male_distance, :female_calories, :male_calories,
+            numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :distance_units_per_rep,
             numericality: { only_integer: true, greater_than: 0 },
             allow_nil: true
+  validate :prescription_values_are_unambiguous
   validate :distance_units_per_rep_matches_prescribed_distance
 
   def score_component
@@ -28,7 +37,7 @@ class Exercise < ApplicationRecord
   end
 
   def load_bearing?
-    metrics.any? { |metric| Metric::LOAD_MEASUREMENTS.include?(metric.measurement) }
+    prescription_metrics.any? { |metric| Metric::LOAD_MEASUREMENTS.include?(metric.measurement) }
   end
 
   private
@@ -55,15 +64,29 @@ class Exercise < ApplicationRecord
   end
 
   def metric_for(measurement)
-    metrics.find { |metric| metric.measurement == measurement.to_s }
+    prescription_metrics.find { |metric| metric.measurement == measurement.to_s }
   end
 
   def distance_metric
-    metrics.find { |metric| Metric::DISTANCE_MEASUREMENTS.include?(metric.measurement) }
+    prescription_metrics.find { |metric| Metric::DISTANCE_MEASUREMENTS.include?(metric.measurement) }
   end
 
   def scorable_metric?(metric)
     metric&.value.present? && metric.value.positive?
+  end
+
+  def prescription_values_are_unambiguous
+    SEX_PAIRED_DIMENSIONS.each do |dimension|
+      value = self[dimension]
+      female = self[:"female_#{dimension}"]
+      male = self[:"male_#{dimension}"]
+
+      if value.present? && (female.present? || male.present?)
+        errors.add(dimension, 'cannot be set with sex-specific values')
+      elsif female.blank? != male.blank?
+        errors.add(:base, "#{dimension} requires both female and male values")
+      end
+    end
   end
 
   def distance_units_per_rep_matches_prescribed_distance

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -55,7 +55,7 @@ class Log < ApplicationRecord
   end
 
   def metrics_for_movement_log(exercise)
-    metrics = exercise.metrics
+    metrics = exercise.prescription_metrics
     return ordered_recording_metrics(metrics) unless workout.rep_scored_amrap?
 
     component = exercise.score_component

--- a/app/models/movement_log.rb
+++ b/app/models/movement_log.rb
@@ -6,4 +6,10 @@ class MovementLog < ApplicationRecord
   default_scope { includes(:metrics) }
 
   accepts_nested_attributes_for :metrics, allow_destroy: true
+
+  # Movement logs record actual performance as metrics; they share the prescription-rendering
+  # helpers with Exercise, which read this collection.
+  def prescription_metrics
+    metrics.to_a
+  end
 end

--- a/test/helpers/measurable_helper_columns_test.rb
+++ b/test/helpers/measurable_helper_columns_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+# measurable_message rendered from the direct prescription columns (the #1651 read path).
+# The metric-backed equivalents live in measurable_helper_test.rb and exercise the fallback.
+class MeasurableHelperColumnsTest < ActionView::TestCase
+  include MeasurableHelper
+  include MetricsHelper
+
+  test 'renders a sex-specific box jump from columns with the length parenthesized' do
+    box_jump = Movement.create!(name: 'Box Jump')
+    exercise = workouts(:fran).exercises.build(movement: box_jump, position: 3,
+                                               reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+
+    assert_equal '30 Box Jumps (♀20-inch / ♂24-inch)', measurable_message(exercise)
+  end
+
+  test 'groups load and target height from columns by sex' do
+    wall_ball = Movement.create!(name: 'Wall-ball Shot')
+    exercise = workouts(:fran).exercises.build(movement: wall_ball, position: 3,
+                                               reps: 0, duration_seconds: 60,
+                                               female_load: 14, male_load: 20, load_unit: :lb,
+                                               female_distance: 9, male_distance: 10, distance_unit: :foot)
+
+    assert_equal '1:00 Wall-ball Shots (♀14lb + 9ft / ♂20lb + 10ft)', measurable_message(exercise)
+  end
+
+  test 'renders a leading distance from columns before the movement' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:run), position: 3,
+                                               reps: 1, distance: 1600, distance_unit: :meter)
+
+    assert_equal '1600 meter Run', measurable_message(exercise)
+  end
+
+  test 'renders the max-reps sentinel from columns' do
+    toes_to_bar = Movement.create!(name: 'Toes to Bar')
+    exercise = workouts(:fran).exercises.build(movement: toes_to_bar, position: 3, reps: 0)
+
+    assert_equal 'max reps Toes to Bar', measurable_message(exercise)
+  end
+
+  test 'prefers direct columns over legacy metrics when both are present' do
+    exercise = exercises(:fran_pullup) # carries a rep metric in fixtures
+    exercise.assign_attributes(reps: 5)
+
+    assert_equal '5 Pull Ups', measurable_message(exercise)
+  end
+end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -83,4 +83,56 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_not exercise.valid?
     assert_includes exercise.errors[:distance_units_per_rep], 'requires a distance metric'
   end
+
+  # --- direct-column prescriptions (the #1651 read path) ---
+
+  test 'load_bearing? reads the load unit column' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, load_unit: :lb)
+
+    assert_predicate exercise, :load_bearing?
+  end
+
+  test 'score_component reads the rep prescription from columns' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, reps: 21)
+
+    assert_equal 21, exercise.score_component[:score_reps]
+  end
+
+  test 'score_component reads the calorie prescription from columns' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:row), position: 3, reps: 1, calories: 20)
+
+    assert_equal 'calorie', exercise.score_component[:measurement]
+    assert_equal 20, exercise.score_component[:score_reps]
+  end
+
+  test 'treats the reps zero sentinel as max and not scorable' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, reps: 0)
+
+    assert_nil exercise.score_component
+  end
+
+  test 'rejects a unisex value combined with sex-specific values' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               load: 50, female_load: 65, male_load: 95, load_unit: :lb)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:load], 'cannot be set with sex-specific values'
+  end
+
+  test 'requires both sex-specific values when only one is present' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               female_load: 65, load_unit: :lb)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:base], 'load requires both female and male values'
+  end
+
+  test 'validates distance units per rep against the column distance' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:run), position: 3,
+                                               reps: 1, distance: 400, distance_unit: :meter,
+                                               distance_units_per_rep: 30)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:distance_units_per_rep], 'must divide the prescribed distance evenly'
+  end
 end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -58,6 +58,20 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 100, hspu_log.metrics.find(&:rep?).value
   end
 
+  test 'builds movement logs from direct column prescriptions' do
+    workout = Workout.new(rounds: 1, score_type: :time)
+    workout.exercises.build(movement: movements(:back_squat), position: 1,
+                            reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+
+    log = workout.logs.build(user: users(:mathew), score_type: :time, score_value: 180)
+    log.build_movement_logs
+
+    movement_log = log.movement_logs.first
+
+    assert_equal 21, movement_log.metrics.find(&:rep?).value
+    assert_equal 95, movement_log.metrics.find(&:lb?).value
+  end
+
   test 'calculates set-based lifting score from heaviest successful set' do
     log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs


### PR DESCRIPTION
Closes #1651. Phase 3 of the data-preserving schema redesign (#1624), **sub-issue B of 3** (data → reads → writes).

> **Stacked on #1653** (#1650). Base is `move-exercise-prescriptions-1650`; review/merge that first. Rebase onto `master` once it lands.

## What this does

Makes every reader prefer the direct prescription columns (added in #1650) and fall back to legacy `metrics` rows while both exist. Behavior-preserving: column-backed and metric-backed exercises render, score, and log identically. **Writes still go through `metrics`** (switched in #1652).

### `ExercisePrescription` concern
New `prescription_metrics` is the single source readers consume:
- When an exercise has direct columns (`uses_direct_prescriptions?`), it builds the prescription from them — `reps`/`calories == 0` → the open-ended "max" sentinel, the single `distance` length dimension covering target heights (foot/inch).
- Otherwise it falls back to the exercise's `metrics`. This is the record-level fallback that mirrors the existing `score_type || metric&.measurement` pattern, so a column-only exercise (created later) and a legacy metric-only exercise both work.
- Declares the `load_unit` / `distance_unit` enums.

### Readers converted
- **Rendering** (`measurable_helper`) reads `prescription_metrics` instead of the `metrics` association; `MovementLog#prescription_metrics` returns its own metrics, so the shared helper is unchanged in behavior.
- **Scoring** (`Exercise#score_component`, `#load_bearing?`, `WorkoutScoring#completed_prescribed_reps?`) reads it too — unisex values only; the `0` sentinel is treated as "max" (not scorable), exactly like the old blank metric.
- **Movement-log building** (`Log#metrics_for_movement_log`) iterates it while still **building movement_log metrics** (those stay until #1625).

### Validations
Unisex-vs-paired-sex over `load`/`distance`/`calories` (port of `Metric#values_are_unambiguous`), plus numericality with `reps`/`calories >= 0` (admitting the `0` sentinel).

## Verification — golden display parity
Captured `measurable_message` for all 123 seeded exercises before the change (metric readers), then after (column readers). **The only diff is the 4 bodyweight `weight` artifacts** (Linda ×3, Lynne ×1) — e.g. `Deadlift (1 weight)` → `Deadlift (1 lb)`, `max reps Bench Press (0 weights)` → `max reps Bench Press`. These become clean when seeds move bodyweight loads to `notes` in #1652. Every other line is byte-identical.

## Tests
- New column-path rendering tests incl. the **sex-specific box jump** parenthetical: `30 Box Jumps (♀20-inch / ♂24-inch)`, the wall-ball grouping, leading distance, the max-reps sentinel, and columns-over-metrics precedence.
- Column-path `score_component` / `load_bearing?` / validation / `0`-sentinel tests; existing metric-based tests now cover the fallback path.
- Column-mode movement-log build test.
- Full non-system suite: **128 runs, 346 assertions, 0 failures**. Rubocop clean.

## Out of scope
Writes/forms/**seeds** (#1652), dropping `metrics` (#1626), MovementLog performance (#1625).

🤖 Generated with [Claude Code](https://claude.com/claude-code)