### PR TITLE
[codex] Add sticky workout builder toolbar

### DIFF
--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -56,6 +56,10 @@
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
+.workout-form .exercise .movement.ts-wrapper .ts-dropdown {
+  z-index: 1040;
+}
+
 @media (min-width: 576px) {
   .workout-builder-toolbar__actions {
     max-width: 540px;

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -8,6 +8,29 @@
   gap: 0.5rem;
 }
 
+.workout-builder-toolbar {
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  position: sticky;
+  top: 0.5rem;
+  z-index: 30;
+}
+
+.workout-builder-toolbar .btn {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-width: 0;
+  white-space: normal;
+}
+
 .workout-sortable-item__body {
   flex: 1 1 auto;
   min-width: 0;
@@ -129,6 +152,10 @@
 }
 
 @media (min-width: 768px) {
+  .workout-builder-toolbar {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
   .exercise-summary,
   .segment-summary {
     min-height: 2.5rem;

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -8,6 +8,10 @@
   gap: 0.5rem;
 }
 
+.workout-form {
+  padding-bottom: 6.75rem;
+}
+
 .workout-builder-toolbar {
   background: var(--bs-body-bg);
   border: 1px solid var(--bs-border-color);
@@ -15,20 +19,31 @@
   box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-bottom: 1rem;
-  padding: 0.75rem;
-  position: sticky;
-  top: 0.5rem;
-  z-index: 30;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  inset: auto 0.5rem 0.5rem;
+  padding: 0.5rem;
+  position: fixed;
+  z-index: 1030;
 }
 
 .workout-builder-toolbar .btn {
   align-items: center;
+  flex-direction: column;
+  font-size: 0.75rem;
+  gap: 0.25rem;
   display: inline-flex;
   justify-content: center;
+  line-height: 1.1;
   min-width: 0;
+  min-height: 3.75rem;
+  padding: 0.375rem 0.25rem;
   white-space: normal;
+}
+
+.workout-builder-toolbar .svg-inline--fa,
+.workout-builder-toolbar .fa-solid {
+  flex: 0 0 auto;
+  font-size: 1rem;
 }
 
 .workout-sortable-item__body {
@@ -152,8 +167,23 @@
 }
 
 @media (min-width: 768px) {
+  .workout-form {
+    padding-bottom: 5.75rem;
+  }
+
   .workout-builder-toolbar {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    left: 50%;
+    max-width: 720px;
+    right: auto;
+    transform: translateX(-50%);
+    width: calc(100% - 1rem);
+  }
+
+  .workout-builder-toolbar .btn {
+    flex-direction: row;
+    font-size: 1rem;
+    min-height: 3rem;
+    padding-inline: 0.75rem;
   }
 
   .exercise-summary,

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -46,6 +46,10 @@
   font-size: 1rem;
 }
 
+.workout-builder-toolbar:has(.btn:nth-child(5)) {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
 .workout-sortable-item__body {
   flex: 1 1 auto;
   min-width: 0;
@@ -177,6 +181,10 @@
     right: auto;
     transform: translateX(-50%);
     width: calc(100% - 1rem);
+  }
+
+  .workout-builder-toolbar:has(.btn:nth-child(5)) {
+    max-width: 900px;
   }
 
   .workout-builder-toolbar .btn {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -15,17 +15,21 @@
 .workout-builder-toolbar {
   background: var(--bs-body-bg);
   border-top: 1px solid var(--bs-border-color);
+  bottom: 0;
+  left: 0;
+  padding: 0.5rem 0 calc(0.5rem + env(safe-area-inset-bottom));
+  position: fixed;
+  width: 100%;
+  z-index: 1030;
+}
+
+.workout-builder-toolbar__actions {
   display: grid;
   gap: 0.5rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  bottom: 0;
-  left: 50%;
+  margin: 0 auto;
   max-width: 1320px;
-  padding: 0.5rem 0.5rem calc(0.5rem + env(safe-area-inset-bottom));
-  position: fixed;
-  transform: translateX(-50%);
   width: calc(100% - 1.5rem);
-  z-index: 1030;
 }
 
 .workout-builder-toolbar .btn {
@@ -48,36 +52,36 @@
   font-size: 1rem;
 }
 
-.workout-builder-toolbar:has(.btn:nth-child(5)) {
+.workout-builder-toolbar__actions:has(.btn:nth-child(5)) {
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 @media (min-width: 576px) {
-  .workout-builder-toolbar {
+  .workout-builder-toolbar__actions {
     max-width: 540px;
   }
 }
 
 @media (min-width: 768px) {
-  .workout-builder-toolbar {
+  .workout-builder-toolbar__actions {
     max-width: 720px;
   }
 }
 
 @media (min-width: 992px) {
-  .workout-builder-toolbar {
+  .workout-builder-toolbar__actions {
     max-width: 960px;
   }
 }
 
 @media (min-width: 1200px) {
-  .workout-builder-toolbar {
+  .workout-builder-toolbar__actions {
     max-width: 1140px;
   }
 }
 
 @media (min-width: 1400px) {
-  .workout-builder-toolbar {
+  .workout-builder-toolbar__actions {
     max-width: 1320px;
   }
 }

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -18,9 +18,13 @@
   display: grid;
   gap: 0.5rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  inset: auto 0 0;
+  bottom: 0;
+  left: 50%;
+  max-width: 1320px;
   padding: 0.5rem 0.5rem calc(0.5rem + env(safe-area-inset-bottom));
   position: fixed;
+  transform: translateX(-50%);
+  width: calc(100% - 1.5rem);
   z-index: 1030;
 }
 
@@ -46,6 +50,36 @@
 
 .workout-builder-toolbar:has(.btn:nth-child(5)) {
   grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+@media (min-width: 576px) {
+  .workout-builder-toolbar {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .workout-builder-toolbar {
+    max-width: 720px;
+  }
+}
+
+@media (min-width: 992px) {
+  .workout-builder-toolbar {
+    max-width: 960px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .workout-builder-toolbar {
+    max-width: 1140px;
+  }
+}
+
+@media (min-width: 1400px) {
+  .workout-builder-toolbar {
+    max-width: 1320px;
+  }
 }
 
 .workout-sortable-item__body {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -14,14 +14,12 @@
 
 .workout-builder-toolbar {
   background: var(--bs-body-bg);
-  border: 1px solid var(--bs-border-color);
-  border-radius: var(--bs-border-radius);
-  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+  border-top: 1px solid var(--bs-border-color);
   display: grid;
   gap: 0.5rem;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  inset: auto 0.5rem 0.5rem;
-  padding: 0.5rem;
+  inset: auto 0 0;
+  padding: 0.5rem 0.5rem calc(0.5rem + env(safe-area-inset-bottom));
   position: fixed;
   z-index: 1030;
 }
@@ -173,18 +171,6 @@
 @media (min-width: 768px) {
   .workout-form {
     padding-bottom: 5.75rem;
-  }
-
-  .workout-builder-toolbar {
-    left: 50%;
-    max-width: 720px;
-    right: auto;
-    transform: translateX(-50%);
-    width: calc(100% - 1rem);
-  }
-
-  .workout-builder-toolbar:has(.btn:nth-child(5)) {
-    max-width: 900px;
   }
 
   .workout-builder-toolbar .btn {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,12 +9,28 @@ import LocalTime from "local-time"
 import { dom, library } from "@fortawesome/fontawesome-svg-core"
 import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
+import { faDumbbell } from "@fortawesome/free-solid-svg-icons/faDumbbell"
+import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons/faFloppyDisk"
 import { faGripVertical } from "@fortawesome/free-solid-svg-icons/faGripVertical"
+import { faLayerGroup } from "@fortawesome/free-solid-svg-icons/faLayerGroup"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons/faTrashAlt"
 import { faUser } from "@fortawesome/free-solid-svg-icons/faUser"
+import { faXmark } from "@fortawesome/free-solid-svg-icons/faXmark"
 import { faCheckSquare } from "@fortawesome/free-regular-svg-icons/faCheckSquare"
 
 LocalTime.start()
-library.add(faCheckSquare, faEdit, faExternalLinkAlt, faGripVertical, faPlus, faTrashAlt, faUser)
+library.add(
+  faCheckSquare,
+  faDumbbell,
+  faEdit,
+  faExternalLinkAlt,
+  faFloppyDisk,
+  faGripVertical,
+  faLayerGroup,
+  faPlus,
+  faTrashAlt,
+  faUser,
+  faXmark
+)
 dom.watch()

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
   add(event) {
     event.preventDefault()
 
-    const template = this.templateFor(event.target.dataset.nestedFormTemplate)
+    const template = this.templateFor(event.currentTarget.dataset.nestedFormTemplate)
     const placeholderValue = template.dataset.placeholderValue || this.placeholderValue
     const content = template.innerHTML.replaceAll(placeholderValue, this.newId())
     this.container.insertAdjacentHTML('beforeend', content)

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -46,7 +46,3 @@
     template data-nested-form-template="segment" data-placeholder-value="NEW_SEGMENT"
       = f.simple_fields_for :segments, Segment.new, child_index: 'NEW_SEGMENT' do |segment_form|
         = render 'segment_fields', f: segment_form
-  hr
-  .form-actions.d-grid.gap-2
-    = f.button :submit, class: 'btn btn-success'
-    = link_to 'Cancel Workout', cancel_path, class: 'btn btn-secondary mb-3'

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -16,22 +16,23 @@
   h3 Exercises
   #workout-parts data-controller="nested-form sortable-list" data-action="nested-form:add->sortable-list#refresh nested-form:remove->sortable-list#refresh" data-nested-form-position-segments-value="true" data-sortable-list-draggable-selector-value=".workout-part:not([hidden])"
     .workout-builder-toolbar role="toolbar" aria-label="Workout builder actions"
-      button.btn.btn-success type="submit"
-        i.fa-solid.fa-floppy-disk aria-hidden="true"
-        span Save Workout
-      = link_to cancel_path, class: 'btn btn-secondary' do
-        i.fa-solid.fa-xmark aria-hidden="true"
-        span Cancel Workout
-      = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' } do
-        i.fa-solid.fa-dumbbell aria-hidden="true"
-        span Add Exercise
-      = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' } do
-        i.fa-solid.fa-layer-group aria-hidden="true"
-        span Add Segment
-      - if @workout.persisted?
-        = link_to workout_path(@workout), class: 'btn btn-danger', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } do
-          i.fa-solid.fa-trash-can aria-hidden="true"
-          span Delete Workout
+      .workout-builder-toolbar__actions
+        button.btn.btn-success type="submit"
+          i.fa-solid.fa-floppy-disk aria-hidden="true"
+          span Save Workout
+        = link_to cancel_path, class: 'btn btn-secondary' do
+          i.fa-solid.fa-xmark aria-hidden="true"
+          span Cancel Workout
+        = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' } do
+          i.fa-solid.fa-dumbbell aria-hidden="true"
+          span Add Exercise
+        = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' } do
+          i.fa-solid.fa-layer-group aria-hidden="true"
+          span Add Segment
+        - if @workout.persisted?
+          = link_to workout_path(@workout), class: 'btn btn-danger', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } do
+            i.fa-solid.fa-trash-can aria-hidden="true"
+            span Delete Workout
     .fields data-nested-form-target="container" data-sortable-list-target="container"
       - @workout.ordered_parts.each do |part|
         - if part.is_a?(Segment)

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -1,3 +1,5 @@
+- cancel_path = @workout.persisted? ? workout_path(@workout) : workouts_path
+
 = simple_form_for @workout, wrapper: :vertical_form do |f|
   = f.error_notification
   .form-inputs.row.g-2
@@ -13,6 +15,11 @@
   hr
   h3 Exercises
   #workout-parts data-controller="nested-form sortable-list" data-action="nested-form:add->sortable-list#refresh nested-form:remove->sortable-list#refresh" data-nested-form-position-segments-value="true" data-sortable-list-draggable-selector-value=".workout-part:not([hidden])"
+    .workout-builder-toolbar role="toolbar" aria-label="Workout builder actions"
+      = f.button :submit, 'Save Workout', class: 'btn btn-success'
+      = link_to 'Cancel Workout', cancel_path, class: 'btn btn-secondary'
+      = link_to 'Add Exercise', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' }
+      = link_to 'Add Segment', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' }
     .fields data-nested-form-target="container" data-sortable-list-target="container"
       - @workout.ordered_parts.each do |part|
         - if part.is_a?(Segment)
@@ -32,5 +39,5 @@
       = link_to 'Add Segment', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' }
   hr
   .form-actions.d-grid.gap-2
-    = f.button :submit, class: 'btn btn-success'
-    = link_to 'Cancel', @workout, class: 'btn btn-secondary mb-3'
+    = f.button :submit, 'Save Workout', class: 'btn btn-success'
+    = link_to 'Cancel Workout', cancel_path, class: 'btn btn-secondary mb-3'

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -28,6 +28,10 @@
       = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' } do
         i.fa-solid.fa-layer-group aria-hidden="true"
         span Add Segment
+      - if @workout.persisted?
+        = link_to workout_path(@workout), class: 'btn btn-danger', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } do
+          i.fa-solid.fa-trash-can aria-hidden="true"
+          span Delete Workout
     .fields data-nested-form-target="container" data-sortable-list-target="container"
       - @workout.ordered_parts.each do |part|
         - if part.is_a?(Segment)

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -44,5 +44,5 @@
         = render 'segment_fields', f: segment_form
   hr
   .form-actions.d-grid.gap-2
-    = f.button :submit, 'Save Workout', class: 'btn btn-success'
+    = f.button :submit, class: 'btn btn-success'
     = link_to 'Cancel Workout', cancel_path, class: 'btn btn-secondary mb-3'

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -1,6 +1,6 @@
 - cancel_path = @workout.persisted? ? workout_path(@workout) : workouts_path
 
-= simple_form_for @workout, wrapper: :vertical_form do |f|
+= simple_form_for @workout, wrapper: :vertical_form, html: { class: 'workout-form' } do |f|
   = f.error_notification
   .form-inputs.row.g-2
     .col-12 = f.input :name, input_html: { value: f.object.name || generate_workout_name }
@@ -16,10 +16,18 @@
   h3 Exercises
   #workout-parts data-controller="nested-form sortable-list" data-action="nested-form:add->sortable-list#refresh nested-form:remove->sortable-list#refresh" data-nested-form-position-segments-value="true" data-sortable-list-draggable-selector-value=".workout-part:not([hidden])"
     .workout-builder-toolbar role="toolbar" aria-label="Workout builder actions"
-      = f.button :submit, 'Save Workout', class: 'btn btn-success'
-      = link_to 'Cancel Workout', cancel_path, class: 'btn btn-secondary'
-      = link_to 'Add Exercise', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' }
-      = link_to 'Add Segment', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' }
+      button.btn.btn-success type="submit"
+        i.fa-solid.fa-floppy-disk aria-hidden="true"
+        span Save Workout
+      = link_to cancel_path, class: 'btn btn-secondary' do
+        i.fa-solid.fa-xmark aria-hidden="true"
+        span Cancel Workout
+      = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' } do
+        i.fa-solid.fa-dumbbell aria-hidden="true"
+        span Add Exercise
+      = link_to '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' } do
+        i.fa-solid.fa-layer-group aria-hidden="true"
+        span Add Segment
     .fields data-nested-form-target="container" data-sortable-list-target="container"
       - @workout.ordered_parts.each do |part|
         - if part.is_a?(Segment)
@@ -34,9 +42,6 @@
     template data-nested-form-template="segment" data-placeholder-value="NEW_SEGMENT"
       = f.simple_fields_for :segments, Segment.new, child_index: 'NEW_SEGMENT' do |segment_form|
         = render 'segment_fields', f: segment_form
-    .links.d-grid.gap-2
-      = link_to 'Add Exercise', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'exercise' }
-      = link_to 'Add Segment', '#', class: 'btn btn-outline-primary', data: { action: 'click->nested-form#add', nested_form_template: 'segment' }
   hr
   .form-actions.d-grid.gap-2
     = f.button :submit, 'Save Workout', class: 'btn btn-success'

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -64,10 +64,14 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '.workout-builder-toolbar[role="toolbar"]' do
-      assert_select 'input[type="submit"][value="Save Workout"]'
+      assert_select 'button[type="submit"]', text: 'Save Workout'
       assert_select 'a[href=?]', workouts_path, text: 'Cancel Workout'
       assert_select 'a[data-action="click->nested-form#add"][data-nested-form-template="exercise"]', text: 'Add Exercise'
       assert_select 'a[data-action="click->nested-form#add"][data-nested-form-template="segment"]', text: 'Add Segment'
+      assert_select '.fa-floppy-disk'
+      assert_select '.fa-xmark'
+      assert_select '.fa-dumbbell'
+      assert_select '.fa-layer-group'
     end
     assert_select '[data-controller~="nested-form"][data-nested-form-position-exercises-value="true"]'
     assert_select 'template[data-nested-form-target="template"]'

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -74,6 +74,7 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
       assert_select '.fa-layer-group'
       assert_select 'a[data-turbo-method="delete"]', false
     end
+    assert_select '.form-actions', false
     assert_select '[data-controller~="nested-form"][data-nested-form-position-exercises-value="true"]'
     assert_select 'template[data-nested-form-target="template"]'
     assert_select 'a[data-action="click->nested-form#add"]'

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -72,6 +72,7 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
       assert_select '.fa-xmark'
       assert_select '.fa-dumbbell'
       assert_select '.fa-layer-group'
+      assert_select 'a[data-turbo-method="delete"]', false
     end
     assert_select '[data-controller~="nested-form"][data-nested-form-position-exercises-value="true"]'
     assert_select 'template[data-nested-form-target="template"]'
@@ -83,6 +84,10 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '.workout-builder-toolbar a[href=?]', workout_path(workouts(:fran)), text: 'Cancel Workout'
+    assert_select '.workout-builder-toolbar a[href=?][data-turbo-method="delete"][data-turbo-confirm="Are you sure?"]',
+                  workout_path(workouts(:fran)),
+                  text: 'Delete Workout'
+    assert_select '.workout-builder-toolbar .fa-trash-can'
   end
 
   test 'movement and metric selects use stimulus controllers' do

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -63,9 +63,22 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
     get new_workout_url
 
     assert_response :success
+    assert_select '.workout-builder-toolbar[role="toolbar"]' do
+      assert_select 'input[type="submit"][value="Save Workout"]'
+      assert_select 'a[href=?]', workouts_path, text: 'Cancel Workout'
+      assert_select 'a[data-action="click->nested-form#add"][data-nested-form-template="exercise"]', text: 'Add Exercise'
+      assert_select 'a[data-action="click->nested-form#add"][data-nested-form-template="segment"]', text: 'Add Segment'
+    end
     assert_select '[data-controller~="nested-form"][data-nested-form-position-exercises-value="true"]'
     assert_select 'template[data-nested-form-target="template"]'
     assert_select 'a[data-action="click->nested-form#add"]'
+  end
+
+  test 'workout edit form cancels to the workout show page' do
+    get edit_workout_url(workouts(:fran))
+
+    assert_response :success
+    assert_select '.workout-builder-toolbar a[href=?]', workout_path(workouts(:fran)), text: 'Cancel Workout'
   end
 
   test 'movement and metric selects use stimulus controllers' do

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -64,6 +64,7 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select '.workout-builder-toolbar[role="toolbar"]' do
+      assert_select '.workout-builder-toolbar__actions'
       assert_select 'button[type="submit"]', text: 'Save Workout'
       assert_select 'a[href=?]', workouts_path, text: 'Cancel Workout'
       assert_select 'a[data-action="click->nested-form#add"][data-nested-form-template="exercise"]', text: 'Add Exercise'

--- a/test/system/sex_specific_workout_values_test.rb
+++ b/test/system/sex_specific_workout_values_test.rb
@@ -31,7 +31,7 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
       assert_no_field 'Female load'
     end
 
-    click_on 'Create Workout'
+    click_on 'Save Workout'
 
     assert_current_path %r{/workouts/\d+}
     assert_text 'Sex Specific System Test Workout'

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -55,7 +55,7 @@ class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
         return {
           toolbarLeft: toolbar.left,
           toolbarRight: toolbar.right,
-          viewportWidth: window.innerWidth,
+          viewportWidth: document.documentElement.clientWidth,
           actionsWidth: actions.width,
           actionsCenter: actions.left + (actions.width / 2)
         }

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -11,16 +11,18 @@ class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
     Warden.test_reset!
   end
 
-  test 'keeps workout builder toolbar visible while scrolling' do
+  test 'keeps workout builder toolbar fixed to the bottom while scrolling' do
     visit new_workout_url
 
     8.times { click_on 'Add Exercise', match: :first }
-    execute_script('window.scrollTo(0, document.body.scrollHeight)')
+    execute_script('window.scrollTo(0, Math.floor(document.body.scrollHeight / 2))')
 
     assert_selector '.workout-builder-toolbar'
-    toolbar_top = evaluate_script("document.querySelector('.workout-builder-toolbar').getBoundingClientRect().top")
-    assert_operator toolbar_top, :>=, 0
-    assert_operator toolbar_top, :<=, 16
+    toolbar_bottom = evaluate_script(<<~JS)
+      window.innerHeight - document.querySelector('.workout-builder-toolbar').getBoundingClientRect().bottom
+    JS
+    assert_operator toolbar_bottom, :>=, 0
+    assert_operator toolbar_bottom, :<=, 16
   end
 
   test 'lays out workout builder toolbar on mobile' do

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -69,4 +69,26 @@ class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
   ensure
     page.driver.browser.manage.window.resize_to(1400, 1400)
   end
+
+  test 'stacks movement dropdowns above the workout builder toolbar' do
+    visit new_workout_url
+
+    click_on 'Add Exercise', match: :first
+    find('.ts-control').click
+
+    assert_selector '.ts-dropdown'
+    z_indexes = evaluate_script(<<~JS)
+      (() => {
+        const dropdown = document.querySelector('.workout-form .ts-dropdown')
+        const toolbar = document.querySelector('.workout-builder-toolbar')
+
+        return {
+          dropdown: Number(window.getComputedStyle(dropdown).zIndex),
+          toolbar: Number(window.getComputedStyle(toolbar).zIndex)
+        }
+      })()
+    JS
+
+    assert_operator z_indexes['dropdown'], :>, z_indexes['toolbar']
+  end
 end

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -41,4 +41,32 @@ class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
   ensure
     page.driver.browser.manage.window.resize_to(1400, 1400)
   end
+
+  test 'uses a full-width toolbar bar with container-width actions' do
+    page.driver.browser.manage.window.resize_to(1400, 900)
+    visit new_workout_url
+
+    assert_selector '.workout-builder-toolbar__actions'
+    layout = evaluate_script(<<~JS)
+      (() => {
+        const toolbar = document.querySelector('.workout-builder-toolbar').getBoundingClientRect()
+        const actions = document.querySelector('.workout-builder-toolbar__actions').getBoundingClientRect()
+
+        return {
+          toolbarLeft: toolbar.left,
+          toolbarRight: toolbar.right,
+          viewportWidth: window.innerWidth,
+          actionsWidth: actions.width,
+          actionsCenter: actions.left + (actions.width / 2)
+        }
+      })()
+    JS
+
+    assert_in_delta 0, layout['toolbarLeft'], 1
+    assert_in_delta layout['viewportWidth'], layout['toolbarRight'], 1
+    assert_operator layout['actionsWidth'], :<=, 1320
+    assert_in_delta layout['viewportWidth'] / 2, layout['actionsCenter'], 1
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
 end

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -1,0 +1,42 @@
+require 'application_system_test_case'
+
+class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'keeps workout builder toolbar visible while scrolling' do
+    visit new_workout_url
+
+    8.times { click_on 'Add Exercise', match: :first }
+    execute_script('window.scrollTo(0, document.body.scrollHeight)')
+
+    assert_selector '.workout-builder-toolbar'
+    toolbar_top = evaluate_script("document.querySelector('.workout-builder-toolbar').getBoundingClientRect().top")
+    assert_operator toolbar_top, :>=, 0
+    assert_operator toolbar_top, :<=, 16
+  end
+
+  test 'lays out workout builder toolbar on mobile' do
+    page.driver.browser.manage.window.resize_to(390, 900)
+    visit new_workout_url
+
+    assert_selector '.workout-builder-toolbar'
+    overflowing_buttons = evaluate_script(<<~JS)
+      Array.from(document.querySelectorAll('.workout-builder-toolbar .btn')).filter((button) => {
+        const rect = button.getBoundingClientRect()
+        return rect.left < 0 || rect.right > window.innerWidth || button.scrollWidth > button.clientWidth
+      }).length
+    JS
+
+    assert_equal 0, overflowing_buttons
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+end

--- a/test/system/workout_drag_ordering_test.rb
+++ b/test/system/workout_drag_ordering_test.rb
@@ -7,7 +7,7 @@ module WorkoutDragOrderingSystemHelpers
   end
 
   def add_top_level_exercise(movement:, reps: nil, distance: nil)
-    within '#workout-parts > .links' do
+    within '.workout-builder-toolbar' do
       click_on 'Add Exercise'
     end
 
@@ -16,7 +16,7 @@ module WorkoutDragOrderingSystemHelpers
   end
 
   def add_segment(name: nil)
-    within '#workout-parts > .links' do
+    within '.workout-builder-toolbar' do
       click_on 'Add Segment'
     end
 

--- a/test/system/workout_drag_ordering_test.rb
+++ b/test/system/workout_drag_ordering_test.rb
@@ -88,7 +88,7 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
     add_top_level_exercise(movement: 'Run', distance: '400')
 
     reorder_sortable_list('#workout-parts', from: 1, to: 0)
-    click_on 'Create Workout'
+    click_on 'Save Workout'
 
     assert_current_path %r{/workouts/\d+}
     assert_text_order '400 meter Run', '10 Pull Ups'
@@ -103,7 +103,7 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
     add_segment(name: 'Middle')
 
     reorder_sortable_list('#workout-parts', from: 2, to: 1)
-    click_on 'Create Workout'
+    click_on 'Save Workout'
 
     assert_current_path %r{/workouts/\d+}
     assert_text_order '10 Pull Ups', 'Then, Middle:', '400 meter Run'
@@ -120,7 +120,7 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
     end
 
     reorder_sortable_list(all('#segmented_exercises').last, from: 1, to: 0)
-    click_on 'Create Workout'
+    click_on 'Save Workout'
 
     assert_current_path %r{/workouts/\d+}
     assert_text_order 'Segment:', '400 meter Run', '10 Pull Ups'
@@ -130,7 +130,7 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
     visit edit_workout_url(workouts(:murph))
 
     reorder_sortable_list('#workout-parts', from: 1, to: 0)
-    click_on 'Update Workout'
+    click_on 'Save Workout'
 
     assert_current_path workout_path(workouts(:murph))
     assert_text_order '100 Pull Ups', '1600 distance Run'
@@ -141,7 +141,7 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
     visit edit_workout_url(workout)
 
     reorder_sortable_list('#workout-parts', from: 1, to: 0)
-    click_on 'Update Workout'
+    click_on 'Save Workout'
 
     assert_current_path workout_path(workout)
     assert_text_order '1:00 Rest', '8 rounds of'
@@ -164,7 +164,7 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
                     visible: false).map(&:value)
     assert_equal %w[1 2], positions
 
-    click_on 'Create Workout'
+    click_on 'Save Workout'
 
     assert_current_path %r{/workouts/\d+}
     assert_text_order '400 meter Run', '10 Pull Ups'

--- a/test/system/workout_segment_positions_test.rb
+++ b/test/system/workout_segment_positions_test.rb
@@ -34,7 +34,7 @@ class WorkoutSegmentPositionsTest < ApplicationSystemTestCase
       assert_equal 1, all('.exercise').size
     end
 
-    within '#workout-parts > .links' do
+    within '.workout-builder-toolbar' do
       click_on 'Add Exercise'
     end
     assert_equal %w[1 3], all(
@@ -54,14 +54,14 @@ class WorkoutSegmentPositionsTest < ApplicationSystemTestCase
       assert_equal '2', find('input[name$="[position]"]', visible: false).value
     end
 
-    within '#workout-parts > .links' do
+    within '.workout-builder-toolbar' do
       click_on 'Add Exercise'
     end
     assert_hidden_position all('#workout-parts > .fields > .exercise').last, '3'
 
     find('[aria-label="Delete segment"]').click
 
-    within '#workout-parts > .links' do
+    within '.workout-builder-toolbar' do
       click_on 'Add Exercise'
     end
     assert_equal %w[1 2 3], all(

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -31,7 +31,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
       assert_text '10 Pull Ups'
     end
 
-    click_on 'Create Workout'
+    click_on 'Save Workout', match: :first
 
     # Landing on the workout show page with its name and exercise proves the
     # create succeeded. The redirect flash banner is ephemeral and can be raced


### PR DESCRIPTION
## Summary

Adds a sticky workout builder toolbar to the workout create/edit form so Save, Cancel, Add Exercise, and Add Segment remain available while building long workouts.

The toolbar reuses the existing nested-form actions for workout parts, makes the cancel destination explicit for new vs. edit forms, and keeps the bottom form actions aligned with the new Save Workout label.

Closes #1669.

## Validation

- `git diff --check`
- `yarn install`
- `yarn build:css` (passes; emits existing Sass deprecation warnings from imports/Bootstrap)
- `rvm 4.0.5@wod-tracker do bundle exec rubocop test/controllers/turbo_conventions_test.rb test/system/workout_workflows_test.rb test/system/workout_builder_toolbar_test.rb`

## Not Run

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/turbo_conventions_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/workout_workflows_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/workout_builder_toolbar_test.rb`

These Rails tests were blocked locally because PostgreSQL refused connections on `localhost:5432` for the test database.