### PR TITLE
Add SolidQueue + scraping/test dependencies (#1672)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,12 @@ gem 'sprockets-rails'
 # Use postgresql as the database for Active Record
 gem 'pg'
 
+# Database-backed Active Job queuing backend
+gem 'solid_queue'
+
+# HTML/XML parsing for the WOD scraper
+gem 'nokogiri'
+
 # Use Puma as the app server
 gem 'puma', '~> 8.0'
 
@@ -72,5 +78,6 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'webmock' # Stub and disable external HTTP in tests
   gem 'simplecov', '0.22.0', require: false # Version locked because of code climate issues
 end

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,6 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
   gem 'selenium-webdriver'
-  gem 'webmock' # Stub and disable external HTTP in tests
   gem 'simplecov', '0.22.0', require: false # Version locked because of code climate issues
+  gem 'webmock' # Stub and disable external HTTP in tests
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
@@ -123,9 +126,15 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     ffi (1.15.5)
+    fugit (1.12.2)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -204,6 +213,7 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -319,6 +329,13 @@ GEM
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -347,6 +364,10 @@ GEM
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -374,6 +395,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   local_time
+  nokogiri
   pg
   puma (~> 8.0)
   rails (~> 8.1.3)
@@ -387,10 +409,12 @@ DEPENDENCIES
   simple_form
   simplecov (= 0.22.0)
   slim
+  solid_queue
   sprockets-rails
   stimulus-rails
   turbo-rails
   tzinfo-data
+  webmock
 
 RUBY VERSION
    ruby 4.0.5p0

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -p $PORT -C ./config/puma.rb
+worker: bundle exec bin/jobs
 release: bundle exec rails db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server -p 3000
 js: yarn build --watch
 css: yarn build:css --watch
+worker: bin/jobs

--- a/app/jobs/noop_job.rb
+++ b/app/jobs/noop_job.rb
@@ -1,0 +1,7 @@
+class NoopJob < ApplicationJob
+  queue_as :default
+
+  # Intentionally does nothing; used to verify the SolidQueue pipeline.
+  def perform
+  end
+end

--- a/app/jobs/noop_job.rb
+++ b/app/jobs/noop_job.rb
@@ -2,6 +2,5 @@ class NoopJob < ApplicationJob
   queue_as :default
 
   # Intentionally does nothing; used to verify the SolidQueue pipeline.
-  def perform
-  end
+  def perform; end
 end

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
+require_relative '../config/environment'
 require 'solid_queue/cli'
 
 SolidQueue::Cli.start(ARGV)

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'solid_queue/cli'
+
+SolidQueue::Cli.start(ARGV)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,10 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # Use the same database-backed queuing backend as production so the bin/dev
+  # worker can process jobs locally.
+  config.active_job.queue_adapter = :solid_queue
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  # config.active_job.queue_adapter = :resque
+  config.active_job.queue_adapter = :solid_queue
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Keep Active Job on the in-memory test adapter so jobs are captured rather
+  # than dispatched to SolidQueue.
+  config.active_job.queue_adapter = :test
+
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'example.com' }
 

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: 1
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/db/migrate/20260618120000_create_solid_queue_tables.rb
+++ b/db/migrate/20260618120000_create_solid_queue_tables.rb
@@ -1,0 +1,125 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string :concurrency_key
+      t.timestamps
+
+      t.index [:active_job_id], name: 'index_solid_queue_jobs_on_active_job_id'
+      t.index [:class_name], name: 'index_solid_queue_jobs_on_class_name'
+      t.index [:finished_at], name: 'index_solid_queue_jobs_on_finished_at'
+      t.index %i[queue_name finished_at], name: 'index_solid_queue_jobs_for_filtering'
+      t.index %i[scheduled_at finished_at], name: 'index_solid_queue_jobs_for_alerting'
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.references :job, null: false, index: { unique: true }
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[scheduled_at priority job_id], name: 'index_solid_queue_dispatch_all'
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.references :job, null: false, index: { unique: true }
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[priority job_id], name: 'index_solid_queue_poll_all'
+      t.index %i[queue_name priority job_id], name: 'index_solid_queue_poll_by_queue'
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.references :job, null: false, index: { unique: true }
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index %i[process_id job_id], name: 'index_solid_queue_claimed_executions_on_process_id_and_job_id'
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.references :job, null: false, index: { unique: true }
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[expires_at concurrency_key], name: 'index_solid_queue_blocked_executions_for_maintenance'
+      t.index %i[concurrency_key priority job_id], name: 'index_solid_queue_blocked_executions_for_release'
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.references :job, null: false, index: { unique: true }
+      t.text :error
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false, index: { unique: true }
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint :supervisor_id, index: true
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+      t.datetime :created_at, null: false
+      t.string :name, null: false
+
+      t.index [:last_heartbeat_at], name: 'index_solid_queue_processes_on_last_heartbeat_at'
+      t.index %i[name supervisor_id], name: 'index_solid_queue_processes_on_name_and_supervisor_id', unique: true
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false, index: { unique: true }
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.timestamps
+
+      t.index [:expires_at], name: 'index_solid_queue_semaphores_on_expires_at'
+      t.index %i[key value], name: 'index_solid_queue_semaphores_on_key_and_value'
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.references :job, null: false, index: { unique: true }
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[task_key run_at], name: 'index_solid_queue_recurring_executions_on_task_key_and_run_at', unique: true
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false, index: { unique: true }
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, default: true, null: false, index: true
+      t.text :description
+      t.timestamps
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_17_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -150,6 +150,127 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_120000) do
     t.index ["workout_id"], name: "index_segments_on_workout_id"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.string "concurrency_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.text "arguments"
