### PR TITLE
Fix workout-recording display: per-round reps and foot/height rendering

### DIFF
--- a/app/helpers/metrics_helper.rb
+++ b/app/helpers/metrics_helper.rb
@@ -5,14 +5,19 @@ module MetricsHelper
     {}
   end
 
+  HEIGHT_MEASUREMENTS = %w[foot inch].freeze
+
   def metric_unit_msg(metric)
     return sex_specific_metric_unit_msg(metric) if metric.sex_specific?
+    return "#{metric.value.to_i} ft" if metric.foot? # Rails has no foot -> feet inflection
     return pluralize(1, metric.measurement) if metric.value.nil?
-    return metric.value == 1 ? '' : metric.value if metric.rep?
+    return rep_count_msg(metric) if metric.rep?
     return seconds_to_duration_string(metric.value) if metric.seconds? || metric.time?
 
     pluralize(metric.value.to_i, metric.measurement)
   end
+
+  def rep_count_msg(metric) = metric.value == 1 ? '' : metric.value
 
   def log_score_msg(log)
     return unless log.score_measurement
@@ -54,6 +59,7 @@ module MetricsHelper
   end
 
   def additional_metric_display_order(metric)
+    return [2, 0] if HEIGHT_MEASUREMENTS.include?(metric.measurement) # target height is a qualifier
     return [0, 1] if metric.calorie? || Metric::DISTANCE_MEASUREMENTS.include?(metric.measurement)
     return [1, 0] if Metric::LOAD_MEASUREMENTS.include?(metric.measurement)
 

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -62,16 +62,10 @@ class Metric < ApplicationRecord
   private
 
   def calculated_rep_value(workout)
+    # Interval ladders (e.g. 21-15-9) record total work; everything else records one round's reps.
     return value * workout.reps_from_interval if workout.interval?
-    return value if fixed_timed_rounds?(workout)
-    return nil unless value # Reps can be nil to signify max
-    return value if workout.rounds.nil? || workout.rounds.zero?
 
-    value * workout.rounds
-  end
-
-  def fixed_timed_rounds?(workout)
-    workout.timed_rounds? && !workout.emom?
+    value
   end
 
   def values_are_unambiguous

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -99,4 +99,14 @@ class MeasurableHelperTest < ActionView::TestCase
 
     assert_equal 'Row (300 meters)', measurable_message(movement_log)
   end
+
+  test 'renders single-value target heights as ft after load' do
+    wall_ball = Movement.create!(name: 'Wall-ball Shot')
+    movement_log = logs(:matt_amrap).movement_logs.create!(movement: wall_ball)
+    movement_log.metrics.create!(measurement: :rep, value: 30)
+    movement_log.metrics.create!(measurement: :lb, value: 20)
+    movement_log.metrics.create!(measurement: :foot, value: 10)
+
+    assert_equal '30 Wall-ball Shots (20 lbs / 10 ft)', measurable_message(movement_log)
+  end
 end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -47,7 +47,7 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 5, log.movement_logs.first.metrics.find(&:rep?).value
   end
 
-  test 'multiplies prescribed reps by segment rounds for segment exercises' do
+  test 'records per-round prescribed reps for segment exercises' do
     exercises(:segmented_hspu).metrics.create!(measurement: :rep, value: 10)
 
     log = workouts(:segmented).logs.build(user: users(:mathew), score_type: :time)
@@ -55,7 +55,7 @@ class LogTest < ActiveSupport::TestCase
 
     hspu_log = log.movement_logs.find { |movement_log| movement_log.movement == movements(:hspu) }
 
-    assert_equal 100, hspu_log.metrics.find(&:rep?).value
+    assert_equal 10, hspu_log.metrics.find(&:rep?).value
   end
 
   test 'builds movement logs from direct column prescriptions' do


### PR DESCRIPTION
Two display bugs surfaced while logging multi-round workouts (e.g. **Kelly** — 5 rounds of 400m run / 30 box jumps / 30 wall-balls), which rendered `150 Wall-ball Shots (10 foots / 20 lbs)`. Both are pre-existing (the #1624/#1625 migrations preserved display exactly); this fixes them.

## 1. Per-round reps (not total)
`Metric#calculated_rep_value` multiplied prescribed reps by `workout.rounds`, so a recording prefilled the **total** across all rounds (Kelly wall-ball = `30 × 5 = 150`). Now it records **one round's** reps (`30`); interval ladders (21-15-9) still record their total work.

Safe because: AMRAP already used per-round (`rounds` is nil for AMRAPs); rounds-for-time is scored by **time**, not reps; set-based lifting uses `default_value`, not this path. This also makes rounds-for-time consistent with AMRAP, which was already per-round. (Dropped the now-redundant `fixed_timed_rounds?` helper.)

## 2. Foot height rendering: `10 ft`, after load
- **`foots`**: Rails has no `foot → feet` inflection (it knows `inch → inches`, `meter → meters`), and the `ft` handling lived only on the sex-specific *prescription* path. Single foot values (used by movement-log recordings) now render `10 ft`.
- **Order**: target heights (`foot`/`inch`) now sort **after** load, so a wall-ball reads `20 lbs / 10 ft` — while travelled distance (`meter`) still leads, so `Run (400 meters / 20 lbs)` is unchanged. (Folding heights into "distance" in #1624 had made the renderer treat a target height like a travelled distance.)

**Result:** Kelly wall-ball now renders `30 Wall-ball Shots (20 lbs / 10 ft)`.

## Verification
- Reproduced the Kelly recordings before/after via `rails runner`.
- Updated the segment-rounds recording test (now per-round) and added a helper test for `20 lbs / 10 ft`.
- Full non-system suite **129 runs, 0 failures**; RuboCop clean.

> Note: #1625 (PR #1658, open) also touches the segment recording test — when it rebases on top of this, that assertion updates from `100` to `10` (per-round). I'll handle that on the #1658 rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)