### PR TITLE
[codex] Use inline nested card toolbars

### DIFF
--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -100,6 +100,11 @@
   min-width: 2.25rem;
 }
 
+.exercise-editor__handle,
+.exercise-editor__delete {
+  margin-top: 2rem;
+}
+
 @media (max-width: 575.98px) {
   .workout-card-toolbar .btn {
     flex: 1 1 8rem;

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -56,8 +56,34 @@
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
+.workout-card-toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.workout-card-toolbar--start {
+  justify-content: flex-start;
+}
+
+.workout-card-toolbar .btn {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-width: 6rem;
+  white-space: normal;
+}
+
 .workout-form .exercise .movement.ts-wrapper .ts-dropdown {
   z-index: 1040;
+}
+
+@media (max-width: 575.98px) {
+  .workout-card-toolbar .btn {
+    flex: 1 1 8rem;
+  }
 }
 
 @media (min-width: 576px) {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -100,7 +100,6 @@
   min-width: 2.25rem;
 }
 
-.exercise-editor__handle,
 .exercise-editor__delete {
   margin-top: 2rem;
 }

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -80,6 +80,26 @@
   z-index: 1040;
 }
 
+.exercise-editor__movement-row {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.exercise-editor__movement {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.exercise-editor__delete {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  min-height: 2.25rem;
+  min-width: 2.25rem;
+}
+
 @media (max-width: 575.98px) {
   .workout-card-toolbar .btn {
     flex: 1 1 8rem;

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -38,14 +38,6 @@ export default class extends Controller {
     this.saveIfValid()
   }
 
-  collapseForDrag(event) {
-    if (!this.expandedValue) return
-    if (this.saveIfValid()) return
-
-    event.preventDefault()
-    event.stopImmediatePropagation()
-  }
-
   handleOpening(event) {
     if (event.detail.card === this || !this.expandedValue) return
     if (this.saveIfValid()) return

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -38,6 +38,14 @@ export default class extends Controller {
     this.saveIfValid()
   }
 
+  collapseForDrag(event) {
+    if (!this.expandedValue) return
+    if (this.saveIfValid()) return
+
+    event.preventDefault()
+    event.stopImmediatePropagation()
+  }
+
   handleOpening(event) {
     if (event.detail.card === this || !this.expandedValue) return
     if (this.saveIfValid()) return

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -19,7 +19,7 @@
       .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
         .card-body
           .exercise-editor__movement-row
-            button.workout-sortable-handle.exercise-editor__handle type="button" aria-label="Drag exercise" data-action="keydown->sortable-list#moveWithKeyboard"
+            button.workout-sortable-handle.exercise-editor__handle type="button" aria-label="Drag exercise" data-action="pointerdown->exercise-card#collapseForDrag touchstart->exercise-card#collapseForDrag keydown->exercise-card#collapseForDrag keydown->sortable-list#moveWithKeyboard"
               i.fas.fa-grip-vertical aria-hidden="true"
             .exercise-editor__movement
               = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -41,7 +41,6 @@
               = f.input :distance_units_per_rep, label: 'Distance units per rep'
           .row.g-2
             .col = f.input :notes
-          .row
-            .col.d-grid.gap-2
-              button.btn.btn-sm.btn-primary.mt-2 type="button" data-action="click->exercise-card#save" Done
-              = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }
+          .workout-card-toolbar.mt-2
+            button.btn.btn-sm.btn-primary type="button" data-action="click->exercise-card#save" Done
+            = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -19,8 +19,6 @@
       .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
         .card-body
           .exercise-editor__movement-row
-            button.workout-sortable-handle.exercise-editor__handle type="button" aria-label="Drag exercise" data-action="pointerdown->exercise-card#collapseForDrag touchstart->exercise-card#collapseForDrag keydown->exercise-card#collapseForDrag keydown->sortable-list#moveWithKeyboard"
-              i.fas.fa-grip-vertical aria-hidden="true"
             .exercise-editor__movement
               = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }
             = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -18,8 +18,13 @@
           i.fas.fa-trash-alt aria-hidden="true"
       .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
         .card-body
-          .row.g-2
-            .col-12 = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }
+          .exercise-editor__movement-row
+            button.workout-sortable-handle.exercise-editor__handle type="button" aria-label="Drag exercise" data-action="keydown->sortable-list#moveWithKeyboard"
+              i.fas.fa-grip-vertical aria-hidden="true"
+            .exercise-editor__movement
+              = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }
+            = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
+              i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
             .col-6.col-md-3 = f.input :reps, hint: '0 = max reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
             .col-6.col-md-3 = f.input :duration_seconds, label: 'Duration (s)', input_html: { data: { 'exercise-card-target': 'durationInput' } }

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -46,4 +46,3 @@
             .col = f.input :notes
           .workout-card-toolbar.mt-2
             button.btn.btn-sm.btn-primary type="button" data-action="click->exercise-card#save" Done
-            = link_to 'Delete Exercise', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }

--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -35,9 +35,8 @@
             template data-nested-form-target="template"
               = f.simple_fields_for :exercises, Exercise.new, child_index: 'CHILD_EXERCISE' do |exercise_form|
                 = render 'exercise_fields', f: exercise_form, workout_part: false
-            .links.d-grid.gap-2
+            .links.workout-card-toolbar.workout-card-toolbar--start
               = link_to 'Add Exercise', '#', class: 'btn btn-sm btn-outline-primary', data: { action: 'click->nested-form#add' }
-        .row
-          .col.d-grid.gap-2
-            button.btn.btn-sm.btn-primary.mt-2 type="button" data-action="click->segment-card#save" Done
-            = link_to 'Delete Segment', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }
+        .workout-card-toolbar.mt-2
+          button.btn.btn-sm.btn-primary type="button" data-action="click->segment-card#save" Done
+          = link_to 'Delete Segment', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }

--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -35,8 +35,7 @@
             template data-nested-form-target="template"
               = f.simple_fields_for :exercises, Exercise.new, child_index: 'CHILD_EXERCISE' do |exercise_form|
                 = render 'exercise_fields', f: exercise_form, workout_part: false
-            .links.workout-card-toolbar.workout-card-toolbar--start
+            .links.workout-card-toolbar.mt-2
               = link_to 'Add Exercise', '#', class: 'btn btn-sm btn-outline-primary', data: { action: 'click->nested-form#add' }
-        .workout-card-toolbar.mt-2
-          button.btn.btn-sm.btn-primary type="button" data-action="click->segment-card#save" Done
-          = link_to 'Delete Segment', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }
+              button.btn.btn-sm.btn-primary type="button" data-action="click->segment-card#save" Done
+              = link_to 'Delete Segment', '#', class: 'btn btn-sm btn-danger', data: { action: 'click->nested-form#remove' }

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -50,34 +50,10 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
 
     within all('#workout-parts > .fields > .exercise').last do
       within '.exercise-editor__movement-row' do
-        assert_selector '[aria-label="Drag exercise"]'
+        assert_no_selector '[aria-label="Drag exercise"]'
         assert_field 'Movement'
         assert_selector '[aria-label="Delete exercise"]'
       end
-    end
-  end
-
-  test 'collapses an expanded exercise before dragging it' do
-    visit new_workout_url
-
-    fill_in 'Name', with: 'Collapse Exercise Before Drag'
-    select 'time', from: 'For'
-    click_on 'Add Exercise'
-
-    exercise = all('#workout-parts > .fields > .exercise').last
-    within exercise do
-      find('.ts-control input').set('Pull')
-      find('.ts-dropdown .option', text: 'Pull Up').click
-      fill_in 'Reps', with: '10'
-      assert_field 'Reps'
-    end
-
-    handle = exercise.find('.exercise-editor__handle')
-    page.execute_script("arguments[0].dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))", handle)
-
-    within exercise do
-      assert_no_field 'Reps'
-      assert_text '10 Pull Ups'
     end
   end
 end

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -21,7 +21,7 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
     within all('#workout-parts > .fields > .exercise').last do
       within '.workout-card-toolbar' do
         assert_button 'Done'
