### PR TITLE
Render weight-scored rounds as for load (#1686)

### DIFF
--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -11,8 +11,7 @@ module WorkoutScoring
 
   def set_based_lifting?
     set_based_lifting_structure? &&
-      score_measurement == 'weight' &&
-      top_level_exercises.any?(&:load_bearing?)
+      score_measurement == 'weight'
   end
 
   def exercises_for_log_recording

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -9,6 +9,13 @@ class WorkoutsHelperTest < ActionView::TestCase
     assert_equal '5 sets for load', workout_objective(workouts(:back_squat_5x5))
   end
 
+  test 'renders weight-scored rounds as sets for load without a prescribed load' do
+    workout = workouts(:back_squat_5x5)
+    workout.exercises.each { |exercise| exercise.update!(load: nil, load_unit: nil, female_load: nil, male_load: nil) }
+
+    assert_equal '5 sets for load', workout_objective(workout.reload)
+  end
+
   test 'renders fixed-rep amraps as rounds and reps' do
     assert_equal 'As many rounds and reps as possible in 10 minutes', workout_objective(workouts(:amrap_couplet))
   end

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -46,4 +46,11 @@ class WorkoutTest < ActiveSupport::TestCase
 
     assert_not workout.set_based_lifting?
   end
+
+  test 'identifies weight-scored rounds as set-based lifting without a prescribed load' do
+    workout = workouts(:back_squat_5x5)
+    workout.exercises.each { |exercise| exercise.update!(load: nil, load_unit: nil, female_load: nil, male_load: nil) }
+
+    assert workout.reload.set_based_lifting?
+  end
 end


### PR DESCRIPTION
Fixes #1686.

## Problem
Creating a workout scored **for weight** (For = Weight, Rounds = 5, a back squat with Reps = 5, no load) rendered as **"5 rounds for time"** instead of "for load".

## Cause
`workout_objective` shows "sets for load" only when `set_based_lifting?` is true, which required `top_level_exercises.any?(&:load_bearing?)` — i.e. a *prescribed* load on an exercise. A 5×5 back squat doesn't prescribe a load; the load is the score the athlete works up to and records per set. With only reps entered, `load_bearing?` was false, so the workout fell through to `rounds_for_time?`.

## Fix
Drop the prescribed-load requirement from `set_based_lifting?`: an explicit `weight` score plus a rounds-based structure (rounds present, no time, no interval) is enough to identify set-based lifting. Scoring (`lifting_score`/`successful_set_load`) already reads the achieved load from the movement logs rather than the prescription, so weight-scored rounds without a prescribed load also log and score correctly.

Note: `Exercise#load_bearing?` is now only referenced by its own unit test. It's a legitimate domain predicate, so it was left in place rather than expanding scope.

## Tests
- `WorkoutTest`: weight-scored rounds with no prescribed load is `set_based_lifting?`.
- `WorkoutsHelperTest`: the same workout renders `5 sets for load`.
- Existing `workout`, `workouts_helper`, and `exercise` tests pass (29 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)