+    t.string "active_job_id"
+    t.string "class_name", null: false
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.text "metadata"
+    t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.text "arguments"
+    t.string "class_name"
+    t.string "command", limit: 2048
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "subscriptions", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.bigint "program_id"
@@ -204,6 +325,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_120000) do
   add_foreign_key "schedules", "programs"
   add_foreign_key "schedules", "workouts"
   add_foreign_key "segments", "workouts"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "subscriptions", "programs"
   add_foreign_key "subscriptions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -178,8 +178,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
-    t.text "arguments"
     t.string "active_job_id"
+    t.text "arguments"
     t.string "class_name", null: false
     t.string "concurrency_key"
     t.datetime "created_at", null: false

--- a/test/jobs/noop_job_test.rb
+++ b/test/jobs/noop_job_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class NoopJobTest < ActiveJob::TestCase
+  test 'enqueues on the default queue' do
+    assert_enqueued_with(job: NoopJob, queue: 'default') do
+      NoopJob.perform_later
+    end
+  end
+
+  test 'performs without raising' do
+    assert_nothing_raised do
+      perform_enqueued_jobs do
+        NoopJob.perform_later
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,10 @@ SimpleCov.start
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'webmock/minitest'
+
+# Disable outbound HTTP in tests; localhost stays open for Capybara/Selenium.
+WebMock.disable_net_connect!(allow_localhost: true)
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
Closes #1672. Infrastructure for the CrossFit WOD scraper epic.

## What's included
- **SolidQueue**: added `solid_queue` (1.4.0), wired `config.active_job.queue_adapter = :solid_queue` in production and development; tests keep the `:test` adapter. Added the queue schema (migration + `db/schema.rb`), `config/queue.yml`, `bin/jobs`, and `worker:` entries in `Procfile` and `Procfile.dev`.
  - Tables live in the **primary database** rather than a separate `queue` DB, since production runs off a single `DATABASE_URL`. No `connects_to` needed.
- **nokogiri**: added as an explicit dependency (previously transitive only).
- **webmock**: added to the `:test` group, required in `test/test_helper.rb`, with `WebMock.disable_net_connect!(allow_localhost: true)` so external HTTP is off by default while Capybara/Selenium still reach localhost.
- **Runtime HTTP**: unchanged — stdlib `Net::HTTP`, no new gem.
- **Smoke test**: `NoopJob` + `test/jobs/noop_job_test.rb` verify a job enqueues on the default queue and performs without raising.

## Verification (run locally under Ruby 4.0.5)
- `bundle install` — green; `Gemfile.lock` committed (solid_queue 1.4.0, webmock, fugit, et-orbi, etc.).
- `db:migrate` against Postgres regenerated `db/schema.rb`; the solid_queue tables match the gem's shipped schema.
- `bin/rails test test/jobs/noop_job_test.rb` — 2 runs, 4 assertions, 0 failures.
- **End-to-end SolidQueue**: enqueued `NoopJob` (adapter `solid_queue`, 1 ready execution), ran `bin/jobs`, confirmed it processed to completion (`finished=1, ready=0`).
- `rubocop` on changed files — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)