-        assert_link 'Delete Exercise'
+        assert_no_link 'Delete Exercise'
       end
       assert_no_selector '.d-grid'
     end

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -1,0 +1,44 @@
+require 'application_system_test_case'
+
+class WorkoutCardToolbarTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'renders expanded card actions in inline toolbars' do
+    visit new_workout_url
+
+    fill_in 'Name', with: 'Inline Card Toolbars'
+    select 'time', from: 'For'
+    click_on 'Add Exercise'
+
+    within all('#workout-parts > .fields > .exercise').last do
+      within '.workout-card-toolbar' do
+        assert_button 'Done'
+        assert_link 'Delete Exercise'
+      end
+      assert_no_selector '.d-grid'
+    end
+
+    click_on 'Add Segment'
+
+    segment = all('#workout-parts > .fields > .workout-part[data-controller~="segment-card"]').last
+    within segment do
+      within '.links.workout-card-toolbar' do
+        assert_link 'Add Exercise'
+      end
+
+      within '.workout-card-toolbar:not(.links)' do
+        assert_button 'Done'
+        assert_link 'Delete Segment'
+      end
+      assert_no_selector '.d-grid'
+    end
+  end
+end

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -30,11 +30,10 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
 
     segment = all('#workout-parts > .fields > .workout-part[data-controller~="segment-card"]').last
     within segment do
+      assert_selector '.workout-card-toolbar', count: 1
+
       within '.links.workout-card-toolbar' do
         assert_link 'Add Exercise'
-      end
-
-      within '.workout-card-toolbar:not(.links)' do
         assert_button 'Done'
         assert_link 'Delete Segment'
       end

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -40,4 +40,20 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
       assert_no_selector '.d-grid'
     end
   end
+
+  test 'renders expanded exercise movement row actions inline' do
+    visit new_workout_url
+
+    fill_in 'Name', with: 'Inline Exercise Movement Row'
+    select 'time', from: 'For'
+    click_on 'Add Exercise'
+
+    within all('#workout-parts > .fields > .exercise').last do
+      within '.exercise-editor__movement-row' do
+        assert_selector '[aria-label="Drag exercise"]'
+        assert_field 'Movement'
+        assert_selector '[aria-label="Delete exercise"]'
+      end
+    end
+  end
 end

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -56,4 +56,28 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'collapses an expanded exercise before dragging it' do
+    visit new_workout_url
+
+    fill_in 'Name', with: 'Collapse Exercise Before Drag'
+    select 'time', from: 'For'
+    click_on 'Add Exercise'
+
+    exercise = all('#workout-parts > .fields > .exercise').last
+    within exercise do
+      find('.ts-control input').set('Pull')
+      find('.ts-dropdown .option', text: 'Pull Up').click
+      fill_in 'Reps', with: '10'
+      assert_field 'Reps'
+    end
+
+    handle = exercise.find('.exercise-editor__handle')
+    page.execute_script("arguments[0].dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))", handle)
+
+    within exercise do
+      assert_no_field 'Reps'
+      assert_text '10 Pull Ups'
+    end
+  end
 end

--- a/test/system/workout_segment_positions_test.rb
+++ b/test/system/workout_segment_positions_test.rb
@@ -29,7 +29,7 @@ class WorkoutSegmentPositionsTest < ApplicationSystemTestCase
       assert_equal %w[1 2], positions, "expected 2 exercises positions, got #{positions.inspect}"
 
       within all('.exercise').last do
-        click_on 'Delete Exercise'
+        find('[aria-label="Delete exercise"]').click
       end
       assert_equal 1, all('.exercise').size
     end


### PR DESCRIPTION
## Summary
- replace expanded exercise and segment action stacks with wrapping inline toolbars
- align segment Add Exercise with the same toolbar treatment
- add a focused system test for the nested card toolbar markup

Closes #1670

## Verification
- yarn install
- yarn build:css
- yarn build
- rvm 4.0.5@wod-tracker do bundle exec rails test test/system/workout_card_toolbar_test.rb test/system/workout_sortable_card_inputs_test.rb
- rvm 4.0.5@wod-tracker do bundle exec rubocop --parallel test/system/workout_card_toolbar_test.rb test/system/workout_sortable_card_inputs_test.rb