### PR TITLE
[codex] Seed CrossFit 260622

### DIFF
--- a/app/helpers/segments_helper.rb
+++ b/app/helpers/segments_helper.rb
@@ -1,11 +1,15 @@
 module SegmentsHelper
   def segment_objective(segment, then_prefix: false)
-    msg = then_prefix && segment.name.blank? ? 'Then, ' : ''
+    msg = then_prefix && !named_max_reps_segment?(segment) ? 'Then, ' : ''
 
     "#{msg}#{segment_prescription(segment)}"
   end
 
   private
+
+  def named_max_reps_segment?(segment)
+    segment.name.present? && segment.max_reps?
+  end
 
   def segment_prescription(segment)
     return "#{segment.interval_scheme} of" if segment.interval?

--- a/app/helpers/segments_helper.rb
+++ b/app/helpers/segments_helper.rb
@@ -1,6 +1,6 @@
 module SegmentsHelper
   def segment_objective(segment, then_prefix: false)
-    msg = then_prefix ? 'Then, ' : ''
+    msg = then_prefix && segment.name.blank? ? 'Then, ' : ''
 
     "#{msg}#{segment_prescription(segment)}"
   end
@@ -10,11 +10,16 @@ module SegmentsHelper
   def segment_prescription(segment)
     return "#{segment.interval_scheme} of" if segment.interval?
     return "#{pluralize segment.rounds, 'round'} of" if segment.rounds?
+    return max_reps_segment_prescription(segment) if segment.max_reps?
     return "As many rounds as possible in #{segment_duration(segment)}" if segment.amrap?
     return "EMOM #{segment.time_seconds / 60}" if segment.emom?
     return "#{segment.rounds} #{segment.time_seconds / 60}-minute rounds" if segment.timed_rounds?
 
     "#{segment.name.presence || 'Segment'}:"
+  end
+
+  def max_reps_segment_prescription(segment)
+    [segment.name.presence, "max reps in #{segment_duration(segment)}"].compact.join(': ')
   end
 
   def segment_duration(segment)

--- a/app/helpers/segments_helper.rb
+++ b/app/helpers/segments_helper.rb
@@ -14,12 +14,16 @@ module SegmentsHelper
   def segment_prescription(segment)
     return "#{segment.interval_scheme} of" if segment.interval?
     return "#{pluralize segment.rounds, 'round'} of" if segment.rounds?
+
+    timed_segment_prescription(segment) || "#{segment.name.presence || 'Segment'}:"
+  end
+
+  def timed_segment_prescription(segment)
     return max_reps_segment_prescription(segment) if segment.max_reps?
     return "As many rounds as possible in #{segment_duration(segment)}" if segment.amrap?
     return "EMOM #{segment.time_seconds / 60}" if segment.emom?
-    return "#{segment.rounds} #{segment.time_seconds / 60}-minute rounds" if segment.timed_rounds?
 
-    "#{segment.name.presence || 'Segment'}:"
+    "#{segment.rounds} #{segment.time_seconds / 60}-minute rounds" if segment.timed_rounds?
   end
 
   def max_reps_segment_prescription(segment)

--- a/app/helpers/workouts_helper.rb
+++ b/app/helpers/workouts_helper.rb
@@ -2,6 +2,7 @@ module WorkoutsHelper
   def workout_objective(workout)
     return "#{pluralize workout.rounds, 'set'} for load" if workout.set_based_lifting?
     return for_time_objective(workout) if workout.rounds_for_time?
+    return total_reps_clock_objective(workout) if workout.segmented_total_reps?
     return amrap_objective(workout) if workout.amrap?
     return "EMOM #{workout.time}" if workout.emom?
     return timed_rounds_objective(workout) if workout.timed_rounds?
@@ -23,6 +24,10 @@ module WorkoutsHelper
     score = workout.fixed_rep_amrap? ? 'rounds and reps' : 'rounds'
 
     "As many #{score} as possible in #{pluralize workout.time, 'minute'}"
+  end
+
+  def total_reps_clock_objective(workout)
+    "On a #{workout.time}-minute clock for total reps"
   end
 
   def timed_rounds_objective(workout)

