### PR TITLE
[codex] Add mobile exercise card editing

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -6,6 +6,7 @@ $select-color-dropdown: $body-bg;
 $input-border-width: $border-width;
 @import "tom-select/dist/scss/tom-select.bootstrap5";
 @import "segments";
+@import "workouts";
 
 .auth-links {
   li:not(:last-of-type):after {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -17,6 +17,18 @@
   width: 100%;
 }
 
+.exercise-summary__button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--bs-body-color);
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+
 .exercise-summary__text {
   flex: 1 1 auto;
   font-weight: 600;
@@ -27,10 +39,9 @@
   white-space: nowrap;
 }
 
-.exercise-summary__hint {
-  color: var(--bs-secondary-color);
+.exercise-summary__delete {
   flex: 0 0 auto;
-  font-size: 0.875rem;
+  min-width: 2.25rem;
 }
 
 @media (min-width: 768px) {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -33,10 +33,6 @@
   font-size: 0.875rem;
 }
 
-.exercise-editor {
-  padding-top: 0.75rem;
-}
-
 @media (min-width: 768px) {
   .exercise-summary {
     min-height: 2.5rem;

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -1,3 +1,45 @@
 // Place all the styles related to the Workouts controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.exercise-summary {
+  align-items: center;
+  background: var(--bs-light);
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  color: var(--bs-body-color);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  width: 100%;
+}
+
+.exercise-summary__text {
+  flex: 1 1 auto;
+  font-weight: 600;
+  line-height: 1.25;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.exercise-summary__hint {
+  color: var(--bs-secondary-color);
+  flex: 0 0 auto;
+  font-size: 0.875rem;
+}
+
+.exercise-editor {
+  padding-top: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .exercise-summary {
+    min-height: 2.5rem;
+    padding-block: 0.375rem;
+  }
+}

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -15,13 +15,16 @@ export default class extends Controller {
 
   connect() {
     this.handleOpening = this.handleOpening.bind(this)
+    this.handleDocumentClick = this.handleDocumentClick.bind(this)
     document.addEventListener("exercise-card:opening", this.handleOpening)
+    document.addEventListener("click", this.handleDocumentClick, true)
 
     this.render()
   }
 
   disconnect() {
     document.removeEventListener("exercise-card:opening", this.handleOpening)
+    document.removeEventListener("click", this.handleDocumentClick, true)
   }
 
   expand() {
@@ -40,6 +43,12 @@ export default class extends Controller {
     if (this.saveIfValid()) return
 
     event.preventDefault()
+  }
+
+  handleDocumentClick(event) {
+    if (!this.expandedValue || this.element.contains(event.target) || this.tomSelectOwns(event.target)) return
+
+    this.saveIfValid()
   }
 
   requestExclusiveOpen() {
@@ -152,6 +161,10 @@ export default class extends Controller {
 
   get movementErrorElement() {
     return this.movementWrapper.parentElement.querySelector("[data-exercise-card-movement-error]")
+  }
+
+  tomSelectOwns(target) {
+    return target.closest(".ts-dropdown") && this.element.contains(this.movementSelectTarget.tomselect?.wrapper)
   }
 
   leading() {

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -14,16 +14,49 @@ export default class extends Controller {
   }
 
   connect() {
+    this.handleOpening = this.handleOpening.bind(this)
+    document.addEventListener("exercise-card:opening", this.handleOpening)
+
     this.render()
   }
 
+  disconnect() {
+    document.removeEventListener("exercise-card:opening", this.handleOpening)
+  }
+
   expand() {
+    if (this.expandedValue) return
+    if (!this.requestExclusiveOpen()) return
+
     this.expandedValue = true
   }
 
   save() {
+    this.saveIfValid()
+  }
+
+  handleOpening(event) {
+    if (event.detail.card === this || !this.expandedValue) return
+    if (this.saveIfValid()) return
+
+    event.preventDefault()
+  }
+
+  requestExclusiveOpen() {
+    return this.element.dispatchEvent(new CustomEvent("exercise-card:opening", {
+      bubbles: true,
+      cancelable: true,
+      detail: { card: this }
+    }))
+  }
+
+  saveIfValid() {
+    if (!this.validateEditor()) return false
+
     this.summaryTextTarget.textContent = this.summaryText()
     this.expandedValue = false
+
+    return true
   }
 
   expandedValueChanged() {
@@ -36,6 +69,47 @@ export default class extends Controller {
     this.editorTarget.hidden = !this.expandedValue
     this.summaryButtonTarget.hidden = this.expandedValue
     this.summaryButtonTarget.setAttribute("aria-expanded", this.expandedValue.toString())
+  }
+
+  validateEditor() {
+    this.clearMovementError()
+
+    if (!this.movementName()) {
+      this.showMovementError("Select a movement")
+      return false
+    }
+
+    const invalidControl = this.editorControls.find((control) => !control.checkValidity())
+    if (!invalidControl) return true
+
+    invalidControl.reportValidity()
+    return false
+  }
+
+  showMovementError(message) {
+    this.movementSelectTarget.setCustomValidity(message)
+    this.movementSelectTarget.tomselect?.control_input.focus()
+
+    if (this.movementErrorElement) {
+      this.movementErrorElement.textContent = message
+      return
+    }
+
+    const error = document.createElement("div")
+    error.className = "invalid-feedback d-block"
+    error.dataset.exerciseCardMovementError = "true"
+    error.textContent = message
+
+    this.movementWrapper.classList.add("is-invalid")
+    this.movementWrapper.insertAdjacentElement("afterend", error)
+  }
+
+  clearMovementError() {
+    if (!this.hasMovementSelectTarget) return
+
+    this.movementSelectTarget.setCustomValidity("")
+    this.movementWrapper.classList.remove("is-invalid")
+    this.movementErrorElement?.remove()
   }
 
   summaryText() {
@@ -66,6 +140,18 @@ export default class extends Controller {
     }
 
     return select.selectedOptions[0]?.textContent.trim() || ""
+  }
+
+  get editorControls() {
+    return Array.from(this.editorTarget.querySelectorAll("input, select, textarea"))
+  }
+
+  get movementWrapper() {
+    return this.movementSelectTarget.tomselect?.wrapper || this.movementSelectTarget
+  }
+
+  get movementErrorElement() {
+    return this.movementWrapper.parentElement.querySelector("[data-exercise-card-movement-error]")
   }
 
   leading() {

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -125,16 +125,18 @@ export default class extends Controller {
     const movementName = this.movementName()
     if (!movementName) return "New exercise"
 
-    const leading = this.leading()
+    const metrics = this.prescriptionMetrics()
+    const leading = this.leading(metrics)
     const leadingText = leading.text
-    const details = this.detailItems()
-      .filter((detail) => detail.kind !== leading.kind)
-      .map((detail) => detail.text)
-    const movementText = [leadingText, this.movementNameForLeadingText(movementName, leadingText)].filter(Boolean).join(" ")
+    const movementText = [
+      leadingText,
+      this.movementNameForLeadingMetric(movementName, leading.metric)
+    ].filter(Boolean).join(" ")
+    const details = this.additionalMetrics(metrics, leading.metric)
 
     if (details.length === 0) return movementText
 
-    return `${movementText} (${details.join(" / ")})`
+    return `${movementText} (${this.additionalMetricsText(details)})`
   }
 
   movementName() {
@@ -167,67 +169,162 @@ export default class extends Controller {
     return target.closest(".ts-dropdown") && this.element.contains(this.movementSelectTarget.tomselect?.wrapper)
   }
 
-  leading() {
-    if (this.hasDurationInputTarget && this.durationInputTarget.value.trim() !== "") {
-      return { kind: "duration", text: this.durationText(this.durationInputTarget.value) }
-    }
-
-    if (this.hasDistanceInputTarget && this.distanceInputTarget.value.trim() !== "" && !this.hasAdditionalWorkDetails()) {
-      return { kind: "distance", text: this.leadingValueWithUnit(this.distanceInputTarget.value, this.distanceUnit()) }
-    }
-
-    if (this.hasCaloriesInputTarget && this.caloriesInputTarget.value.trim() !== "" && !this.hasAdditionalWorkDetails()) {
-      return { kind: "calorie", text: this.leadingValueWithUnit(this.caloriesInputTarget.value, "calorie") }
-    }
-
-    if (!this.hasRepsInputTarget || this.repsInputTarget.value.trim() === "") return { kind: null, text: "" }
-    if (this.repsInputTarget.value.trim() === "0") return { kind: "reps", text: "max reps" }
-
-    return { kind: "reps", text: this.repsInputTarget.value.trim() }
+  prescriptionMetrics() {
+    return [
+      this.metric("rep", "rep", this.repsInputTarget),
+      this.metric("duration", "seconds", this.durationInputTarget),
+      this.metric("load", this.loadUnit(), this.loadInputTarget, this.femaleLoadInputTarget, this.maleLoadInputTarget),
+      this.metric("distance", this.distanceUnit(), this.distanceInputTarget, this.femaleDistanceInputTarget, this.maleDistanceInputTarget),
+      this.metric("calorie", "calorie", this.caloriesInputTarget, this.femaleCaloriesInputTarget, this.maleCaloriesInputTarget)
+    ].filter(Boolean)
   }
 
-  movementNameForLeadingText(movementName, leadingText) {
-    if (!leadingText) return movementName
-    if (leadingText === "max reps") return movementName
-    if (/^\d+$/.test(leadingText) && parseInt(leadingText, 10) !== 1) return this.pluralizeMovement(movementName)
+  metric(kind, measurement, valueInput, femaleInput = null, maleInput = null) {
+    if (!valueInput) return null
+
+    const value = valueInput.value.trim()
+    const femaleValue = femaleInput?.value.trim() || ""
+    const maleValue = maleInput?.value.trim() || ""
+    if (value === "" && femaleValue === "" && maleValue === "") return null
+
+    return {
+      kind,
+      measurement,
+      value: kind === "rep" && value === "0" ? "" : value,
+      femaleValue,
+      maleValue,
+      sexSpecific: femaleValue !== "" && maleValue !== ""
+    }
+  }
+
+  leading(metrics) {
+    const durationMetric = metrics.find((metric) => this.durationMetric(metric) && metric.value !== "")
+    if (durationMetric) return { metric: durationMetric, text: this.durationText(durationMetric.value) }
+
+    const leadingWorkMetric = this.leadingWorkMetric(metrics)
+    if (leadingWorkMetric) {
+      return { metric: leadingWorkMetric, text: this.leadingWorkMetricText(leadingWorkMetric) }
+    }
+
+    const repMetric = metrics.find((metric) => metric.kind === "rep")
+    if (!repMetric) return { metric: null, text: "" }
+    if (repMetric.value === "" && !repMetric.sexSpecific) return { metric: repMetric, text: "max reps" }
+
+    return { metric: repMetric, text: this.metricUnitText(repMetric) }
+  }
+
+  leadingWorkMetric(metrics) {
+    const candidate = metrics.find((metric) => this.visibleMetric(metric) && this.leadingWorkMetricKind(metric))
+    if (!candidate) return null
+
+    return metrics.every((metric) => !this.visibleMetric(metric) || metric === candidate || this.structuralSingleRepMetric(metric))
+      ? candidate
+      : null
+  }
+
+  additionalMetrics(metrics, leadingMetric) {
+    return metrics
+      .filter((metric) => metric.kind !== "rep")
+      .filter((metric) => metric !== leadingMetric)
+      .filter((metric) => !this.durationMetric(metric))
+      .filter((metric) => this.visibleMetric(metric))
+      .sort((left, right) => this.compareOrders(this.additionalMetricDisplayOrder(left), this.additionalMetricDisplayOrder(right)))
+  }
+
+  additionalMetricsText(metrics) {
+    if (metrics.length > 1 && metrics.every((metric) => metric.sexSpecific)) {
+      return this.sexSpecificMetricsText(metrics)
+    }
+
+    return metrics.map((metric) => this.metricUnitText(metric)).join(" / ")
+  }
+
+  sexSpecificMetricsText(metrics) {
+    const orderedMetrics = [...metrics].sort((left, right) => (
+      this.compareOrders(this.sexSpecificMetricDisplayOrder(left), this.sexSpecificMetricDisplayOrder(right))
+    ))
+    const femaleValues = orderedMetrics.map((metric) => this.sexSpecificMetricValueText(metric, metric.femaleValue))
+    const maleValues = orderedMetrics.map((metric) => this.sexSpecificMetricValueText(metric, metric.maleValue))
+
+    return `♀${femaleValues.join(" + ")} / ♂${maleValues.join(" + ")}`
+  }
+
+  metricUnitText(metric) {
+    if (metric.sexSpecific) return this.sexSpecificMetricUnitText(metric)
+    if (metric.value === "") return this.valueWithUnit("1", metric.measurement)
+    if (metric.kind === "rep") return metric.value === "1" ? "" : metric.value
+    if (this.durationMetric(metric)) return this.durationText(metric.value)
+
+    return this.valueWithUnit(metric.value, metric.measurement)
+  }
+
+  sexSpecificMetricUnitText(metric) {
+    const unit = this.singularUnit(metric.measurement)
+    const separator = this.loadMeasurement(unit) ? "" : "-"
+
+    return `♀${metric.femaleValue}${separator}${unit} / ♂${metric.maleValue}${separator}${unit}`
+  }
+
+  sexSpecificMetricValueText(metric, value) {
+    const unit = metric.measurement === "foot" ? "ft" : this.singularUnit(metric.measurement)
+    const separator = this.loadMeasurement(unit) || unit === "ft" ? "" : "-"
+
+    return `${value}${separator}${unit}`
+  }
+
+  leadingWorkMetricText(metric) {
+    if (metric.sexSpecific) return `${metric.maleValue}/${metric.femaleValue} ${this.singularUnit(metric.measurement)}`
+
+    return this.leadingValueWithUnit(metric.value, metric.measurement)
+  }
+
+  movementNameForLeadingMetric(movementName, metric) {
+    if (!metric) return movementName
+    if (metric.kind === "rep" && metric.value === "" && !metric.sexSpecific) return movementName
+    if (this.durationMetric(metric)) {
+      return this.repsInputTarget.value.trim() === "0" ? this.pluralizeMovement(movementName) : movementName
+    }
+    if (metric.kind === "rep" && parseInt(metric.value, 10) > 1) return this.pluralizeMovement(movementName)
 
     return movementName
   }
 
-  detailItems() {
-    return [
-      { kind: "load", text: this.sexSpecificDetail(this.femaleLoadInputTarget, this.maleLoadInputTarget, this.loadUnit(), "") },
-      { kind: "load", text: this.scalarDetail(this.loadInputTarget, this.loadUnit()) },
-      { kind: "distance", text: this.sexSpecificDetail(this.femaleDistanceInputTarget, this.maleDistanceInputTarget, this.distanceUnit(), "-") },
-      { kind: "distance", text: this.scalarDetail(this.distanceInputTarget, this.distanceUnit()) },
-      { kind: "calorie", text: this.sexSpecificDetail(this.femaleCaloriesInputTarget, this.maleCaloriesInputTarget, "calorie", "-") },
-      { kind: "calorie", text: this.scalarDetail(this.caloriesInputTarget, "calorie") }
-    ].filter(Boolean)
-      .filter((detail) => detail.text)
+  visibleMetric(metric) {
+    return metric.value !== "" || metric.sexSpecific
   }
 
-  scalarDetail(input, unit) {
-    if (!input || input.value.trim() === "") return null
-
-    return this.valueWithUnit(input.value, unit)
+  durationMetric(metric) {
+    return metric.kind === "duration"
   }
 
-  sexSpecificDetail(femaleInput, maleInput, unit, separator) {
-    if (!femaleInput || !maleInput) return null
-
-    const female = femaleInput.value.trim()
-    const male = maleInput.value.trim()
-    if (female === "" || male === "") return null
-
-    return `♀${female}${separator}${this.singularUnit(unit)} / ♂${male}${separator}${this.singularUnit(unit)}`
+  leadingWorkMetricKind(metric) {
+    return metric.kind === "calorie" || metric.kind === "distance"
   }
 
-  hasAdditionalWorkDetails() {
-    return [
-      this.loadInputTarget, this.femaleLoadInputTarget, this.maleLoadInputTarget,
-      this.femaleDistanceInputTarget, this.maleDistanceInputTarget,
-      this.femaleCaloriesInputTarget, this.maleCaloriesInputTarget
-    ].some((input) => input && input.value.trim() !== "")
+  structuralSingleRepMetric(metric) {
+    return metric.kind === "rep" && metric.value === "1"
+  }
+
+  additionalMetricDisplayOrder(metric) {
+    if (metric.kind === "calorie" || metric.kind === "distance") return [0, 1]
+    if (metric.kind === "load") return [1, 0]
+
+    return [1, 1]
+  }
+
+  sexSpecificMetricDisplayOrder(metric) {
+    if (metric.kind === "load") return [0, 1]
+    if (metric.kind === "distance") return [1, 0]
+
+    return [1, 1]
+  }
+
+  compareOrders(left, right) {
+    return left[0] - right[0] || left[1] - right[1]
+  }
+
+  loadMeasurement(unit) {
+    return ["lb", "kg"].includes(unit)
   }
 
   valueWithUnit(value, unit) {

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -147,6 +147,7 @@ export default class extends Controller {
     if (!value) return ""
 
     if (select.tomselect) {
+      // TomSelect stores server-provided Movement JSON with a name key; created options may only expose text.
       return select.tomselect.options[value]?.name || select.tomselect.options[value]?.text || ""
     }
 
@@ -190,7 +191,7 @@ export default class extends Controller {
     return {
       kind,
       measurement,
-      value: kind === "rep" && value === "0" ? "" : value,
+      value: ["rep", "calorie"].includes(kind) && value === "0" ? "" : value,
       femaleValue,
       maleValue,
       sexSpecific: femaleValue !== "" && maleValue !== ""

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -34,6 +34,7 @@ export default class extends Controller {
     if (!this.hasEditorTarget) return
 
     this.editorTarget.hidden = !this.expandedValue
+    this.summaryButtonTarget.hidden = this.expandedValue
     this.summaryButtonTarget.setAttribute("aria-expanded", this.expandedValue.toString())
   }
 

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -1,0 +1,190 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "summaryButton", "summaryText", "editor", "movementSelect",
+    "repsInput", "durationInput",
+    "loadInput", "femaleLoadInput", "maleLoadInput", "loadUnitSelect",
+    "distanceInput", "femaleDistanceInput", "maleDistanceInput", "distanceUnitSelect",
+    "caloriesInput", "femaleCaloriesInput", "maleCaloriesInput"
+  ]
+
+  static values = {
+    expanded: Boolean
+  }
+
+  connect() {
+    this.render()
+  }
+
+  expand() {
+    this.expandedValue = true
+  }
+
+  save() {
+    this.summaryTextTarget.textContent = this.summaryText()
+    this.expandedValue = false
+  }
+
+  expandedValueChanged() {
+    this.render()
+  }
+
+  render() {
+    if (!this.hasEditorTarget) return
+
+    this.editorTarget.hidden = !this.expandedValue
+    this.summaryButtonTarget.setAttribute("aria-expanded", this.expandedValue.toString())
+  }
+
+  summaryText() {
+    const movementName = this.movementName()
+    if (!movementName) return "New exercise"
+
+    const leading = this.leading()
+    const leadingText = leading.text
+    const details = this.detailItems()
+      .filter((detail) => detail.kind !== leading.kind)
+      .map((detail) => detail.text)
+    const movementText = [leadingText, this.movementNameForLeadingText(movementName, leadingText)].filter(Boolean).join(" ")
+
+    if (details.length === 0) return movementText
+
+    return `${movementText} (${details.join(" / ")})`
+  }
+
+  movementName() {
+    if (!this.hasMovementSelectTarget) return ""
+
+    const select = this.movementSelectTarget
+    const value = select.value
+    if (!value) return ""
+
+    if (select.tomselect) {
+      return select.tomselect.options[value]?.name || select.tomselect.options[value]?.text || ""
+    }
+
+    return select.selectedOptions[0]?.textContent.trim() || ""
+  }
+
+  leading() {
+    if (this.hasDurationInputTarget && this.durationInputTarget.value.trim() !== "") {
+      return { kind: "duration", text: this.durationText(this.durationInputTarget.value) }
+    }
+
+    if (this.hasDistanceInputTarget && this.distanceInputTarget.value.trim() !== "" && !this.hasAdditionalWorkDetails()) {
+      return { kind: "distance", text: this.leadingValueWithUnit(this.distanceInputTarget.value, this.distanceUnit()) }
+    }
+
+    if (this.hasCaloriesInputTarget && this.caloriesInputTarget.value.trim() !== "" && !this.hasAdditionalWorkDetails()) {
+      return { kind: "calorie", text: this.leadingValueWithUnit(this.caloriesInputTarget.value, "calorie") }
+    }
+
+    if (!this.hasRepsInputTarget || this.repsInputTarget.value.trim() === "") return { kind: null, text: "" }
+    if (this.repsInputTarget.value.trim() === "0") return { kind: "reps", text: "max reps" }
+
+    return { kind: "reps", text: this.repsInputTarget.value.trim() }
+  }
+
+  movementNameForLeadingText(movementName, leadingText) {
+    if (!leadingText) return movementName
+    if (leadingText === "max reps") return movementName
+    if (/^\d+$/.test(leadingText) && parseInt(leadingText, 10) !== 1) return this.pluralizeMovement(movementName)
+
+    return movementName
+  }
+
+  detailItems() {
+    return [
+      { kind: "load", text: this.sexSpecificDetail(this.femaleLoadInputTarget, this.maleLoadInputTarget, this.loadUnit(), "") },
+      { kind: "load", text: this.scalarDetail(this.loadInputTarget, this.loadUnit()) },
+      { kind: "distance", text: this.sexSpecificDetail(this.femaleDistanceInputTarget, this.maleDistanceInputTarget, this.distanceUnit(), "-") },
+      { kind: "distance", text: this.scalarDetail(this.distanceInputTarget, this.distanceUnit()) },
+      { kind: "calorie", text: this.sexSpecificDetail(this.femaleCaloriesInputTarget, this.maleCaloriesInputTarget, "calorie", "-") },
+      { kind: "calorie", text: this.scalarDetail(this.caloriesInputTarget, "calorie") }
+    ].filter(Boolean)
+      .filter((detail) => detail.text)
+  }
+
+  scalarDetail(input, unit) {
+    if (!input || input.value.trim() === "") return null
+
+    return this.valueWithUnit(input.value, unit)
+  }
+
+  sexSpecificDetail(femaleInput, maleInput, unit, separator) {
+    if (!femaleInput || !maleInput) return null
+
+    const female = femaleInput.value.trim()
+    const male = maleInput.value.trim()
+    if (female === "" || male === "") return null
+
+    return `♀${female}${separator}${this.singularUnit(unit)} / ♂${male}${separator}${this.singularUnit(unit)}`
+  }
+
+  hasAdditionalWorkDetails() {
+    return [
+      this.loadInputTarget, this.femaleLoadInputTarget, this.maleLoadInputTarget,
+      this.femaleDistanceInputTarget, this.maleDistanceInputTarget,
+      this.femaleCaloriesInputTarget, this.maleCaloriesInputTarget
+    ].some((input) => input && input.value.trim() !== "")
+  }
+
+  valueWithUnit(value, unit) {
+    const cleanValue = value.trim()
+    const cleanUnit = this.singularUnit(unit)
+
+    return cleanValue === "1" ? `${cleanValue} ${cleanUnit}` : `${cleanValue} ${this.pluralizeUnit(cleanUnit)}`
+  }
+
+  leadingValueWithUnit(value, unit) {
+    return `${value.trim()} ${this.singularUnit(unit)}`
+  }
+
+  durationText(value) {
+    const totalSeconds = parseInt(value, 10)
+    if (Number.isNaN(totalSeconds)) return value.trim()
+
+    const hours = Math.floor(totalSeconds / 3600)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+    const seconds = totalSeconds % 60
+
+    if (hours > 0) return `${hours}:${this.pad(minutes)}:${this.pad(seconds)}`
+
+    return `${minutes}:${this.pad(seconds)}`
+  }
+
+  loadUnit() {
+    return this.hasLoadUnitSelectTarget && this.loadUnitSelectTarget.value ? this.loadUnitSelectTarget.value : "lb"
+  }
+
+  distanceUnit() {
+    return this.hasDistanceUnitSelectTarget && this.distanceUnitSelectTarget.value ? this.distanceUnitSelectTarget.value : "meter"
+  }
+
+  singularUnit(unit) {
+    if (unit === "feet") return "foot"
+    if (unit.endsWith("s")) return unit.slice(0, -1)
+
+    return unit
+  }
+
+  pluralizeUnit(unit) {
+    if (unit === "foot") return "feet"
+    if (unit === "inch") return "inches"
+    if (unit.endsWith("s")) return unit
+
+    return `${unit}s`
+  }
+
+  pluralizeMovement(movementName) {
+    if (movementName.endsWith("s")) return movementName
+    if (movementName.endsWith("y")) return `${movementName.slice(0, -1)}ies`
+
+    return `${movementName}s`
+  }
+
+  pad(value) {
+    return value.toString().padStart(2, "0")
+  }
+}

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = [
-    "summaryButton", "summaryText", "editor", "movementSelect",
+    "summaryButton", "summaryText", "expandButton", "editor", "movementSelect",
     "repsInput", "durationInput",
     "loadInput", "femaleLoadInput", "maleLoadInput", "loadUnitSelect",
     "distanceInput", "femaleDistanceInput", "maleDistanceInput", "distanceUnitSelect",
@@ -77,7 +77,7 @@ export default class extends Controller {
 
     this.editorTarget.hidden = !this.expandedValue
     this.summaryButtonTarget.hidden = this.expandedValue
-    this.summaryButtonTarget.setAttribute("aria-expanded", this.expandedValue.toString())
+    this.expandButtonTarget.setAttribute("aria-expanded", this.expandedValue.toString())
   }
 
   validateEditor() {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,5 +16,8 @@ application.register("movement-select", MovementSelectController)
 import ExerciseFormController from "./exercise_form_controller.js"
 application.register("exercise-form", ExerciseFormController)
 
+import ExerciseCardController from "./exercise_card_controller.js"
+application.register("exercise-card", ExerciseCardController)
+
 import NestedFormController from "./nested_form_controller.js"
 application.register("nested-form", NestedFormController)

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -5,9 +5,11 @@
 
 .exercise.nested-fields.mb-3 data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError" data-exercise-card-expanded-value=expanded
   = f.hidden_field :_destroy
-  button.exercise-summary type="button" data-action="click->exercise-card#expand" data-exercise-card-target="summaryButton" aria-expanded=expanded
-    span.exercise-summary__text data-exercise-card-target="summaryText" = summary
-    span.exercise-summary__hint Edit
+  .exercise-summary data-exercise-card-target="summaryButton"
+    button.exercise-summary__button type="button" data-action="click->exercise-card#expand" data-exercise-card-target="expandButton" aria-expanded=expanded
+      span.exercise-summary__text data-exercise-card-target="summaryText" = summary
+    = link_to '#', class: 'exercise-summary__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
+      i.fas.fa-trash-alt aria-hidden="true"
   .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
     .card-body
       .row.g-2

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -3,13 +3,13 @@
 - expanded = f.object.new_record?
 - summary = f.object.persisted? ? measurable_message(f.object) : 'New exercise'
 
-.exercise.nested-fields.card.mb-3 data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError" data-exercise-card-expanded-value=expanded
+.exercise.nested-fields.mb-3 data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError" data-exercise-card-expanded-value=expanded
   = f.hidden_field :_destroy
-  .card-body
-    button.exercise-summary type="button" data-action="click->exercise-card#expand" data-exercise-card-target="summaryButton" aria-expanded=expanded
-      span.exercise-summary__text data-exercise-card-target="summaryText" = summary
-      span.exercise-summary__hint Edit
-    .exercise-editor data-exercise-card-target="editor" hidden=(!expanded)
+  button.exercise-summary type="button" data-action="click->exercise-card#expand" data-exercise-card-target="summaryButton" aria-expanded=expanded
+    span.exercise-summary__text data-exercise-card-target="summaryText" = summary
+    span.exercise-summary__hint Edit
+  .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
+    .card-body
       .row.g-2
         .col-12.col-md = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }
         .col-6.col-md-2 = f.input :position

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -3,7 +3,7 @@
 - expanded = f.object.new_record?
 - summary = f.object.persisted? ? measurable_message(f.object) : 'New exercise'
 
-.exercise.nested-fields.card.mb-3 data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits" data-exercise-card-expanded-value=expanded
+.exercise.nested-fields.card.mb-3 data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError" data-exercise-card-expanded-value=expanded
   = f.hidden_field :_destroy
   .card-body
     button.exercise-summary type="button" data-action="click->exercise-card#expand" data-exercise-card-target="summaryButton" aria-expanded=expanded

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -38,5 +38,5 @@
         .col = f.input :notes
       .row
         .col.d-grid.gap-2
-          button.btn.btn-sm.btn-primary.mt-2 type="button" data-action="click->exercise-card#save" Save Exercise
+          button.btn.btn-sm.btn-primary.mt-2 type="button" data-action="click->exercise-card#save" Done
           = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -1,33 +1,40 @@
 - has_distance = f.object.distance.present? || f.object.female_distance.present? || f.object.male_distance.present? || f.object.distance_unit.present?
 - distance_units_hidden = f.object.distance_units_per_rep.blank? && !has_distance
+- expanded = f.object.new_record?
+- summary = f.object.persisted? ? measurable_message(f.object) : 'New exercise'
 
-.exercise.nested-fields.card.mb-3 data-controller="exercise-form" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits"
+.exercise.nested-fields.card.mb-3 data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits" data-exercise-card-expanded-value=expanded
   = f.hidden_field :_destroy
   .card-body
-    .row.g-2
-      .col-12.col-md = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select' } }
-      .col-6.col-md-2 = f.input :position
-    .row.g-2
-      .col-6.col-md-3 = f.input :reps, hint: '0 = max reps'
-      .col-6.col-md-3 = f.input :duration_seconds, label: 'Duration (s)'
-    .row.g-2
-      .col-6.col-md-3 = f.input :load
-      .col-6.col-md-3 = f.input :female_load
-      .col-6.col-md-3 = f.input :male_load
-      .col-6.col-md-3 = f.input :load_unit, collection: Exercise.load_units.keys, prompt: 'Load unit'
-    .row.g-2
-      .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue' } }
-      .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue' } }
-      .col-6.col-md-3 = f.input :male_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue' } }
-      .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect' } }
-    .row.g-2
-      .col-6.col-md-3 = f.input :calories, hint: '0 = max calories'
-      .col-6.col-md-3 = f.input :female_calories
-      .col-6.col-md-3 = f.input :male_calories
-      .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
-        = f.input :distance_units_per_rep, label: 'Distance units per rep'
-    .row.g-2
-      .col = f.input :notes
-    .row
-      .col.d-grid.gap-2
-        = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger mt-2', data: { action: 'click->nested-form#remove' }
+    button.exercise-summary type="button" data-action="click->exercise-card#expand" data-exercise-card-target="summaryButton" aria-expanded=expanded
+      span.exercise-summary__text data-exercise-card-target="summaryText" = summary
+      span.exercise-summary__hint Edit
+    .exercise-editor data-exercise-card-target="editor" hidden=(!expanded)
+      .row.g-2
+        .col-12.col-md = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }
+        .col-6.col-md-2 = f.input :position
+      .row.g-2
+        .col-6.col-md-3 = f.input :reps, hint: '0 = max reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
+        .col-6.col-md-3 = f.input :duration_seconds, label: 'Duration (s)', input_html: { data: { 'exercise-card-target': 'durationInput' } }
+      .row.g-2
+        .col-6.col-md-3 = f.input :load, input_html: { data: { 'exercise-card-target': 'loadInput' } }
+        .col-6.col-md-3 = f.input :female_load, input_html: { data: { 'exercise-card-target': 'femaleLoadInput' } }
+        .col-6.col-md-3 = f.input :male_load, input_html: { data: { 'exercise-card-target': 'maleLoadInput' } }
+        .col-6.col-md-3 = f.input :load_unit, collection: Exercise.load_units.keys, prompt: 'Load unit', input_html: { data: { 'exercise-card-target': 'loadUnitSelect' } }
+      .row.g-2
+        .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'distanceInput' } }
+        .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'femaleDistanceInput' } }
+        .col-6.col-md-3 = f.input :male_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'maleDistanceInput' } }
+        .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect', 'exercise-card-target': 'distanceUnitSelect' } }
+      .row.g-2
+        .col-6.col-md-3 = f.input :calories, hint: '0 = max calories', input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
+        .col-6.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
+        .col-6.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
+        .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
+          = f.input :distance_units_per_rep, label: 'Distance units per rep'
+      .row.g-2
+        .col = f.input :notes
+      .row
+        .col.d-grid.gap-2
+          button.btn.btn-sm.btn-primary.mt-2 type="button" data-action="click->exercise-card#save" Save Exercise
+          = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }

--- a/test/system/exercise_card_deletion_test.rb
+++ b/test/system/exercise_card_deletion_test.rb
@@ -19,7 +19,7 @@ class ExerciseCardDeletionTest < ApplicationSystemTestCase
     within '.exercise' do
       find('.ts-control input').set('Pull')
       find('.ts-dropdown .option', text: 'Pull Up').click
-      click_on 'Save Exercise'
+      click_on 'Done'
 
       assert_text 'Pull Up'
       find('[aria-label="Delete exercise"]').click

--- a/test/system/exercise_card_deletion_test.rb
+++ b/test/system/exercise_card_deletion_test.rb
@@ -1,0 +1,30 @@
+require 'application_system_test_case'
+
+class ExerciseCardDeletionTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'deletes a collapsed exercise card from the summary row' do
+    visit new_workout_url
+
+    click_on 'Add Exercise'
+
+    within '.exercise' do
+      find('.ts-control input').set('Pull')
+      find('.ts-dropdown .option', text: 'Pull Up').click
+      click_on 'Save Exercise'
+
+      assert_text 'Pull Up'
+      find('[aria-label="Delete exercise"]').click
+    end
+
+    assert_no_selector '.exercise'
+  end
+end

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -20,6 +20,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
 
       click_on 'Thruster (95 weights)'
 
+      assert_no_text 'Thruster (95 weights)'
       assert_field 'Reps', with: ''
       fill_in 'Reps', with: '15'
       click_on 'Save Exercise'
@@ -49,6 +50,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
         assert_text '400 meter Run'
 
         click_on '400 meter Run'
+        assert_no_text '400 meter Run'
         assert_field 'Distance', with: '400'
       end
     end

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -1,0 +1,56 @@
+require 'application_system_test_case'
+
+class ExerciseCardEditingTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'edits an existing workout exercise through a summary card' do
+    visit edit_workout_url(workouts(:fran))
+
+    within first('.exercise') do
+      assert_no_field 'Reps'
+      assert_text 'Thruster (95 weights)'
+
+      click_on 'Thruster (95 weights)'
+
+      assert_field 'Reps', with: ''
+      fill_in 'Reps', with: '15'
+      click_on 'Save Exercise'
+
+      assert_no_field 'Reps'
+      assert_text '15 Thrusters'
+    end
+  end
+
+  test 'edits a segment exercise through a summary card' do
+    visit new_workout_url
+
+    click_on 'Add Segment'
+
+    within all('#workout-parts > .fields > .nested-fields').last do
+      click_on 'Add Exercise'
+
+      within '.exercise' do
+        assert_field 'Position', with: '1'
+        find('.ts-control input').set('Run')
+        find('.ts-dropdown .option', text: 'Run').click
+        fill_in 'Distance', with: '400', exact: true
+        select 'meter', from: 'Distance unit'
+        click_on 'Save Exercise'
+
+        assert_no_field 'Distance'
+        assert_text '400 meter Run'
+
+        click_on '400 meter Run'
+        assert_field 'Distance', with: '400'
+      end
+    end
+  end
+end

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -23,7 +23,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
       assert_no_text 'Thruster (95 weights)'
       assert_field 'Reps', with: ''
       fill_in 'Reps', with: '15'
-      click_on 'Save Exercise'
+      click_on 'Done'
 
       assert_no_field 'Reps'
       assert_text '15 Thrusters'
@@ -44,7 +44,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
         find('.ts-dropdown .option', text: 'Run').click
         fill_in 'Distance', with: '400', exact: true
         select 'meter', from: 'Distance unit'
-        click_on 'Save Exercise'
+        click_on 'Done'
 
         assert_no_field 'Distance'
         assert_text '400 meter Run'
@@ -85,7 +85,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
     within first('.exercise') do
       find('.ts-control input').set('Pull')
       find('.ts-dropdown .option', text: 'Pull Up').click
-      click_on 'Save Exercise'
+      click_on 'Done'
       assert_text 'Pull Up'
     end
 

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -55,4 +55,50 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'opening another card saves and collapses the currently open exercise' do
+    visit edit_workout_url(workouts(:fran))
+
+    cards = all('.exercise')
+
+    within cards.first do
+      click_on 'Thruster (95 weights)'
+      fill_in 'Reps', with: '15'
+    end
+
+    within cards[1] do
+      click_on 'Pull Up'
+      assert_field 'Reps', with: ''
+    end
+
+    within cards.first do
+      assert_no_field 'Reps'
+      assert_text '15 Thrusters'
+    end
+  end
+
+  test 'opening another card is blocked when the current exercise cannot be saved' do
+    visit new_workout_url
+
+    click_on 'Add Exercise'
+
+    within first('.exercise') do
+      find('.ts-control input').set('Pull')
+      find('.ts-dropdown .option', text: 'Pull Up').click
+      click_on 'Save Exercise'
+      assert_text 'Pull Up'
+    end
+
+    click_on 'Add Exercise'
+
+    within first('.exercise') do
+      click_on 'Pull Up'
+      assert_no_field 'Reps'
+    end
+
+    within all('.exercise').last do
+      assert_field 'Reps'
+      assert_text 'Select a movement'
+    end
+  end
 end

--- a/test/system/exercise_card_outside_click_test.rb
+++ b/test/system/exercise_card_outside_click_test.rb
@@ -1,0 +1,41 @@
+require 'application_system_test_case'
+
+class ExerciseCardOutsideClickTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'clicking outside saves and collapses the currently open exercise' do
+    visit edit_workout_url(workouts(:fran))
+
+    within first('.exercise') do
+      click_on 'Thruster (95 weights)'
+      fill_in 'Reps', with: '15'
+    end
+
+    find_field('Name').click
+
+    within first('.exercise') do
+      assert_no_field 'Reps'
+      assert_text '15 Thrusters'
+    end
+  end
+
+  test 'clicking outside is blocked when the current exercise cannot be saved' do
+    visit new_workout_url
+
+    click_on 'Add Exercise'
+    find_field('Name').click
+
+    within first('.exercise') do
+      assert_field 'Reps'
+      assert_text 'Select a movement'
+    end
+  end
+end

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -22,7 +22,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       select 'meter', from: 'Distance unit'
       fill_in 'Load', with: '95'
       select 'lb', from: 'Load unit'
-      click_on 'Save Exercise'
+      click_on 'Done'
 
       assert_text 'Run (10 meters / 95 lbs)'
     end
@@ -41,7 +41,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
-      click_on 'Save Exercise'
+      click_on 'Done'
 
       assert_text 'Run (♀65lb + 80-meter / ♂95lb + 100-meter)'
     end
@@ -57,9 +57,22 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
-      click_on 'Save Exercise'
+      click_on 'Done'
 
       assert_text '100/80 meter Run'
+    end
+  end
+
+  test 'omits zero calories from the local summary' do
+    visit new_workout_url
+    click_on 'Add Exercise'
+
+    within '.exercise' do
+      select_movement 'Row'
+      fill_in 'Calories', with: '0'
+      click_on 'Done'
+
+      assert_text 'Row'
     end
   end
 

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -1,0 +1,72 @@
+require 'application_system_test_case'
+
+class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'orders additional distance before load after local save' do
+    visit new_workout_url
+    click_on 'Add Exercise'
+
+    within '.exercise' do
+      select_movement 'Run'
+      fill_in 'Reps', with: '1'
+      fill_in 'Distance', with: '10', exact: true
+      select 'meter', from: 'Distance unit'
+      fill_in 'Load', with: '95'
+      select 'lb', from: 'Load unit'
+      click_on 'Save Exercise'
+
+      assert_text 'Run (10 meters / 95 lbs)'
+    end
+  end
+
+  test 'groups sex-specific additional metrics after local save' do
+    visit new_workout_url
+    click_on 'Add Exercise'
+
+    within '.exercise' do
+      select_movement 'Run'
+      fill_in 'Reps', with: '1'
+      fill_in 'Female load', with: '65'
+      fill_in 'Male load', with: '95'
+      select 'lb', from: 'Load unit'
+      fill_in 'Female distance', with: '80'
+      fill_in 'Male distance', with: '100'
+      select 'meter', from: 'Distance unit'
+      click_on 'Save Exercise'
+
+      assert_text 'Run (♀65lb + 80-meter / ♂95lb + 100-meter)'
+    end
+  end
+
+  test 'uses sex-specific distance as leading work after local save' do
+    visit new_workout_url
+    click_on 'Add Exercise'
+
+    within '.exercise' do
+      select_movement 'Run'
+      fill_in 'Reps', with: '1'
+      fill_in 'Female distance', with: '80'
+      fill_in 'Male distance', with: '100'
+      select 'meter', from: 'Distance unit'
+      click_on 'Save Exercise'
+
+      assert_text '100/80 meter Run'
+    end
+  end
+
+  private
+
+  def select_movement(name)
+    find('.ts-control input').set(name)
+    find('.ts-dropdown .option', text: name).click
+  end
+end

--- a/test/system/sex_specific_workout_values_test.rb
+++ b/test/system/sex_specific_workout_values_test.rb
@@ -26,6 +26,9 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
       fill_in 'Female load', with: '65'
       fill_in 'Male load', with: '95'
       select 'lb', from: 'Load unit'
+      click_on 'Save Exercise'
+      assert_text 'Thruster (♀65lb / ♂95lb)'
+      assert_no_field 'Female load'
     end
 
     click_on 'Create Workout'

--- a/test/system/sex_specific_workout_values_test.rb
+++ b/test/system/sex_specific_workout_values_test.rb
@@ -26,7 +26,7 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
       fill_in 'Female load', with: '65'
       fill_in 'Male load', with: '95'
       select 'lb', from: 'Load unit'
-      click_on 'Save Exercise'
+      click_on 'Done'
       assert_text 'Thruster (♀65lb / ♂95lb)'
       assert_no_field 'Female load'
     end

--- a/test/system/workout_segment_positions_test.rb
+++ b/test/system/workout_segment_positions_test.rb
@@ -27,6 +27,11 @@ class WorkoutSegmentPositionsTest < ApplicationSystemTestCase
       click_on 'Add Exercise'
       positions = all('.exercise input[name$="[position]"]').map(&:value)
       assert_equal %w[1 2], positions, "expected 2 exercises positions, got #{positions.inspect}"
+
+      within all('.exercise').last do
+        click_on 'Delete Exercise'
+      end
+      assert_equal 1, all('.exercise').size
     end
 
     within '#workout-parts > .links' do

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -26,6 +26,9 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
       assert_field 'Position', with: '1'
       fill_in 'Reps', with: '10'
       assert_no_field 'Distance units per rep'
+      click_on 'Save Exercise'
+      assert_no_field 'Reps'
+      assert_text '10 Pull Ups'
     end
 
     click_on 'Create Workout'
@@ -66,6 +69,49 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
 
     assert_selector 'trix-toolbar'
     assert_selector 'trix-editor[input^="workout_notes_trix_input"]'
+  end
+
+  test 'edits an existing workout exercise through a summary card' do
+    visit edit_workout_url(workouts(:fran))
+
+    within first('.exercise') do
+      assert_no_field 'Reps'
+      assert_text 'Thruster (95 weights)'
+
+      click_on 'Thruster (95 weights)'
+
+      assert_field 'Reps', with: ''
+      fill_in 'Reps', with: '15'
+      click_on 'Save Exercise'
+
+      assert_no_field 'Reps'
+      assert_text '15 Thrusters'
+    end
+  end
+
+  test 'edits a segment exercise through a summary card' do
+    visit new_workout_url
+
+    click_on 'Add Segment'
+
+    within all('#workout-parts > .fields > .nested-fields').last do
+      click_on 'Add Exercise'
+
+      within '.exercise' do
+        assert_field 'Position', with: '1'
+        find('.ts-control input').set('Run')
+        find('.ts-dropdown .option', text: 'Run').click
+        fill_in 'Distance', with: '400', exact: true
+        select 'meter', from: 'Distance unit'
+        click_on 'Save Exercise'
+
+        assert_no_field 'Distance'
+        assert_text '400 meter Run'
+
+        click_on '400 meter Run'
+        assert_field 'Distance', with: '400'
+      end
+    end
   end
 
   test 'schedules a workout' do

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -26,7 +26,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
       assert_field 'Position', with: '1'
       fill_in 'Reps', with: '10'
       assert_no_field 'Distance units per rep'
-      click_on 'Save Exercise'
+      click_on 'Done'
       assert_no_field 'Reps'
       assert_text '10 Pull Ups'
     end

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -71,49 +71,6 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
     assert_selector 'trix-editor[input^="workout_notes_trix_input"]'
   end
 
-  test 'edits an existing workout exercise through a summary card' do
-    visit edit_workout_url(workouts(:fran))
-
-    within first('.exercise') do
-      assert_no_field 'Reps'
-      assert_text 'Thruster (95 weights)'
-
-      click_on 'Thruster (95 weights)'
-
-      assert_field 'Reps', with: ''
-      fill_in 'Reps', with: '15'
-      click_on 'Save Exercise'
-
-      assert_no_field 'Reps'
-      assert_text '15 Thrusters'
-    end
-  end
-
-  test 'edits a segment exercise through a summary card' do
-    visit new_workout_url
-
-    click_on 'Add Segment'
-
-    within all('#workout-parts > .fields > .nested-fields').last do
-      click_on 'Add Exercise'
-
-      within '.exercise' do
-        assert_field 'Position', with: '1'
-        find('.ts-control input').set('Run')
-        find('.ts-dropdown .option', text: 'Run').click
-        fill_in 'Distance', with: '400', exact: true
-        select 'meter', from: 'Distance unit'
-        click_on 'Save Exercise'
-
-        assert_no_field 'Distance'
-        assert_text '400 meter Run'
-
-        click_on '400 meter Run'
-        assert_field 'Distance', with: '400'
-      end
-    end
-  end
-
   test 'schedules a workout' do
     subscriptions(:one).update!(role: :owner)
     visit workout_url(workouts(:murph))


### PR DESCRIPTION
## Summary
- Add a Stimulus exercise-card controller for local expand/collapse editing on workout forms.
- Render exercise nested fields as compact summary cards by default for persisted exercises, while newly added exercises open expanded.
- Update card-level Save to refresh summary text from current form values without persisting to the server.
- Apply the behavior to top-level and segment-nested exercises, leaving segment cards unchanged.
- Add focused mobile Sass and system coverage for card editing, sex-specific summaries, segment exercises, delete, and position behavior.

## Validation
- `yarn build`
- `yarn build:css` (passes with existing Sass/Bootstrap deprecation warnings)
- `rvm 3.4.9@wod-tracker do bundle exec rails test`
- `rvm 3.4.9@wod-tracker do bundle exec rails test:system test/system/workout_workflows_test.rb test/system/workout_segment_positions_test.rb test/system/sex_specific_workout_values_test.rb`