### PR TITLE
Switch exercise prescription writes to columns (#1652) — re-lands #1651

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -67,9 +67,11 @@ class WorkoutsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def workout_params
-    metric_params = %i[id measurement value female_value male_value _destroy]
-    exercise_params = [:id, :reps, :movement_id, :position, :distance_units_per_rep, :_destroy,
-                       { metrics_attributes: [metric_params] }]
+    exercise_params = [:id, :movement_id, :position, :distance_units_per_rep, :_destroy,
+                       :reps, :duration_seconds,
+                       :load, :female_load, :male_load, :load_unit,
+                       :distance, :female_distance, :male_distance, :distance_unit,
+                       :calories, :female_calories, :male_calories, :notes]
 
     params.expect(workout: [:name, :rounds, :time, :interval, :notes, :time_cap,
                             :score_type,

--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -4,7 +4,7 @@ module MeasurableHelper
   end
 
   def measurable_movement_msg(measurable)
-    rep_metric = measurable.metrics.find_by(measurement: :rep)
+    rep_metric = measurable.prescription_metrics.find(&:rep?)
     duration_metric = duration_metric(measurable)
     return duration_movement_msg(measurable, rep_metric, duration_metric) if duration_metric
 
@@ -20,7 +20,7 @@ module MeasurableHelper
   end
 
   def measurable_reps_msg(measurable)
-    rep_metric = measurable.metrics.find_by(measurement: :rep)
+    rep_metric = measurable.prescription_metrics.find(&:rep?)
     metric_unit_msg(rep_metric)
   end
 
@@ -35,7 +35,7 @@ module MeasurableHelper
   def additional_metrics(measurable)
     leading_work_metric = leading_work_metric(measurable)
 
-    measurable.metrics.where.not(measurement: :rep)
+    measurable.prescription_metrics.reject(&:rep?)
               .reject { |metric| metric == leading_work_metric }
               .reject { |metric| duration_metric?(metric) }
               .select { |metric| visible_metric?(metric) }
@@ -49,7 +49,7 @@ module MeasurableHelper
   def visible_metric?(metric) = metric.value.present? || metric.sex_specific?
 
   def duration_metric(measurable)
-    measurable.metrics.find { |metric| duration_metric?(metric) && metric.value.present? }
+    measurable.prescription_metrics.find { |metric| duration_metric?(metric) && metric.value.present? }
   end
 
   def duration_metric?(metric) = metric.seconds? || metric.time?
@@ -109,8 +109,9 @@ module MeasurableHelper
   def leading_work_metric(measurable)
     return unless measurable.is_a?(Exercise)
 
-    candidate = measurable.metrics.find { |metric| leading_work_candidate?(metric) }
-    candidate if leading_work_metric_stands_alone?(candidate, measurable.metrics)
+    metrics = measurable.prescription_metrics
+    candidate = metrics.find { |metric| leading_work_candidate?(metric) }
+    candidate if leading_work_metric_stands_alone?(candidate, metrics)
   end
 
   def leading_work_candidate?(metric) = visible_metric?(metric) && leading_work_metric?(metric)

--- a/app/javascript/controllers/exercise_form_controller.js
+++ b/app/javascript/controllers/exercise_form_controller.js
@@ -1,31 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["distanceUnits"]
-  static values = {
-    distanceMeasurements: Array
-  }
+  static targets = ["distanceUnits", "distanceValue", "distanceUnitSelect"]
 
   connect() {
     this.toggleDistanceUnits()
   }
 
   toggleDistanceUnits(event) {
-    const usesDistanceMetric = this.metricSelects.some((select) => {
-      const fields = select.closest(".nested-fields")
+    const hasDistance =
+      this.distanceValueTargets.some((input) => input.value.trim() !== "") ||
+      (this.hasDistanceUnitSelectTarget && this.distanceUnitSelectTarget.value !== "")
 
-      return !fields?.hidden && this.distanceMeasurementsValue.includes(select.value)
-    })
+    this.distanceUnitsTarget.hidden = !hasDistance
 
-    this.distanceUnitsTarget.hidden = !usesDistanceMetric
-
-    if (!usesDistanceMetric && event) {
+    if (!hasDistance && event) {
       this.distanceUnitsInput.value = ""
     }
-  }
-
-  get metricSelects() {
-    return Array.from(this.element.querySelectorAll("select.metric"))
   }
 
   get distanceUnitsInput() {

--- a/app/models/concerns/exercise_prescription.rb
+++ b/app/models/concerns/exercise_prescription.rb
@@ -1,0 +1,74 @@
+module ExercisePrescription
+  extend ActiveSupport::Concern
+
+  # Columns that indicate an exercise carries its prescription directly (not via legacy metrics).
+  DIRECT_PRESCRIPTION_COLUMNS = %i[
+    reps duration_seconds
+    load female_load male_load load_unit
+    distance female_distance male_distance distance_unit
+    calories female_calories male_calories
+  ].freeze
+
+  included do
+    enum :load_unit, { lb: 0, kg: 1 }, prefix: :load_unit
+    enum :distance_unit, { meter: 0, foot: 1, inch: 2 }, prefix: :distance_unit
+  end
+
+  # Canonical prescription, preferring the direct columns and falling back to legacy metric rows
+  # while both exist (legacy metrics are removed in a later phase). Rendering, scoring, and log
+  # recording all read this, so column-backed and metric-backed exercises behave identically.
+  # Memoized so the helper's object-identity comparisons see the same column-built instances.
+  def prescription_metrics
+    @prescription_metrics ||= build_prescription_metrics
+  end
+
+  def uses_direct_prescriptions?
+    DIRECT_PRESCRIPTION_COLUMNS.any? { |column| self[column].present? }
+  end
+
+  private
+
+  def build_prescription_metrics
+    return metrics.to_a unless uses_direct_prescriptions?
+
+    [
+      rep_prescription_metric,
+      duration_prescription_metric,
+      load_prescription_metric,
+      distance_prescription_metric,
+      calorie_prescription_metric
+    ].compact
+  end
+
+  def rep_prescription_metric
+    return if reps.nil?
+
+    Metric.new(measurement: :rep, value: reps.zero? ? nil : reps) # 0 is the "max reps" sentinel
+  end
+
+  def duration_prescription_metric
+    return if duration_seconds.blank?
+
+    Metric.new(measurement: :seconds, value: duration_seconds)
+  end
+
+  def load_prescription_metric
+    return unless load_unit.present? || load.present? || female_load.present? || male_load.present?
+
+    Metric.new(measurement: load_unit || :lb, value: load, female_value: female_load, male_value: male_load)
+  end
+
+  def distance_prescription_metric
+    return unless distance_unit.present? || distance.present? || female_distance.present? || male_distance.present?
+
+    Metric.new(measurement: distance_unit || :distance, value: distance,
+               female_value: female_distance, male_value: male_distance)
+  end
+
+  def calorie_prescription_metric
+    return unless calories.present? || female_calories.present? || male_calories.present?
+
+    Metric.new(measurement: :calorie, value: (calories&.zero? ? nil : calories), # 0 is "max calories"
+               female_value: female_calories, male_value: male_calories)
+  end
+end

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -83,7 +83,7 @@ module WorkoutScoring
   end
 
   def completed_prescribed_reps?(exercise, movement_log)
-    prescribed_reps = exercise.metrics.find(&:rep?)&.value
+    prescribed_reps = exercise.prescription_metrics.find(&:rep?)&.value
     completed_reps = movement_log.metrics.find(&:rep?)&.value
 
     prescribed_reps.present? && completed_reps.present? && completed_reps >= prescribed_reps

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -11,8 +11,6 @@ class Exercise < ApplicationRecord
 
   default_scope { order(:position).includes(:metrics) }
 
-  accepts_nested_attributes_for :metrics, allow_destroy: true
-
   validates :reps, :calories,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :duration_seconds, :load, :female_load, :male_load,

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,5 +1,8 @@
 class Exercise < ApplicationRecord
   include ExercisePositionValidation
+  include ExercisePrescription
+
+  SEX_PAIRED_DIMENSIONS = %i[load distance calories].freeze
 
   belongs_to :workout
   belongs_to :movement
@@ -10,9 +13,15 @@ class Exercise < ApplicationRecord
 
   accepts_nested_attributes_for :metrics, allow_destroy: true
 
+  validates :reps, :calories,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :duration_seconds, :load, :female_load, :male_load,
+            :distance, :female_distance, :male_distance, :female_calories, :male_calories,
+            numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :distance_units_per_rep,
             numericality: { only_integer: true, greater_than: 0 },
             allow_nil: true
+  validate :prescription_values_are_unambiguous
   validate :distance_units_per_rep_matches_prescribed_distance
 
   def score_component
@@ -28,7 +37,7 @@ class Exercise < ApplicationRecord
   end
 
   def load_bearing?
-    metrics.any? { |metric| Metric::LOAD_MEASUREMENTS.include?(metric.measurement) }
+    prescription_metrics.any? { |metric| Metric::LOAD_MEASUREMENTS.include?(metric.measurement) }
   end
 
   private
@@ -55,15 +64,29 @@ class Exercise < ApplicationRecord
   end
 
   def metric_for(measurement)
-    metrics.find { |metric| metric.measurement == measurement.to_s }
+    prescription_metrics.find { |metric| metric.measurement == measurement.to_s }
   end
 
   def distance_metric
-    metrics.find { |metric| Metric::DISTANCE_MEASUREMENTS.include?(metric.measurement) }
+    prescription_metrics.find { |metric| Metric::DISTANCE_MEASUREMENTS.include?(metric.measurement) }
   end
 
   def scorable_metric?(metric)
     metric&.value.present? && metric.value.positive?
+  end
+
+  def prescription_values_are_unambiguous
+    SEX_PAIRED_DIMENSIONS.each do |dimension|
+      value = self[dimension]
+      female = self[:"female_#{dimension}"]
+      male = self[:"male_#{dimension}"]
+
+      if value.present? && (female.present? || male.present?)
+        errors.add(dimension, 'cannot be set with sex-specific values')
+      elsif female.blank? != male.blank?
+        errors.add(:base, "#{dimension} requires both female and male values")
+      end
+    end
   end
 
   def distance_units_per_rep_matches_prescribed_distance

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -55,7 +55,7 @@ class Log < ApplicationRecord
   end
 
   def metrics_for_movement_log(exercise)
-    metrics = exercise.metrics
+    metrics = exercise.prescription_metrics
     return ordered_recording_metrics(metrics) unless workout.rep_scored_amrap?
 
     component = exercise.score_component

--- a/app/models/movement_log.rb
+++ b/app/models/movement_log.rb
@@ -6,4 +6,10 @@ class MovementLog < ApplicationRecord
   default_scope { includes(:metrics) }
 
   accepts_nested_attributes_for :metrics, allow_destroy: true
+
+  # Movement logs record actual performance as metrics; they share the prescription-rendering
+  # helpers with Exercise, which read this collection.
+  def prescription_metrics
+    metrics.to_a
+  end
 end

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -1,24 +1,33 @@
-- distance_metric = f.object.metrics.reject(&:marked_for_destruction?).any? { |metric| Metric::DISTANCE_MEASUREMENTS.include?(metric.measurement) }
-- distance_units_hidden = f.object.distance_units_per_rep.blank? && !distance_metric
+- has_distance = f.object.distance.present? || f.object.female_distance.present? || f.object.male_distance.present? || f.object.distance_unit.present?
+- distance_units_hidden = f.object.distance_units_per_rep.blank? && !has_distance
 
-.exercise.nested-fields.card.mb-3 data-controller="exercise-form" data-action="change->exercise-form#toggleDistanceUnits nested-form:add->exercise-form#toggleDistanceUnits nested-form:remove->exercise-form#toggleDistanceUnits" data-exercise-form-distance-measurements-value=Metric::DISTANCE_MEASUREMENTS.to_json
+.exercise.nested-fields.card.mb-3 data-controller="exercise-form" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits"
   = f.hidden_field :_destroy
   .card-body
     .row.g-2
       .col-12.col-md = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select' } }
       .col-6.col-md-2 = f.input :position
+    .row.g-2
+      .col-6.col-md-3 = f.input :reps, hint: '0 = max reps'
+      .col-6.col-md-3 = f.input :duration_seconds, label: 'Duration (s)'
+    .row.g-2
+      .col-6.col-md-3 = f.input :load
+      .col-6.col-md-3 = f.input :female_load
+      .col-6.col-md-3 = f.input :male_load
+      .col-6.col-md-3 = f.input :load_unit, collection: Exercise.load_units.keys, prompt: 'Load unit'
+    .row.g-2
+      .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue' } }
+      .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue' } }
+      .col-6.col-md-3 = f.input :male_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue' } }
+      .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect' } }
+    .row.g-2
+      .col-6.col-md-3 = f.input :calories, hint: '0 = max calories'
+      .col-6.col-md-3 = f.input :female_calories
+      .col-6.col-md-3 = f.input :male_calories
       .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
         = f.input :distance_units_per_rep, label: 'Distance units per rep'
+    .row.g-2
+      .col = f.input :notes
     .row
-      .col#metrics data-controller="nested-form" data-nested-form-placeholder-value="NEW_METRIC"
-        .fields data-nested-form-target="container"
-          = f.simple_fields_for :metrics do |metric_form|
-            = render 'metric_fields', f: metric_form, sex_specific: true
-        template data-nested-form-target="template"
-          = f.simple_fields_for :metrics, Metric.new, child_index: 'NEW_METRIC' do |metric_form|
-            = render 'metric_fields', f: metric_form, sex_specific: true
-        .links.d-grid.gap-2
-          = link_to 'Add Metric', '#', class: 'btn btn-sm btn-outline-primary', data: { action: 'click->nested-form#add' }
-    .row
-      .col.d-grid
+      .col.d-grid.gap-2
         = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger mt-2', data: { action: 'click->nested-form#remove' }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -185,36 +185,12 @@ fight_gone_bad = Workout.find_or_create_by(name: 'Fight Gone Bad') do |workout|
           ' The clock does not reset or stop between exercises.'\
           ' On the call of "rotate," the athlete(s) must move to the next station immediately for a good score.'\
           ' One point is given for each rep, except on the rower where each calorie is 1 point.'
-  workout.exercises.build(movement: wallball, position: 1) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :seconds, value: 60)
-    e.metrics.build(measurement: :lb, female_value: 14, male_value: 20)
-    e.metrics.build(measurement: :foot, female_value: 9, male_value: 10)
-  end
-  workout.exercises.build(movement: sumo_deadlift_hight_pull, position: 2) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :seconds, value: 60)
-    e.metrics.build(measurement: :lb, female_value: 55, male_value: 75)
-  end
-  workout.exercises.build(movement: box_jump, position: 3) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :seconds, value: 60)
-    e.metrics.build(measurement: :inch, value: 20)
-  end
-  workout.exercises.build(movement: push_press, position: 4) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :seconds, value: 60)
-    e.metrics.build(measurement: :lb, female_value: 55, male_value: 75)
-  end
-  workout.exercises.build(movement: row, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :calorie)
-    e.metrics.build(measurement: :seconds, value: 60)
-  end
-  workout.exercises.build(movement: rest, position: 6) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :seconds, value: 60)
-  end
+  workout.exercises.build(movement: wallball, position: 1, reps: 0, duration_seconds: 60, female_load: 14, male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10, distance_unit: :foot)
+  workout.exercises.build(movement: sumo_deadlift_hight_pull, position: 2, reps: 0, duration_seconds: 60, female_load: 55, male_load: 75, load_unit: :lb)
+  workout.exercises.build(movement: box_jump, position: 3, reps: 0, duration_seconds: 60, distance: 20, distance_unit: :inch)
+  workout.exercises.build(movement: push_press, position: 4, reps: 0, duration_seconds: 60, female_load: 55, male_load: 75, load_unit: :lb)
+  workout.exercises.build(movement: row, position: 5, reps: 1, calories: 0, duration_seconds: 60)
+  workout.exercises.build(movement: rest, position: 6, reps: 1, duration_seconds: 60)
 end
 
 cfj.schedules.find_or_initialize_by(workout: fight_gone_bad).update(posted_at: '01-02-2018')