--- a/app/javascript/controllers/segment_card_controller.js
+++ b/app/javascript/controllers/segment_card_controller.js
@@ -63,6 +63,7 @@ export default class extends Controller {
     if (rounds) return `${rounds} ${rounds === "1" ? "round" : "rounds"} of`
 
     const seconds = this.timeInSeconds()
+    if (seconds > 0 && this.hasMaxRepExercise) return this.maxRepsSummaryText(seconds)
     if (seconds > 0) return `As many rounds as possible in ${this.durationText(seconds)}`
 
     const name = this.nameInputTarget.value.trim()
@@ -82,6 +83,10 @@ export default class extends Controller {
     if (seconds % 60 === 0) return `${seconds / 60} ${seconds === 60 ? "minute" : "minutes"}`
 
     return `${seconds} ${seconds === 1 ? "second" : "seconds"}`
+  }
+
+  maxRepsSummaryText(seconds) {
+    return [this.nameInputTarget.value.trim(), `max reps in ${this.durationText(seconds)}`].filter(Boolean).join(": ")
   }
 
   renderExerciseSummaryDetails() {
@@ -112,5 +117,15 @@ export default class extends Controller {
 
   get exerciseSummaryTexts() {
     return this.exerciseSummaryElements.map((element) => element.textContent.trim()).filter(Boolean)
+  }
+
+  get hasMaxRepExercise() {
+    return this.visibleSegmentExercises.some((element) => (
+      element.querySelector("[data-exercise-card-target~='repsInput']")?.value.trim() === "0"
+    ))
+  }
+
+  get visibleSegmentExercises() {
+    return Array.from(this.editorTarget.querySelectorAll(".segment-exercise")).filter((element) => !element.hidden)
   }
 }

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -21,6 +21,10 @@ class Segment < ApplicationRecord
     time_seconds.present? && rounds.blank? && interval_scheme.blank?
   end
 
+  def max_reps?
+    amrap? && exercises.any? { |exercise| exercise.reps&.zero? }
+  end
+
   def emom?
     time_seconds.present? && rounds.present? && (time_seconds % (60 * rounds)).zero?
   end

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -22,6 +22,7 @@ class Segment < ApplicationRecord
   end
 
   def max_reps?
+    # A prescribed rep count of 0 is the app's "max reps" sentinel.
     amrap? && exercises.any? { |exercise| exercise.reps&.zero? }
   end
 

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -39,6 +39,7 @@ class Workout < ApplicationRecord
     amrap? &&
       score_measurement == 'rep' &&
       segments.any? &&
+      exercises.any? &&
       exercises.none? { |exercise| exercise.segment.blank? }
   end
 

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -35,6 +35,13 @@ class Workout < ApplicationRecord
     time.present? && rounds.blank? && interval.blank?
   end
 
+  def segmented_total_reps?
+    amrap? &&
+      score_measurement == 'rep' &&
+      segments.any? &&
+      exercises.none? { |exercise| exercise.segment.blank? }
+  end
+
   def emom?
     time.present? && rounds.present? && (time % rounds).zero?
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -165,9 +165,6 @@ Movement.find_or_create_by(name: 'Zercher Squat')
 # Programs
 cfj = Program.find_or_create_by(name: 'Crossfit Journal')
 
-# ==============================================================================
-# CrossFit Daily Workouts
-# ==============================================================================
 # 260622
 # On a 20-minute clock for total reps:
 # 0:00-5:00:
@@ -188,7 +185,7 @@ cfj = Program.find_or_create_by(name: 'Crossfit Journal')
 #
 # Female 2-inch deficit
 # Male 4-inch deficit
-crossfit_260622 = Workout.find_or_create_by(name: 'CrossFit 260622') do |workout|
+crossfit_260622 = Workout.find_or_create_by(name: 'CF-260622') do |workout|
   workout.time = 20
   workout.score_type = :rep
   workout.notes = 'Each 5-minute window begins with a 200-meter run, followed by max reps of the gymnastics movement. '\

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,6 +60,7 @@ Movement.find_or_create_by(name: 'Dumbbell Thruster')
 Movement.find_or_create_by(name: 'Dumbbell Turkish Get-up')
 Movement.find_or_create_by(name: 'Forward Roll From Support')
 Movement.find_or_create_by(name: 'Freestanding Handstand Push-up')
+freestanding_shoulder_tap = Movement.find_or_create_by(name: 'Freestanding Shoulder Tap')
 Movement.find_or_create_by(name: 'Front Scale')
 Movement.find_or_create_by(name: 'Front Squat')
 Movement.find_or_create_by(name: 'GHD Back Extension')
@@ -85,7 +86,7 @@ jumping_lunge = Movement.find_or_create_by(name: 'Jumping Lunge')
 Movement.find_or_create_by(name: 'Kettlebell Snatch')
 Movement.find_or_create_by(name: 'Kettlebell Sumo Hi Pull')
 kbswing = Movement.find_or_create_by(name: 'Kettlebell Swing')
-Movement.find_or_create_by(name: 'L Pull-up')
+l_pullup = Movement.find_or_create_by(name: 'L Pull-up')
 Movement.find_or_create_by(name: 'L Sit Hold on Matador')
 Movement.find_or_create_by(name: 'L-sit')
 Movement.find_or_create_by(name: 'L-sit on Rings')
@@ -111,6 +112,7 @@ pullup = Movement.find_or_create_by(name: 'Pull-up')
 Movement.find_or_create_by(name: 'Push Jerk')
 push_press = Movement.find_or_create_by(name: 'Push Press')
 pushup = Movement.find_or_create_by(name: 'Push-up')
+deficit_pushup = Movement.find_or_create_by(name: 'Deficit Push-up')
 Movement.find_or_create_by(name: 'Renegade Row')
 rest = Movement.find_or_create_by(name: 'Rest')
 ringdip = Movement.find_or_create_by(name: 'Ring Dip')
@@ -126,7 +128,7 @@ Movement.find_or_create_by(name: 'Shoulder to Overhead')
 pistol = Movement.find_or_create_by(name: 'Single-leg Squat (Pistol)')
 Movement.find_or_create_by(name: 'Single-under')
 situp = Movement.find_or_create_by(name: 'Sit-up')
-Movement.find_or_create_by(name: 'Skin the Cat')
+skin_the_cat = Movement.find_or_create_by(name: 'Skin the Cat')
 Movement.find_or_create_by(name: 'Slam Ball')
 Movement.find_or_create_by(name: 'Sled Pull')
 snatch = Movement.find_or_create_by(name: 'Snatch')
@@ -162,6 +164,63 @@ Movement.find_or_create_by(name: 'Zercher Squat')
 
 # Programs
 cfj = Program.find_or_create_by(name: 'Crossfit Journal')
+
+# ==============================================================================
+# CrossFit Daily Workouts
+# ==============================================================================
+# 260622
+# On a 20-minute clock for total reps:
+# 0:00-5:00:
+# 200-meter run
+# Max freestanding shoulder taps
+#
+# 5:00-10:00:
+# 200-meter run
+# Max skin-the-cats
+#
+# 10:00-15:00:
+# 200-meter run
+# Max L pull-ups
+#
+# 15:00-20:00:
+# 200-meter run
+# Max deficit push-ups
+#
+# Female 2-inch deficit
+# Male 4-inch deficit
+crossfit_260622 = Workout.find_or_create_by(name: 'CrossFit 260622') do |workout|
+  workout.time = 20
+  workout.score_type = :rep
+  workout.notes = 'Each 5-minute window begins with a 200-meter run, followed by max reps of the gymnastics movement. '\
+                  'Post total reps to comments. '\
+                  'Intermediate option: use wall-facing handstand shoulder taps, skin-the-cats, strict pull-ups, and push-ups. '\
+                  'Beginner option: use 100-meter runs with plank shoulder taps, ring hanging leg raises, foot-assisted pull-ups, and hand-elevated push-ups. '\
+                  'Source: https://www.crossfit.com/260622'
+
+  first_window = workout.segments.build(name: '0:00-5:00', time_seconds: 300, position: 1)
+  workout.exercises.build(movement: run, segment: first_window, position: 1,
+                          reps: 1, distance: 200, distance_unit: :meter)
+  workout.exercises.build(movement: freestanding_shoulder_tap, segment: first_window,
+                          position: 2, reps: 0)
+
+  second_window = workout.segments.build(name: '5:00-10:00', time_seconds: 300, position: 2)
+  workout.exercises.build(movement: run, segment: second_window, position: 1,
+                          reps: 1, distance: 200, distance_unit: :meter)
+  workout.exercises.build(movement: skin_the_cat, segment: second_window, position: 2, reps: 0)
+
+  third_window = workout.segments.build(name: '10:00-15:00', time_seconds: 300, position: 3)
+  workout.exercises.build(movement: run, segment: third_window, position: 1,
+                          reps: 1, distance: 200, distance_unit: :meter)
+  workout.exercises.build(movement: l_pullup, segment: third_window, position: 2, reps: 0)
+
+  fourth_window = workout.segments.build(name: '15:00-20:00', time_seconds: 300, position: 4)
+  workout.exercises.build(movement: run, segment: fourth_window, position: 1,
+                          reps: 1, distance: 200, distance_unit: :meter)
+  workout.exercises.build(movement: deficit_pushup, segment: fourth_window, position: 2,
+                          reps: 0, female_distance: 2, male_distance: 4, distance_unit: :inch)
+end
+
+cfj.schedules.find_or_initialize_by(workout: crossfit_260622).update(posted_at: Date.new(2026, 6, 22))
 
 # Fight Gone Bad
 # In this workout you move from each of 5 stations after a minute.

--- a/test/fixtures/exercises.yml
+++ b/test/fixtures/exercises.yml
@@ -133,3 +133,19 @@ back_squat_5x5_back_squat:
   position: 1
   reps: 5
   load_unit: lb
+
+segmented_total_reps_run:
+  workout: segmented_total_reps
+  segment: segmented_total_reps_first
+  movement: run
+  position: 1
+  reps: 1
+  distance: 200
+  distance_unit: meter
+
+segmented_total_reps_pushup:
+  workout: segmented_total_reps
+  segment: segmented_total_reps_first
+  movement: pushup
+  position: 2
+  reps: 0

--- a/test/fixtures/segments.yml
+++ b/test/fixtures/segments.yml
@@ -4,3 +4,9 @@ test:
   workout: segmented
   rounds: 10
   position: 2
+
+segmented_total_reps_first:
+  workout: segmented_total_reps
+  name: 0:00-5:00
+  time_seconds: 300
+  position: 1

--- a/test/fixtures/workouts.yml
+++ b/test/fixtures/workouts.yml
@@ -33,3 +33,8 @@ back_squat_5x5:
   name: Back Squat 5x5
   rounds: 5
   score_type: weight
+
+segmented_total_reps:
+  name: Segmented Total Reps
+  time: 20
+  score_type: rep

--- a/test/helpers/segments_helper_test.rb
+++ b/test/helpers/segments_helper_test.rb
@@ -40,6 +40,10 @@ class SegmentsHelperTest < ActionView::TestCase
     assert_equal 'Skill work:', segment_objective(Segment.new(name: 'Skill work'))
   end
 
+  test 'prefixes subsequent named segments with then' do
+    assert_equal 'Then, Middle:', segment_objective(Segment.new(name: 'Middle'), then_prefix: true)
+  end
+
   test 'falls back to a generic label for empty segments' do
     assert_equal 'Segment:', segment_objective(Segment.new)
   end

--- a/test/helpers/segments_helper_test.rb
+++ b/test/helpers/segments_helper_test.rb
@@ -17,6 +17,13 @@ class SegmentsHelperTest < ActionView::TestCase
     assert_equal 'As many rounds as possible in 90 seconds', segment_objective(Segment.new(time_seconds: 90))
   end
 
+  test 'renders named max-rep segments with their time window' do
+    segment = Segment.new(name: '0:00-5:00', time_seconds: 300)
+    segment.exercises.build(reps: 0)
+
+    assert_equal '0:00-5:00: max reps in 5 minutes', segment_objective(segment, then_prefix: true)
+  end
+
   test 'renders emom segments with their duration in minutes' do
     assert_equal 'EMOM 10', segment_objective(Segment.new(time_seconds: 600, rounds: 10))
   end

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -20,6 +20,10 @@ class WorkoutsHelperTest < ActionView::TestCase
     assert_equal 'As many rounds and reps as possible in 10 minutes', workout_objective(workouts(:amrap_couplet))
   end
 
+  test 'renders segmented rep-scored clocks as total reps' do
+    assert_equal 'On a 20-minute clock for total reps', workout_objective(workouts(:segmented_total_reps))
+  end
+
   test 'renders timed rep-scored rounds as round amraps' do
     workout = workouts(:back_squat_5x5)
     workout.update!(time: 3, score_type: :rep)

--- a/test/models/segment_test.rb
+++ b/test/models/segment_test.rb
@@ -49,6 +49,13 @@ class SegmentTest < ActiveSupport::TestCase
     assert_not_predicate Segment.new(rounds: 4), :timed_rounds?
   end
 
+  test 'identifies max-rep segments by zero-rep exercises' do
+    segment = Segment.new(time_seconds: 300)
+    segment.exercises.build(reps: 0)
+
+    assert_predicate segment, :max_reps?
+  end
+
   test 'identifies interval segments by their scheme' do
     assert_predicate Segment.new(interval_scheme: '21-15-9'), :interval?
     assert_not_predicate Segment.new, :interval?

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -28,6 +28,17 @@ class WorkoutTest < ActiveSupport::TestCase
     assert_nil workouts(:amrap_unknown_distance).amrap_reps_per_round
   end
 
+  test 'identifies segmented total-rep clocks' do
+    assert_predicate workouts(:segmented_total_reps), :segmented_total_reps?
+  end
+
+  test 'does not identify empty segmented clocks as total-rep clocks' do
+    workout = Workout.new(name: 'Empty Segments', time: 20, score_type: :rep)
+    workout.segments.build(time_seconds: 300, position: 1)
+
+    assert_not_predicate workout, :segmented_total_reps?
+  end
+
   test 'distance scoring takes precedence over legacy rep marker' do
     component = exercises(:amrap_mixed_row).score_component
 

--- a/test/system/workout_sortable_card_inputs_test.rb
+++ b/test/system/workout_sortable_card_inputs_test.rb
@@ -54,6 +54,22 @@ class WorkoutSortableCardInputsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'preserves max reps segment summaries after expanding and collapsing' do
+    visit edit_workout_url(workouts(:segmented_total_reps))
+
+    segment = find('#workout-parts > .fields > .workout-part[data-controller~="segment-card"]')
+    within segment do
+      assert_text '0:00-5:00: max reps in 5 minutes'
+
+      find('.segment-summary__button').click
+      assert_field 'Time seconds', with: '300'
+      click_on 'Done'
+
+      assert_text '0:00-5:00: max reps in 5 minutes'
+      assert_no_text 'As many rounds as possible in 5 minutes'
+    end
+  end
+
   test 'shows segment drag handles only while collapsed' do
     visit new_workout_url
 


### PR DESCRIPTION
## Summary

- seed CrossFit daily workout 260622 from https://www.crossfit.com/260622
- add missing source movement names for freestanding shoulder taps and deficit push-ups
- render segmented total-rep clocks as `On a 20-minute clock for total reps`
- render named max-rep timed segments with their time windows

## Modeling

This workout is four 5-minute windows scored by total reps. Each window starts with a 200-meter run and then max reps of one gymnastics movement. The existing segment model can represent the structure, but the old objective text rendered these workouts like AMRAP rounds. This PR adds a narrow rendering path for segmented total-rep clocks so the seeded workout does not display misleadingly.

## Validation

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/helpers/workouts_helper_test.rb test/helpers/segments_helper_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec ruby -c db/seeds.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails runner "load Rails.root.join('db/seeds.rb'); ..."`
- `git diff --check`

The Rails runner confirmed: `CrossFit 260622 | rep | 20 | 4 | 8 | 2026-06-22`.
