### PR TITLE
Add posted_at indexes to schedules for program/date feeds (#1627)

### DIFF
--- a/db/migrate/20260617120000_add_posted_at_indexes_to_schedules.rb
+++ b/db/migrate/20260617120000_add_posted_at_indexes_to_schedules.rb
@@ -1,0 +1,6 @@
+class AddPostedAtIndexesToSchedules < ActiveRecord::Migration[8.1]
+  def change
+    add_index :schedules, [:program_id, :posted_at]
+    add_index :schedules, :posted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_16_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -129,6 +129,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_120000) do
     t.bigint "program_id"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "workout_id"
+    t.index ["posted_at"], name: "index_schedules_on_posted_at"
+    t.index ["program_id", "posted_at"], name: "index_schedules_on_program_id_and_posted_at"
     t.index ["program_id"], name: "index_schedules_on_program_id"
     t.index ["workout_id"], name: "index_schedules_on_workout_id"
   end


### PR DESCRIPTION
Closes #1627.

## Context

I investigated #1627 ("Evolve schedules into program workouts") and found most of it is already satisfied by the current schema:

- **Reusing the same workout across programs/dates already works.** `schedules` is a plain join table (`program_id`, `workout_id`, `posted_at`) with no unique index and no uniqueness validation, so a workout can be posted by many programs on many dates today.
- **The rename was intentionally skipped.** Keeping `schedules`/`Schedule` as-is; the user-facing "Schedule" feed stays named.
- **Publishing fields (title/notes/visibility/source_uid) skipped** — listed as "only if needed" and nothing requires them yet.

The one genuine gap was indexing: the date-ordered feed queries weren't indexed.

## Change

Adds two indexes to `schedules`:

- `[program_id, posted_at]` — for a program's date-ordered feed (`programs#show`: `program.schedules.order(posted_at: :desc)`)
- `[posted_at]` — for the cross-program subscriber feed (`schedules#index` via the `posted_dates` scope + per-day range filter)

`[workout_id]` already existed. Purely additive — no rename, no new columns, no association changes.

## Verification

- `bin/rails db:migrate` applied cleanly; `db/schema.rb` regenerated.
- `bin/rails test test/controllers/schedules_controller_test.rb test/models/schedule_test.rb` — green (after building assets in the fresh worktree).
- `rubocop` on the migration — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)