@@ -230,18 +206,10 @@ cfj.schedules.find_or_initialize_by(workout: fight_gone_bad).update(posted_at: '
 # 100 squats
 angie = Workout.find_or_create_by(name: 'Angie') do |workout|
   workout.score_type = :time
-  workout.exercises.build(movement: pullup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 100)
-  end
-  workout.exercises.build(movement: pushup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 100)
-  end
-  workout.exercises.build(movement: situp, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 100)
-  end
-  workout.exercises.build(movement: airsquat, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 100)
-  end
+  workout.exercises.build(movement: pullup, position: 1, reps: 100)
+  workout.exercises.build(movement: pushup, position: 2, reps: 100)
+  workout.exercises.build(movement: situp, position: 3, reps: 100)
+  workout.exercises.build(movement: airsquat, position: 4, reps: 100)
 end
 
 cfj.schedules.find_or_initialize_by(workout: angie).update(posted_at: '30-01-2018')
@@ -257,22 +225,11 @@ cfj.schedules.find_or_initialize_by(workout: angie).update(posted_at: '30-01-201
 barbara = Workout.find_or_create_by(name: 'Barbara') do |workout|
   workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: pullup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 20)
-  end
-  workout.exercises.build(movement: pushup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-  end
-  workout.exercises.build(movement: situp, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 40)
-  end
-  workout.exercises.build(movement: airsquat, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-  end
-  workout.exercises.build(movement: rest, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :seconds, value: 180)
-  end
+  workout.exercises.build(movement: pullup, position: 1, reps: 20)
+  workout.exercises.build(movement: pushup, position: 2, reps: 30)
+  workout.exercises.build(movement: situp, position: 3, reps: 40)
+  workout.exercises.build(movement: airsquat, position: 4, reps: 50)
+  workout.exercises.build(movement: rest, position: 5, reps: 1, duration_seconds: 180)
 end
 
 cfj.schedules.find_or_initialize_by(workout: barbara).update(posted_at: '29-01-2018')
@@ -287,15 +244,9 @@ chelsea = Workout.find_or_create_by(name: 'Chelsea') do |workout|
   workout.rounds = 30
   workout.time = 30
   workout.score_type = :rep
-  workout.exercises.build(movement: pullup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 5)
-  end
-  workout.exercises.build(movement: pushup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 10)
-  end
-  workout.exercises.build(movement: airsquat, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 15)
-  end
+  workout.exercises.build(movement: pullup, position: 1, reps: 5)
+  workout.exercises.build(movement: pushup, position: 2, reps: 10)
+  workout.exercises.build(movement: airsquat, position: 3, reps: 15)
 end
 
 cfj.schedules.find_or_initialize_by(workout: chelsea).update(posted_at: '28-01-2018')
@@ -309,15 +260,9 @@ cfj.schedules.find_or_initialize_by(workout: chelsea).update(posted_at: '28-01-2
 cindy = Workout.find_or_create_by(name: 'Cindy') do |workout|
   workout.time = 20
   workout.score_type = :rep
-  workout.exercises.build(movement: pullup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 5)
-  end
-  workout.exercises.build(movement: pushup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 10)
-  end
-  workout.exercises.build(movement: airsquat, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 15)
-  end
+  workout.exercises.build(movement: pullup, position: 1, reps: 5)
+  workout.exercises.build(movement: pushup, position: 2, reps: 10)
+  workout.exercises.build(movement: airsquat, position: 3, reps: 15)
 end
 
 cfj.schedules.find_or_initialize_by(workout: cindy).update(posted_at: '27-01-2018')
@@ -330,13 +275,8 @@ cfj.schedules.find_or_initialize_by(workout: cindy).update(posted_at: '27-01-201
 diane = Workout.find_or_create_by(name: 'Diane') do |workout|
   workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :lb, female_value: 155, male_value: 225)
-  end
-  workout.exercises.build(movement: hspu, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
+  workout.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
+  workout.exercises.build(movement: hspu, position: 2, reps: 1)
 end
 
 cfj.schedules.find_or_initialize_by(workout: diane).update(posted_at: '26-01-2018')
@@ -349,13 +289,8 @@ cfj.schedules.find_or_initialize_by(workout: diane).update(posted_at: '26-01-201
 elizabeth = Workout.find_or_create_by(name: 'Elizabeth') do |workout|
   workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: clean, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
-  end
-  workout.exercises.build(movement: ringdip, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
+  workout.exercises.build(movement: clean, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
+  workout.exercises.build(movement: ringdip, position: 2, reps: 1)
 end
 
 cfj.schedules.find_or_initialize_by(workout: elizabeth).update(posted_at: '25-01-2018')
@@ -368,13 +303,8 @@ cfj.schedules.find_or_initialize_by(workout: elizabeth).update(posted_at: '25-01
 fran = Workout.find_or_create_by(name: 'Fran') do |workout|
   workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: thruster, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
-  workout.exercises.build(movement: pullup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
+  workout.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 2, reps: 1)
 end
 
 cfj.schedules.find_or_initialize_by(workout: fran).update(posted_at: '24-01-2018')
@@ -386,10 +316,7 @@ cfj.schedules.find_or_initialize_by(workout: fran).update(posted_at: '24-01-2018
 grace = Workout.find_or_create_by(name: 'Grace') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: cleanjerk, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-    e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
-  end
+  workout.exercises.build(movement: cleanjerk, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
  cfj.schedules.find_or_initialize_by(workout: grace).update(posted_at: '23-01-2018')
@@ -403,17 +330,9 @@ end
 helen = Workout.find_or_create_by(name: 'Helen') do |workout|
   workout.rounds = 3
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 400)
-  end
-  workout.exercises.build(movement: kbswing, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 21)
-    e.metrics.build(measurement: :lb, female_value: 35, male_value: 53)
-  end
-  workout.exercises.build(movement: pullup, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 12)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  workout.exercises.build(movement: kbswing, position: 2, reps: 21, female_load: 35, male_load: 53, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 3, reps: 12)
 end
 
 cfj.schedules.find_or_initialize_by(workout: helen).update(posted_at: '22-01-2018')
@@ -425,10 +344,7 @@ cfj.schedules.find_or_initialize_by(workout: helen).update(posted_at: '22-01-201
 isabel = Workout.find_or_create_by(name: 'Isabel') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: snatch, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-    e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
-  end
+  workout.exercises.build(movement: snatch, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 cfj.schedules.find_or_initialize_by(workout: isabel).update(posted_at: '21-01-2018')
@@ -442,17 +358,9 @@ cfj.schedules.find_or_initialize_by(workout: isabel).update(posted_at: '21-01-20
 jackie = Workout.find_or_create_by(name: 'Jackie') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 1000)
-  end
-  workout.exercises.build(movement: thruster, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-    e.metrics.build(measurement: :lb, female_value: 35, male_value: 45)
-  end
-  workout.exercises.build(movement: pullup, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-  end
+  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  workout.exercises.build(movement: thruster, position: 2, reps: 50, female_load: 35, male_load: 45, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 3, reps: 30)
 end
 
 cfj.schedules.find_or_initialize_by(workout: jackie).update(posted_at: '20-01-2018')
@@ -464,11 +372,7 @@ cfj.schedules.find_or_initialize_by(workout: jackie).update(posted_at: '20-01-20
 karen = Workout.find_or_create_by(name: 'Karen') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: wallball, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 150)
-    e.metrics.build(measurement: :lb, female_value: 14, male_value: 20)
-    e.metrics.build(measurement: :foot, female_value: 9, male_value: 10)
-  end
+  workout.exercises.build(movement: wallball, position: 1, reps: 150, female_load: 14, male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10, distance_unit: :foot)
 end
 
 cfj.schedules.find_or_initialize_by(workout: karen).update(posted_at: '19-01-2018')
@@ -482,18 +386,9 @@ cfj.schedules.find_or_initialize_by(workout: karen).update(posted_at: '19-01-201
 linda = Workout.find_or_create_by(name: 'Linda') do |workout|
   workout.interval = '10-9-8-7-6-5-4-3-2-1'
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1)  do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :weight, value: '1 1/2 body weight')
-  end
-  workout.exercises.build(movement: bench_press, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :weight, value: 'body weight')
-  end
-  workout.exercises.build(movement: clean, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :weight, value: '3/4 body weight')
-  end
+  workout.exercises.build(movement: deadlift, position: 1, reps: 1, notes: '1 1/2 body weight')
+  workout.exercises.build(movement: bench_press, position: 2, reps: 1, notes: 'body weight')
+  workout.exercises.build(movement: clean, position: 3, reps: 1, notes: '3/4 body weight')
 end
 
 cfj.schedules.find_or_initialize_by(workout: linda).update(posted_at: '18-01-2018')
@@ -507,15 +402,9 @@ cfj.schedules.find_or_initialize_by(workout: linda).update(posted_at: '18-01-201
 mary = Workout.find_or_create_by(name: 'Mary') do |workout|
   workout.time = 20
   workout.score_type = :rep
-  workout.exercises.build(movement: hspu, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 5)
-  end
-  workout.exercises.build(movement: pistol, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 10)
-  end
-  workout.exercises.build(movement: pullup, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 15)
-  end
+  workout.exercises.build(movement: hspu, position: 1, reps: 5)
+  workout.exercises.build(movement: pistol, position: 2, reps: 10)
+  workout.exercises.build(movement: pullup, position: 3, reps: 15)
 end
 
 cfj.schedules.find_or_initialize_by(workout: mary).update(posted_at: '17-01-2018')
@@ -528,14 +417,8 @@ cfj.schedules.find_or_initialize_by(workout: mary).update(posted_at: '17-01-2018
 nancy = Workout.find_or_create_by(name: 'Nancy') do |workout|
   workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 400)
-  end
-  workout.exercises.build(movement: ohs, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 15)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  workout.exercises.build(movement: ohs, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 cfj.schedules.find_or_initialize_by(workout: nancy).update(posted_at: '16-01-2018')
@@ -550,12 +433,8 @@ cfj.schedules.find_or_initialize_by(workout: nancy).update(posted_at: '16-01-201
 annie = Workout.find_or_create_by(name: 'Annie') do |workout|
   workout.interval = '50-40-30-20-10'
   workout.score_type = :time
-  workout.exercises.build(movement: double_under, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: situp, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
+  workout.exercises.build(movement: double_under, position: 1, reps: 1)
+  workout.exercises.build(movement: situp, position: 2, reps: 1)
 end
 
 cfj.schedules.find_or_initialize_by(workout: annie).update(posted_at: '15-01-2018')
@@ -569,17 +448,9 @@ cfj.schedules.find_or_initialize_by(workout: annie).update(posted_at: '15-01-201
 eva = Workout.find_or_create_by(name: 'Eva') do |workout|
   workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 800)
-  end
-  workout.exercises.build(movement: kbswing, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-    e.metrics.build(measurement: :lb, female_value: 53, male_value: 70)
-  end
-  workout.exercises.build(movement: pullup, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  workout.exercises.build(movement: kbswing, position: 2, reps: 30, female_load: 53, male_load: 70, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 3, reps: 30)
 end
 
 cfj.schedules.find_or_initialize_by(workout: eva).update(posted_at: '14-01-2018')
@@ -593,19 +464,9 @@ cfj.schedules.find_or_initialize_by(workout: eva).update(posted_at: '14-01-2018'
 kelly = Workout.find_or_create_by(name: 'Kelly') do |workout|
   workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 400)
-  end
-  workout.exercises.build(movement: box_jump, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-    e.metrics.build(measurement: :inch, female_value: 20, male_value: 24)
-  end
-  workout.exercises.build(movement: wallball, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-    e.metrics.build(measurement: :lb, female_value: 14, male_value: 20)
-    e.metrics.build(measurement: :foot, female_value: 9, male_value: 10)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  workout.exercises.build(movement: box_jump, position: 2, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  workout.exercises.build(movement: wallball, position: 3, reps: 30, female_load: 14, male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10, distance_unit: :foot)
 end
 
 cfj.schedules.find_or_initialize_by(workout: kelly).update(posted_at: '13-01-2018')
@@ -619,13 +480,8 @@ cfj.schedules.find_or_initialize_by(workout: kelly).update(posted_at: '13-01-201
 lynne = Workout.find_or_create_by(name: 'Lynne') do |workout|
   workout.rounds = 5
   workout.score_type = :rep
-  workout.exercises.build(movement: bench_press, position: 1) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :weight, value: 'body weight')
-  end
-  workout.exercises.build(movement: pullup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-  end
+  workout.exercises.build(movement: bench_press, position: 1, reps: 0, notes: 'body weight')
+  workout.exercises.build(movement: pullup, position: 2, reps: 30)
 end
 
 cfj.schedules.find_or_initialize_by(workout: lynne).update(posted_at: '12-01-2018')
@@ -639,13 +495,8 @@ cfj.schedules.find_or_initialize_by(workout: lynne).update(posted_at: '12-01-201
 nicole = Workout.find_or_create_by(name: 'Nicole') do |workout|
   workout.time = 20
   workout.score_type = :round
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 400)
-  end
-  workout.exercises.build(movement: pullup, position: 2) do |e|
-    e.metrics.build(measurement: :rep)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  workout.exercises.build(movement: pullup, position: 2, reps: 0)
 end
 
 cfj.schedules.find_or_initialize_by(workout: nicole).update(posted_at: '11-01-2018')
@@ -658,13 +509,8 @@ cfj.schedules.find_or_initialize_by(workout: nicole).update(posted_at: '11-01-20
 amanda = Workout.find_or_create_by(name: 'Amanda') do |workout|
   workout.interval = '9-7-5'
   workout.score_type = :time
-  workout.exercises.build(movement: muscleup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: snatch, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :lb, female_value: 95, male_value: 135)
-  end
+  workout.exercises.build(movement: muscleup, position: 1, reps: 1)
+  workout.exercises.build(movement: snatch, position: 2, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 cfj.schedules.find_or_initialize_by(workout: amanda).update(posted_at: '10-01-2018')
@@ -678,10 +524,7 @@ cfj.schedules.find_or_initialize_by(workout: amanda).update(posted_at: '10-01-20
 gwen = Workout.find_or_create_by(name: 'Gwen') do |workout|
   workout.interval = '15-12-9'
   workout.score_type = :weight
-  workout.exercises.build(movement: cleanjerk, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-      e.metrics.build(measurement: :lb)
-  end
+  workout.exercises.build(movement: cleanjerk, position: 1, reps: 1, load_unit: :lb)
 end
 
 cfj.schedules.find_or_initialize_by(workout: gwen).update(posted_at: '09-01-2018')
@@ -693,21 +536,11 @@ cfj.schedules.find_or_initialize_by(workout: gwen).update(posted_at: '09-01-2018
 marguerita = Workout.find_or_create_by(name: 'Marguerita') do |workout|
   workout.rounds = 50
   workout.score_type = :time
-  workout.exercises.build(movement: burpee, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: pushup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: jumpingjack, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: situp, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: handstand, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
+  workout.exercises.build(movement: burpee, position: 1, reps: 1)
+  workout.exercises.build(movement: pushup, position: 2, reps: 1)
+  workout.exercises.build(movement: jumpingjack, position: 3, reps: 1)
+  workout.exercises.build(movement: situp, position: 4, reps: 1)
+  workout.exercises.build(movement: handstand, position: 5, reps: 1)
 end
 
 cfj.schedules.find_or_initialize_by(workout: marguerita).update(posted_at: '08-01-2018')
@@ -721,15 +554,9 @@ cfj.schedules.find_or_initialize_by(workout: marguerita).update(posted_at: '08-0
 candy = Workout.find_or_create_by(name: 'Candy') do |workout|
   workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: pullup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 20)
-  end
-  workout.exercises.build(movement: pushup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 40)
-  end
-  workout.exercises.build(movement: airsquat, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 60)
-  end
+  workout.exercises.build(movement: pullup, position: 1, reps: 20)
+  workout.exercises.build(movement: pushup, position: 2, reps: 40)
+  workout.exercises.build(movement: airsquat, position: 3, reps: 60)
 end
 
 cfj.schedules.find_or_initialize_by(workout: candy).update(posted_at: '07-01-2018')
@@ -743,15 +570,9 @@ cfj.schedules.find_or_initialize_by(workout: candy).update(posted_at: '07-01-201
 maggie = Workout.find_or_create_by(name: 'Maggie') do |workout|
   workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: hspu, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 20)
-  end
-  workout.exercises.build(movement: pullup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 40)
-  end
-  workout.exercises.build(movement: pistol, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 60)
-  end
+  workout.exercises.build(movement: hspu, position: 1, reps: 20)
+  workout.exercises.build(movement: pullup, position: 2, reps: 40)
+  workout.exercises.build(movement: pistol, position: 3, reps: 60)
 end
 
 cfj.schedules.find_or_initialize_by(workout: maggie).update(posted_at: '06-01-2018')
@@ -780,28 +601,12 @@ hope = Workout.find_or_create_by(name: 'Hope') do |workout|
                   ' between exercises. On call of "rotate," the athlete/s must'\
                   ' move to next station immediately for good score. One point'\
                   ' is given for each rep.'
-  workout.exercises.build(movement: burpee, position: 1) do |e|
-    e.metrics.build(measurement: :rep)
-  end
-  workout.exercises.build(movement: snatch, position: 2) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :lb, female_value: 55, male_value: 75)
-  end
-  workout.exercises.build(movement: box_jump, position: 3) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :inch, female_value: 20, male_value: 24)
-  end
-  workout.exercises.build(movement: thruster, position: 4) do |e|
-    e.metrics.build(measurement: :rep)
-    e.metrics.build(measurement: :lb, female_value: 55, male_value: 75)
-  end
-  workout.exercises.build(movement: chest2bar, position: 5) do |e|
-    e.metrics.build(measurement: :rep)
-  end
-  workout.exercises.build(movement: rest, position: 6) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :seconds, value: 60)
-  end
+  workout.exercises.build(movement: burpee, position: 1, reps: 0)
+  workout.exercises.build(movement: snatch, position: 2, reps: 0, female_load: 55, male_load: 75, load_unit: :lb)
+  workout.exercises.build(movement: box_jump, position: 3, reps: 0, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  workout.exercises.build(movement: thruster, position: 4, reps: 0, female_load: 55, male_load: 75, load_unit: :lb)
+  workout.exercises.build(movement: chest2bar, position: 5, reps: 0)
+  workout.exercises.build(movement: rest, position: 6, reps: 1, duration_seconds: 60)
 end
 
 cfj.schedules.find_or_initialize_by(workout: hope).update(posted_at: '05-01-2018')
@@ -817,15 +622,9 @@ cfj.schedules.find_or_initialize_by(workout: hope).update(posted_at: '05-01-2018
 Workout.find_or_create_by(name: 'JT') do |workout|
   workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: hspu, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: ringdip, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
-  workout.exercises.build(movement: pushup, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-  end
+  workout.exercises.build(movement: hspu, position: 1, reps: 1)
+  workout.exercises.build(movement: ringdip, position: 2, reps: 1)
+  workout.exercises.build(movement: pushup, position: 3, reps: 1)
 end
 
 
@@ -838,16 +637,9 @@ end
 Workout.find_or_create_by(name: 'Michael') do |workout|
   workout.rounds = 3
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 800)
-  end
-  workout.exercises.build(movement: backext, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-  end
-  workout.exercises.build(movement: situp, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  workout.exercises.build(movement: backext, position: 2, reps: 50)
+  workout.exercises.build(movement: situp, position: 3, reps: 50)
 end
 
 # ==============================================================================
@@ -861,23 +653,11 @@ end
 Workout.find_or_create_by(name: 'Murph') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 1600)
-  end
-  workout.exercises.build(movement: pullup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 100)
-  end
-  workout.exercises.build(movement: pushup, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 200)
-  end
-  workout.exercises.build(movement: airsquat, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 300)
-  end
-  workout.exercises.build(movement: run, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 1600)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  workout.exercises.build(movement: pullup, position: 2, reps: 100)
+  workout.exercises.build(movement: pushup, position: 3, reps: 200)
+  workout.exercises.build(movement: airsquat, position: 4, reps: 300)
+  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -893,32 +673,13 @@ end
 Workout.find_or_create_by(name: 'Daniel') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: pullup, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-  end
-  workout.exercises.build(movement: run, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 400)
-  end
-  workout.exercises.build(movement: thruster, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 21)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
-  workout.exercises.build(movement: run, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 800)
-  end
-  workout.exercises.build(movement: thruster, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 21)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
-  workout.exercises.build(movement: run, position: 6) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 400)
-  end
-  workout.exercises.build(movement: pullup, position: 7) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-  end
+  workout.exercises.build(movement: pullup, position: 1, reps: 50)
+  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
+  workout.exercises.build(movement: thruster, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  workout.exercises.build(movement: thruster, position: 5, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
+  workout.exercises.build(movement: pullup, position: 7, reps: 50)
 end
 
 # ==============================================================================
@@ -933,27 +694,12 @@ end
 Workout.find_or_create_by(name: 'Josh') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: ohs, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 21)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
-  workout.exercises.build(movement: pullup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 42)
-  end
-  workout.exercises.build(movement: ohs, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 15)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
-  workout.exercises.build(movement: pullup, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 30)
-  end
-  workout.exercises.build(movement: ohs, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 9)
-    e.metrics.build(measurement: :lb, female_value: 65, male_value: 95)
-  end
-  workout.exercises.build(movement: pullup, position: 6) do |e|
-    e.metrics.build(measurement: :rep, value: 18)
-  end
+  workout.exercises.build(movement: ohs, position: 1, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 2, reps: 42)
+  workout.exercises.build(movement: ohs, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 4, reps: 30)
+  workout.exercises.build(movement: ohs, position: 5, reps: 9, female_load: 65, male_load: 95, load_unit: :lb)
+  workout.exercises.build(movement: pullup, position: 6, reps: 18)
 end
 
 # ==============================================================================
@@ -970,30 +716,14 @@ end
 Workout.find_or_create_by(name: 'Jason') do |workout|
   workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: airsquat, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 100)
-  end
-  workout.exercises.build(movement: muscleup, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 5)
-  end
-  workout.exercises.build(movement: airsquat, position: 3) do |e|
-    e.metrics.build(measurement: :rep, value: 75)
-  end
-  workout.exercises.build(movement: muscleup, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 10)
-  end
-  workout.exercises.build(movement: airsquat, position: 5) do |e|
-    e.metrics.build(measurement: :rep, value: 50)
-  end
-  workout.exercises.build(movement: muscleup, position: 6) do |e|
-    e.metrics.build(measurement: :rep, value: 15)
-  end
-  workout.exercises.build(movement: airsquat, position: 7) do |e|
-    e.metrics.build(measurement: :rep, value: 25)
-  end
-  workout.exercises.build(movement: muscleup, position: 8) do |e|
-    e.metrics.build(measurement: :rep, value: 20)
-  end
+  workout.exercises.build(movement: airsquat, position: 1, reps: 100)
+  workout.exercises.build(movement: muscleup, position: 2, reps: 5)
+  workout.exercises.build(movement: airsquat, position: 3, reps: 75)
+  workout.exercises.build(movement: muscleup, position: 4, reps: 10)
+  workout.exercises.build(movement: airsquat, position: 5, reps: 50)
+  workout.exercises.build(movement: muscleup, position: 6, reps: 15)
+  workout.exercises.build(movement: airsquat, position: 7, reps: 25)
+  workout.exercises.build(movement: muscleup, position: 8, reps: 20)
 end
 
 # Example WODS
@@ -1008,21 +738,11 @@ end
 # Then, run 800 meters
 segmented = Workout.find_or_create_by!(name: 'CFJ-181202') do |workout|
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 800)
-  end
+  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
   seg = workout.segments.build(rounds: 10, position: 2)
-  workout.exercises.build(movement: hspu, segment: seg, position: 1) do |e|
-    e.metrics.build(measurement: :rep, value: 10)
-  end
-  workout.exercises.build(movement: pistol, segment: seg, position: 2) do |e|
-    e.metrics.build(measurement: :rep, value: 10)
-  end
-  workout.exercises.build(movement: run, position: 4) do |e|
-    e.metrics.build(measurement: :rep, value: 1)
-    e.metrics.build(measurement: :meter, value: 800)
-  end
+  workout.exercises.build(movement: hspu, segment: seg, position: 1, reps: 10)
+  workout.exercises.build(movement: pistol, segment: seg, position: 2, reps: 10)
+  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 cfj.schedules.find_or_initialize_by(workout: segmented).update(posted_at: '02-12-2018')
@@ -1042,48 +762,26 @@ cfj.schedules.find_or_initialize_by(workout: segmented).update(posted_at: '02-12
 tabata = Workout.find_or_create_by!(name: 'CFJ-181226') do |workout|
   workout.score_type = :rep
   tab1 = workout.segments.build(rounds: 8, position: 1)
-  workout.exercises.build(movement: hspu, segment: tab1, position: 1) do |e|
-    e.metrics.build(measurement: :seconds, value: 20)
-  end
-  workout.exercises.build(movement: rest, segment: tab1, position: 2) do |e|
-    e.metrics.build(measurement: :seconds, value: 10)
-  end
+  workout.exercises.build(movement: hspu, segment: tab1, position: 1, duration_seconds: 20)
+  workout.exercises.build(movement: rest, segment: tab1, position: 2, duration_seconds: 10)
 
-  workout.exercises.build(movement: rest, position: 2) do |e|
-    e.metrics.build(measurement: :seconds, value: 60)
-  end
+  workout.exercises.build(movement: rest, position: 2, duration_seconds: 60)
 
   tab2 = workout.segments.build(rounds: 8, position: 3)
-  workout.exercises.build(movement: pistol, segment: tab2, position: 1) do |e|
-    e.metrics.build(measurement: :seconds, value: 20)
-  end
-  workout.exercises.build(movement: rest, segment: tab2, position: 2) do |e|
-    e.metrics.build(measurement: :seconds, value: 10)
-  end
+  workout.exercises.build(movement: pistol, segment: tab2, position: 1, duration_seconds: 20)
+  workout.exercises.build(movement: rest, segment: tab2, position: 2, duration_seconds: 10)
 
-  workout.exercises.build(movement: rest, position: 4) do |e|
-    e.metrics.build(measurement: :seconds, value: 60)
-  end
+  workout.exercises.build(movement: rest, position: 4, duration_seconds: 60)
 
   tab3 = workout.segments.build(rounds: 8, position: 5)
-  workout.exercises.build(movement: pushup, segment: tab3, position: 1) do |e|
-    e.metrics.build(measurement: :seconds, value: 20)
-  end
-  workout.exercises.build(movement: rest, segment: tab3, position: 2) do |e|
-    e.metrics.build(measurement: :seconds, value: 10)
-  end
+  workout.exercises.build(movement: pushup, segment: tab3, position: 1, duration_seconds: 20)
+  workout.exercises.build(movement: rest, segment: tab3, position: 2, duration_seconds: 10)
 
-  workout.exercises.build(movement: rest, position: 6) do |e|
-    e.metrics.build(measurement: :seconds, value: 60)
-  end
+  workout.exercises.build(movement: rest, position: 6, duration_seconds: 60)
 
   tab4 = workout.segments.build(rounds: 8, position: 7)
-  workout.exercises.build(movement: jumping_lunge, segment: tab4, position: 1) do |e|
-    e.metrics.build(measurement: :seconds, value: 20)
-  end
-  workout.exercises.build(movement: rest, segment: tab4, position: 2) do |e|
-    e.metrics.build(measurement: :seconds, value: 10)
-  end
+  workout.exercises.build(movement: jumping_lunge, segment: tab4, position: 1, duration_seconds: 20)
+  workout.exercises.build(movement: rest, segment: tab4, position: 2, duration_seconds: 10)
 end
 
 cfj.schedules.find_or_initialize_by(workout: tabata).update(posted_at: '26-12-2018')

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -73,8 +73,8 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
     get edit_workout_url(workouts(:fran))
 
     assert_response :success
+    # Exercise prescriptions are direct columns now; only the movement select remains here.
     assert_select 'select.movement[data-controller="movement-select"]'
-    assert_select 'select.metric[data-controller="metric-select"]'
 
     get new_workout_log_url(workouts(:murph))
 

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -35,8 +35,8 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Use the prescribed loading.', Workout.last.notes.to_plain_text.strip
   end
 
-  test 'should create workout with nested exercise metrics' do
-    assert_difference('Metric.count', 1) do
+  test 'should create workout with direct exercise prescriptions' do
+    assert_no_difference('Metric.where(measurable_type: "Exercise").count') do
       assert_difference(['Workout.count', 'Exercise.count'], 1) do
         post workouts_url, params: { workout: {
           name: 'Nested Workout',
@@ -45,9 +45,7 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
             '0' => {
               movement_id: movements(:pullup).id,
               position: 1,
-              metrics_attributes: {
-                '0' => { measurement: :rep, value: 10 }
-              }
+              reps: 10
             }
           }
         } }
@@ -55,12 +53,13 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to workout_url(Workout.last)
-    assert_equal movements(:pullup), Workout.last.exercises.first.movement
-    assert_equal 10, Workout.last.exercises.first.metrics.find_by!(measurement: :rep).value
+    exercise = Workout.last.exercises.first
+    assert_equal movements(:pullup), exercise.movement
+    assert_equal 10, exercise.reps
   end
 
-  test 'should create workout with nested sex-specific exercise metrics' do
-    assert_difference('Metric.count', 2) do
+  test 'should create workout with sex-specific exercise prescriptions' do
+    assert_no_difference('Metric.where(measurable_type: "Exercise").count') do
       assert_difference(['Workout.count', 'Exercise.count'], 1) do
         post workouts_url, params: { workout: {
           name: 'Sex Specific Workout',
@@ -69,20 +68,19 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
             '0' => {
               movement_id: movements(:thruster).id,
               position: 1,
-              metrics_attributes: {
-                '0' => { measurement: :rep, value: 1 },
-                '1' => { measurement: :lb, female_value: 65, male_value: 95 }
-              }
+              reps: 1,
+              female_load: 65, male_load: 95, load_unit: :lb
             }
           }
         } }
       end
     end
 
-    load_metric = Workout.last.exercises.first.metrics.find_by!(measurement: :lb)
-    assert_nil load_metric.value
-    assert_equal 65, load_metric.female_value
-    assert_equal 95, load_metric.male_value
+    exercise = Workout.last.exercises.first
+    assert_nil exercise.load
+    assert_equal 65, exercise.female_load
+    assert_equal 95, exercise.male_load
+    assert_equal 'lb', exercise.load_unit
   end
 
   test 'should show workout' do

--- a/test/helpers/measurable_helper_columns_test.rb
+++ b/test/helpers/measurable_helper_columns_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+# measurable_message rendered from the direct prescription columns (the #1651 read path).
+# The metric-backed equivalents live in measurable_helper_test.rb and exercise the fallback.
+class MeasurableHelperColumnsTest < ActionView::TestCase
+  include MeasurableHelper
+  include MetricsHelper
+
+  test 'renders a sex-specific box jump from columns with the length parenthesized' do
+    box_jump = Movement.create!(name: 'Box Jump')
+    exercise = workouts(:fran).exercises.build(movement: box_jump, position: 3,
+                                               reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+
+    assert_equal '30 Box Jumps (♀20-inch / ♂24-inch)', measurable_message(exercise)
+  end
+
+  test 'groups load and target height from columns by sex' do
+    wall_ball = Movement.create!(name: 'Wall-ball Shot')
+    exercise = workouts(:fran).exercises.build(movement: wall_ball, position: 3,
+                                               reps: 0, duration_seconds: 60,
+                                               female_load: 14, male_load: 20, load_unit: :lb,
+                                               female_distance: 9, male_distance: 10, distance_unit: :foot)
+
+    assert_equal '1:00 Wall-ball Shots (♀14lb + 9ft / ♂20lb + 10ft)', measurable_message(exercise)
+  end
+
+  test 'renders a leading distance from columns before the movement' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:run), position: 3,
+                                               reps: 1, distance: 1600, distance_unit: :meter)
+
+    assert_equal '1600 meter Run', measurable_message(exercise)
+  end
+
+  test 'renders the max-reps sentinel from columns' do
+    toes_to_bar = Movement.create!(name: 'Toes to Bar')
+    exercise = workouts(:fran).exercises.build(movement: toes_to_bar, position: 3, reps: 0)
+
+    assert_equal 'max reps Toes to Bar', measurable_message(exercise)
+  end
+
+  test 'prefers direct columns over legacy metrics when both are present' do
+    exercise = exercises(:fran_pullup) # carries a rep metric in fixtures
+    exercise.assign_attributes(reps: 5)
+
+    assert_equal '5 Pull Ups', measurable_message(exercise)
+  end
+end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -83,4 +83,56 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_not exercise.valid?
     assert_includes exercise.errors[:distance_units_per_rep], 'requires a distance metric'
   end
+
+  # --- direct-column prescriptions (the #1651 read path) ---
+
+  test 'load_bearing? reads the load unit column' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, load_unit: :lb)
+
+    assert_predicate exercise, :load_bearing?
+  end
+
+  test 'score_component reads the rep prescription from columns' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, reps: 21)
+
+    assert_equal 21, exercise.score_component[:score_reps]
+  end
+
+  test 'score_component reads the calorie prescription from columns' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:row), position: 3, reps: 1, calories: 20)
+
+    assert_equal 'calorie', exercise.score_component[:measurement]
+    assert_equal 20, exercise.score_component[:score_reps]
+  end
+
+  test 'treats the reps zero sentinel as max and not scorable' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, reps: 0)
+
+    assert_nil exercise.score_component
+  end
+
+  test 'rejects a unisex value combined with sex-specific values' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               load: 50, female_load: 65, male_load: 95, load_unit: :lb)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:load], 'cannot be set with sex-specific values'
+  end
+
+  test 'requires both sex-specific values when only one is present' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               female_load: 65, load_unit: :lb)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:base], 'load requires both female and male values'
+  end
+
+  test 'validates distance units per rep against the column distance' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:run), position: 3,
+                                               reps: 1, distance: 400, distance_unit: :meter,
+                                               distance_units_per_rep: 30)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:distance_units_per_rep], 'must divide the prescribed distance evenly'
+  end
 end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -58,6 +58,20 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 100, hspu_log.metrics.find(&:rep?).value
   end
 
+  test 'builds movement logs from direct column prescriptions' do
+    workout = Workout.new(rounds: 1, score_type: :time)
+    workout.exercises.build(movement: movements(:back_squat), position: 1,
+                            reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+
+    log = workout.logs.build(user: users(:mathew), score_type: :time, score_value: 180)
+    log.build_movement_logs
+
+    movement_log = log.movement_logs.first
+
+    assert_equal 21, movement_log.metrics.find(&:rep?).value
+    assert_equal 95, movement_log.metrics.find(&:lb?).value
+  end
+
   test 'calculates set-based lifting score from heaviest successful set' do
     log = workouts(:back_squat_5x5).logs.build(user: users(:mathew), score_type: :weight)
     log.build_movement_logs

--- a/test/system/sex_specific_workout_values_test.rb
+++ b/test/system/sex_specific_workout_values_test.rb
@@ -22,14 +22,10 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
       find('.ts-control input').set('Thruster')
       find('.ts-dropdown .option', text: 'Thruster').click
 
-      click_on 'Add Metric'
-      find('input[name$="[value]"]').set('1')
-      find('select.metric', visible: :all).select('rep')
-
-      click_on 'Add Metric'
-      all('input[placeholder="Female value"]').last.set('65')
-      all('input[placeholder="Male value"]').last.set('95')
-      all('select.metric', visible: :all).last.select('lb')
+      fill_in 'Reps', with: '1'
+      fill_in 'Female load', with: '65'
+      fill_in 'Male load', with: '95'
+      select 'lb', from: 'Load unit'
     end
 
     click_on 'Create Workout'

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -24,9 +24,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
       find('.ts-dropdown .option', text: 'Pull Up').click
       assert_no_selector '.ts-wrapper.dropdown-active'
       assert_field 'Position', with: '1'
-      click_on 'Add Metric'
-      find('input[name$="[value]"]').set('10')
-      find('select.metric', visible: :all).select('rep')
+      fill_in 'Reps', with: '10'
       assert_no_field 'Distance units per rep'
     end
 
@@ -48,9 +46,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
     within '.exercise' do
       assert_no_field 'Distance units per rep'
 
-      click_on 'Add Metric'
-      find('input[name$="[value]"]').set('400')
-      find('select.metric', visible: :all).select('meter')
+      fill_in 'Distance', with: '400', exact: true
 
       assert_field 'Distance units per rep'
     end


### PR DESCRIPTION
Closes #1652. Final sub-issue (**C of 3**) of the exercise-prescription migration (#1624): data (#1650) → reads (#1651) → **writes (#1652)**.

> **Heads-up on history:** #1651's PR (#1655) merged into the stranded `move-exercise-prescriptions-1650` branch rather than `master`, so master had the columns (#1650) but not the readers. This PR therefore carries **two commits** — the #1651 reader changes (re-applied onto master) **and** the #1652 write switch — and resolves the form conflict introduced by #1654 ("mobile workout form usability"). Do **not** also merge the old 1650 branch; it would duplicate #1651.

## #1651 — read from columns (metric fallback)
`ExercisePrescription` concern exposes `prescription_metrics`: builds the prescription from the direct columns when present (the `0` max sentinel, single `distance` length dimension), else falls back to legacy `metrics`. Rendering (`measurable_helper`), scoring (`score_component`/`load_bearing?`/`completed_prescribed_reps?`), and movement-log building all read it, so column-backed and metric-backed exercises behave identically. Adds `load_unit`/`distance_unit` enums and unisex-vs-paired-sex validations.

## #1652 — switch writes to columns
- Replace the nested metric fields in the exercise form with direct prescription inputs (reps, duration, load + sex + unit, distance + sex + unit, calories + sex, notes), keeping #1654's mobile-responsive column layout. The shared `_metric_fields` partial stays for movement logs.
- Toggle distance-units-per-rep from the distance inputs (`exercise_form_controller.js`).
- Permit the prescription columns in `workout_params`; drop `metrics_attributes` and `accepts_nested_attributes_for :metrics`.
- Rewrite `db/seeds.rb` to build columns; bodyweight loads move to `notes` (fixes their garbled display).

## Verification (on the rebased branch)
- **Golden display parity**: reseeded and compared `measurable_message` across all seeded exercises to the pre-change baseline — only the four bodyweight lines differ, now clean (`Deadlift (1 weight)` → `Deadlift`).
- **Controller test** asserts no exercise `Metric` rows are written on create.
- **System tests** (headless Chrome) drive the new form: `Thruster (♀65lb / ♂95lb)` via the Female/Male-load + Load-unit fields, the distance-units toggle, and set-based lifting logging.
- Full non-system suite **128 runs, 0 failures**; the 3 exercise/log system tests **9 runs, 0 failures**; **RuboCop clean (88 files)**.

## Scope note
The metric fallback stays live until #1626, so I kept the bulk test fixtures metric-based (now exercising the fallback) rather than flipping them all to columns — the column write/read path is covered by the controller test, system tests, and #1651's column-mode tests. The full fixture flip happens naturally in #1626 when `metrics` is removed.

## Out of scope
Dropping the `metrics` model/table (#1626); MovementLog performance (#1625).

🤖 Generated with [Claude Code](https://claude.com/claude-code)