### PR TITLE
Add implement count for dumbbell and kettlebell loads

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -84,7 +84,7 @@ class LogsController < ApplicationController
                     {
                       movement_logs_attributes: [[
                         :id, :movement_id,
-                        :reps, :duration_seconds, :load, :load_unit,
+                        :reps, :duration_seconds, :load, :load_unit, :implement_count,
                         :distance, :distance_unit, :calories, :notes
                       ]]
                     }

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -79,7 +79,7 @@ class WorkoutsController < ApplicationController
   def workout_params
     exercise_params = [:id, :movement_id, :position, :distance_units_per_rep, :_destroy,
                        :reps, :duration_seconds,
-                       :load, :female_load, :male_load, :load_unit,
+                       :load, :female_load, :male_load, :load_unit, :implement_count,
                        :distance, :female_distance, :male_distance, :distance_unit,
                        :calories, :female_calories, :male_calories, :notes]
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,10 @@ module ApplicationHelper
   def nav_item_class(name)
     "nav-item nav-link #{'active' if controller_name.to_sym.eql? name}"
   end
+
+  # Ids of movements whose forms should show the implement-count field. Memoized per request so
+  # the workout builder's many exercise rows share one query.
+  def implement_count_movement_ids
+    @implement_count_movement_ids ||= Movement.supporting_implement_count.ids
+  end
 end

--- a/app/helpers/metrics_helper.rb
+++ b/app/helpers/metrics_helper.rb
@@ -2,6 +2,18 @@ module MetricsHelper
   HEIGHT_MEASUREMENTS = %w[foot inch].freeze
 
   def metric_unit_msg(metric)
+    "#{implement_count_prefix(metric)}#{metric_value_msg(metric)}"
+  end
+
+  # `2×` qualifier for load held in multiple implements (e.g. double-dumbbell). Renders before the
+  # load so `♀35lb / ♂50lb` dumbbells become `2×♀35lb / ♂50lb`.
+  def implement_count_prefix(metric)
+    return '' unless metric.respond_to?(:multiple_implements?) && metric.multiple_implements?
+
+    "#{metric.implement_count}×"
+  end
+
+  def metric_value_msg(metric)
     return sex_specific_metric_unit_msg(metric) if metric.sex_specific?
     return "#{metric.value.to_i} ft" if metric.foot? # Rails has no foot -> feet inflection
     return pluralize(1, metric.measurement) if metric.value.nil?

--- a/app/javascript/controllers/implement_count_controller.js
+++ b/app/javascript/controllers/implement_count_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Shows the implement-count field only for movements that support single/double loading
+// (dumbbell, kettlebell). The supported movement ids come from the server; swap that source for
+// the equipment taxonomy once it lands.
+export default class extends Controller {
+  static targets = ["field", "movementSelect"]
+  static values = { movementIds: Array }
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle(event) {
+    if (!this.hasFieldTarget || !this.hasMovementSelectTarget) return
+
+    const supported = this.movementIdsValue.includes(Number(this.movementSelectTarget.value))
+    this.fieldTarget.hidden = !supported
+
+    if (!supported && event) this.clearInput()
+  }
+
+  clearInput() {
+    const input = this.fieldTarget.querySelector("input")
+    if (input) input.value = ""
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("exercise-form", ExerciseFormController)
 import ExerciseCardController from "./exercise_card_controller.js"
 application.register("exercise-card", ExerciseCardController)
 
+import ImplementCountController from "./implement_count_controller.js"
+application.register("implement-count", ImplementCountController)
+
 import SegmentCardController from "./segment_card_controller.js"
 application.register("segment-card", SegmentCardController)
 

--- a/app/models/concerns/exercise_prescription.rb
+++ b/app/models/concerns/exercise_prescription.rb
@@ -36,7 +36,8 @@ module ExercisePrescription
   def load_prescription_metric
     return unless load_unit.present? || load.present? || female_load.present? || male_load.present?
 
-    Metric.new(measurement: load_unit || :lb, value: load, female_value: female_load, male_value: male_load)
+    Metric.new(measurement: load_unit || :lb, value: load, female_value: female_load, male_value: male_load,
+               implement_count: implement_count)
   end
 
   def distance_prescription_metric

--- a/app/models/concerns/movement_log_performance.rb
+++ b/app/models/concerns/movement_log_performance.rb
@@ -29,7 +29,7 @@ module MovementLogPerformance
   def clear_blank_performance_units
     if load.blank?
       self.load_unit = nil
-      self.implement_count = nil
+      self.implement_count = 1 # reset the load qualifier to its single-implement default
     end
     self.distance_unit = nil if distance.blank?
   end

--- a/app/models/concerns/movement_log_performance.rb
+++ b/app/models/concerns/movement_log_performance.rb
@@ -27,13 +27,20 @@ module MovementLogPerformance
   # The recording form always submits a unit (defaulting to lb/meter) for every movement log, so a
   # dimension the athlete left blank would otherwise persist an orphan unit and build a stray metric.
   def clear_blank_performance_units
-    self.load_unit = nil if load.blank?
+    if load.blank?
+      self.load_unit = nil
+      self.implement_count = nil
+    end
     self.distance_unit = nil if distance.blank?
   end
 
   def rep_metric = (Metric.new(measurement: :rep, value: reps) if records_reps?)
   def duration_metric = (Metric.new(measurement: :seconds, value: duration_seconds) if records_duration?)
-  def load_metric = (Metric.new(measurement: load_unit || :lb, value: load) if records_load?)
+
+  def load_metric
+    Metric.new(measurement: load_unit || :lb, value: load, implement_count: implement_count) if records_load?
+  end
+
   def calorie_metric = (Metric.new(measurement: :calorie, value: calories) if records_calories?)
 
   def distance_metric

--- a/app/models/concerns/movement_log_performance.rb
+++ b/app/models/concerns/movement_log_performance.rb
@@ -29,7 +29,7 @@ module MovementLogPerformance
   def clear_blank_performance_units
     if load.blank?
       self.load_unit = nil
-      self.implement_count = 1 # reset the load qualifier to its single-implement default
+      self.implement_count = nil
     end
     self.distance_unit = nil if distance.blank?
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -91,7 +91,7 @@ class Exercise < ApplicationRecord
   end
 
   def implement_count_requires_load
-    return if implement_count.blank?
+    return if implement_count.to_i <= 1 # a single implement is the default and needs no load
 
     errors.add(:implement_count, 'requires a load') unless load_bearing?
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -18,8 +18,12 @@ class Exercise < ApplicationRecord
   validates :distance_units_per_rep,
             numericality: { only_integer: true, greater_than: 0 },
             allow_nil: true
+  validates :implement_count,
+            numericality: { only_integer: true, greater_than: 0 },
+            allow_nil: true
   validate :prescription_values_are_unambiguous
   validate :distance_units_per_rep_matches_prescribed_distance
+  validate :implement_count_requires_load
 
   def score_component
     return distance_score_component if distance_units_per_rep.present?
@@ -84,6 +88,12 @@ class Exercise < ApplicationRecord
         errors.add(:base, "#{dimension} requires both female and male values")
       end
     end
+  end
+
+  def implement_count_requires_load
+    return if implement_count.blank?
+
+    errors.add(:implement_count, 'requires a load') unless load_bearing?
   end
 
   def distance_units_per_rep_matches_prescribed_distance

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -17,7 +17,7 @@ class Metric
   ].freeze
 
   attr_accessor :value, :female_value, :male_value
-  attr_reader :measurement
+  attr_reader :measurement, :implement_count
 
   def self.measurements
     @measurements ||= MEASUREMENTS.stringify_keys.freeze
@@ -31,12 +31,18 @@ class Metric
     RECORDING_MEASUREMENT_ORDER.index(measurement.to_s) || RECORDING_MEASUREMENT_ORDER.length
   end
 
-  def initialize(measurement:, value: nil, female_value: nil, male_value: nil)
+  def initialize(measurement:, value: nil, female_value: nil, male_value: nil, implement_count: nil)
     @measurement = measurement.to_s
     @value = value
     @female_value = female_value
     @male_value = male_value
+    @implement_count = implement_count || 1
   end
+
+  # Number of implements (e.g. dumbbells, kettlebells) the prescribed load is held in. The load
+  # value is per-implement, so a single 50lb dumbbell and a double 50lb dumbbell share the same
+  # value but differ in count.
+  def multiple_implements? = implement_count > 1
 
   MEASUREMENTS.each_key do |name|
     define_method(:"#{name}?") { measurement == name.to_s }

--- a/app/models/movement.rb
+++ b/app/models/movement.rb
@@ -1,8 +1,18 @@
 class Movement < ApplicationRecord
+  # Single vs. double loading only applies to handheld implements. Detected by name for now;
+  # swap this for the equipment taxonomy (#1629) once it lands.
+  IMPLEMENT_COUNT_NAME_PATTERN = /dumbbell|kettlebell/i
+
   has_many :exercises, dependent: :destroy
   has_many :movement_logs, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  scope :supporting_implement_count, -> { where('name ~* ?', IMPLEMENT_COUNT_NAME_PATTERN.source) }
+
+  def supports_implement_count?
+    name.to_s.match?(IMPLEMENT_COUNT_NAME_PATTERN)
+  end
 
   def self.search_by_name(name)
     return all unless name

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -20,9 +20,9 @@
   h2.mt-3 Exercise Recordings
   = f.simple_fields_for :movement_logs do |ml_form|
     - ml = ml_form.object
-    .card.mb-3
+    .card.mb-3 data-controller="implement-count" data-action="change->implement-count#toggle" data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
       .card-body
-        = ml_form.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select' } }, label: false
+        = ml_form.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'implement-count-target': 'movementSelect' } }, label: false
         / Always render every recording dimension so a scaled movement (e.g. rowing calories in
         / place of a prescribed run) can be logged, not only the prescribed dimensions.
         .row.g-2
@@ -31,7 +31,8 @@
           .col
             = ml_form.input :load, label: "Load (#{ml.load_unit || 'lb'})", input_html: { class: 'recording-value' }
             = ml_form.hidden_field :load_unit, value: ml.load_unit || 'lb'
-          .col = ml_form.input :implement_count, label: 'Implements'
+          .col data-implement-count-target="field" hidden=(!ml.movement&.supports_implement_count?)
+            = ml_form.input :implement_count, label: 'Implements'
           .col
             = ml_form.input :distance, label: "Distance (#{ml.distance_unit || 'meter'})", input_html: { class: 'recording-value' }
             = ml_form.hidden_field :distance_unit, value: ml.distance_unit || 'meter'

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -31,7 +31,7 @@
           .col
             = ml_form.input :load, label: "Load (#{ml.load_unit || 'lb'})", input_html: { class: 'recording-value' }
             = ml_form.hidden_field :load_unit, value: ml.load_unit || 'lb'
-          .col = ml_form.input :implement_count, label: 'Implements', input_html: { class: 'recording-value' }
+          .col = ml_form.input :implement_count, label: 'Implements'
           .col
             = ml_form.input :distance, label: "Distance (#{ml.distance_unit || 'meter'})", input_html: { class: 'recording-value' }
             = ml_form.hidden_field :distance_unit, value: ml.distance_unit || 'meter'

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -31,6 +31,7 @@
           .col
             = ml_form.input :load, label: "Load (#{ml.load_unit || 'lb'})", input_html: { class: 'recording-value' }
             = ml_form.hidden_field :load_unit, value: ml.load_unit || 'lb'
+          .col = ml_form.input :implement_count, label: 'Implements', input_html: { class: 'recording-value' }
           .col
             = ml_form.input :distance, label: "Distance (#{ml.distance_unit || 'meter'})", input_html: { class: 'recording-value' }
             = ml_form.hidden_field :distance_unit, value: ml.distance_unit || 'meter'

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -4,7 +4,7 @@
 - summary = f.object.persisted? ? measurable_message(f.object) : 'New exercise'
 - workout_part = local_assigns.fetch(:workout_part, false)
 
-.exercise.nested-fields.mb-3 class=(workout_part ? 'workout-part' : 'segment-exercise') data-controller="exercise-form exercise-card" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError" data-exercise-card-expanded-value=expanded
+.exercise.nested-fields.mb-3 class=(workout_part ? 'workout-part' : 'segment-exercise') data-controller="exercise-form exercise-card implement-count" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError change->implement-count#toggle" data-exercise-card-expanded-value=expanded data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
   = f.hidden_field :_destroy
   = f.hidden_field :position
   .workout-sortable-item
@@ -20,7 +20,7 @@
         .card-body
           .exercise-editor__movement-row
             .exercise-editor__movement
-              = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect' } }
+              = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect', 'implement-count-target': 'movementSelect' } }
             = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
               i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
@@ -31,7 +31,8 @@
             .col-6.col-md-3 = f.input :female_load, input_html: { data: { 'exercise-card-target': 'femaleLoadInput' } }
             .col-6.col-md-3 = f.input :male_load, input_html: { data: { 'exercise-card-target': 'maleLoadInput' } }
             .col-6.col-md-3 = f.input :load_unit, collection: Exercise.load_units.keys, prompt: 'Load unit', input_html: { data: { 'exercise-card-target': 'loadUnitSelect' } }
-            .col-6.col-md-3 = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
+            .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
+              = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
           .row.g-2
             .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'distanceInput' } }
             .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'femaleDistanceInput' } }

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -31,6 +31,7 @@
             .col-6.col-md-3 = f.input :female_load, input_html: { data: { 'exercise-card-target': 'femaleLoadInput' } }
             .col-6.col-md-3 = f.input :male_load, input_html: { data: { 'exercise-card-target': 'maleLoadInput' } }
             .col-6.col-md-3 = f.input :load_unit, collection: Exercise.load_units.keys, prompt: 'Load unit', input_html: { data: { 'exercise-card-target': 'loadUnitSelect' } }
+            .col-6.col-md-3 = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
           .row.g-2
             .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'distanceInput' } }
             .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'femaleDistanceInput' } }

--- a/cf/docs/movement-standards.md
+++ b/cf/docs/movement-standards.md
@@ -25,3 +25,15 @@ should use one `lb` metric and one `foot` metric.
 loads can be sex-specific. Relative loads such as `body weight` or
 `1 1/2 body weight` should remain as `weight` values unless the source gives a
 specific female/male numeric pair.
+
+## Implement Count
+
+Dumbbell and kettlebell movements can be prescribed with one or two implements,
+and the difference matters: a single 50lb dumbbell thruster is easier than a
+double (two-dumbbell) 50lb thruster. The prescribed load is **per implement**, so
+both share the same `lb` value and differ only in how many implements are held.
+
+Model this with the `implement_count` column on `exercises` and `movement_logs`
+(blank/`1` = single). It renders as a `2×` prefix on the load, so a double 50lb
+dumbbell thruster shows as `2×♀35lb / ♂50lb`. An `implement_count` is only
+meaningful alongside a load.

--- a/cf/docs/movement-standards.md
+++ b/cf/docs/movement-standards.md
@@ -33,7 +33,7 @@ and the difference matters: a single 50lb dumbbell thruster is easier than a
 double (two-dumbbell) 50lb thruster. The prescribed load is **per implement**, so
 both share the same `lb` value and differ only in how many implements are held.
 
-Model this with the `implement_count` column on `exercises` and `movement_logs`
-(defaults to `1` = single). It renders as a `2×` prefix on the load, so a double
-50lb dumbbell thruster shows as `2×♀35lb / ♂50lb`. A count above `1` requires a
-load; the single-implement default needs none.
+Model this with the `implement_count` column on `exercises` and `movement_logs`.
+It has no default: a blank count means a single implement, so only multi-implement
+prescriptions set it. It renders as a `2×` prefix on the load, so a double 50lb
+dumbbell thruster shows as `2×♀35lb / ♂50lb`. A count above `1` requires a load.

--- a/cf/docs/movement-standards.md
+++ b/cf/docs/movement-standards.md
@@ -34,6 +34,6 @@ double (two-dumbbell) 50lb thruster. The prescribed load is **per implement**, s
 both share the same `lb` value and differ only in how many implements are held.
 
 Model this with the `implement_count` column on `exercises` and `movement_logs`
-(blank/`1` = single). It renders as a `2×` prefix on the load, so a double 50lb
-dumbbell thruster shows as `2×♀35lb / ♂50lb`. An `implement_count` is only
-meaningful alongside a load.
+(defaults to `1` = single). It renders as a `2×` prefix on the load, so a double
+50lb dumbbell thruster shows as `2×♀35lb / ♂50lb`. A count above `1` requires a
+load; the single-implement default needs none.

--- a/cf/docs/movement-standards.md
+++ b/cf/docs/movement-standards.md
@@ -37,3 +37,8 @@ Model this with the `implement_count` column on `exercises` and `movement_logs`.
 It has no default: a blank count means a single implement, so only multi-implement
 prescriptions set it. It renders as a `2×` prefix on the load, so a double 50lb
 dumbbell thruster shows as `2×♀35lb / ♂50lb`. A count above `1` requires a load.
+
+The field only applies to handheld implements, so the workout and log forms surface
+it only for movements where `Movement#supports_implement_count?` is true. That check
+is name-based (dumbbell/kettlebell) until the equipment taxonomy (#1629) lands, at
+which point it should key off equipment instead.

--- a/db/migrate/20260624120000_add_implement_count_to_loaded_movements.rb
+++ b/db/migrate/20260624120000_add_implement_count_to_loaded_movements.rb
@@ -1,6 +1,6 @@
 class AddImplementCountToLoadedMovements < ActiveRecord::Migration[8.1]
   def change
-    add_column :exercises, :implement_count, :integer
-    add_column :movement_logs, :implement_count, :integer
+    add_column :exercises, :implement_count, :integer, default: 1
+    add_column :movement_logs, :implement_count, :integer, default: 1
   end
 end

--- a/db/migrate/20260624120000_add_implement_count_to_loaded_movements.rb
+++ b/db/migrate/20260624120000_add_implement_count_to_loaded_movements.rb
@@ -1,6 +1,6 @@
 class AddImplementCountToLoadedMovements < ActiveRecord::Migration[8.1]
   def change
-    add_column :exercises, :implement_count, :integer, default: 1
-    add_column :movement_logs, :implement_count, :integer, default: 1
+    add_column :exercises, :implement_count, :integer
+    add_column :movement_logs, :implement_count, :integer
   end
 end

--- a/db/migrate/20260624120000_add_implement_count_to_loaded_movements.rb
+++ b/db/migrate/20260624120000_add_implement_count_to_loaded_movements.rb
@@ -1,0 +1,6 @@
+class AddImplementCountToLoadedMovements < ActiveRecord::Migration[8.1]
+  def change
+    add_column :exercises, :implement_count, :integer
+    add_column :movement_logs, :implement_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
     t.integer "female_calories"
     t.integer "female_distance"
     t.integer "female_load"
-    t.integer "implement_count"
+    t.integer "implement_count", default: 1
     t.integer "load"
     t.integer "load_unit"
     t.integer "male_calories"
@@ -100,7 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
     t.integer "distance"
     t.integer "distance_unit"
     t.integer "duration_seconds"
-    t.integer "implement_count"
+    t.integer "implement_count", default: 1
     t.integer "load"
     t.integer "load_unit"
     t.bigint "log_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
     t.integer "female_calories"
     t.integer "female_distance"
     t.integer "female_load"
+    t.integer "implement_count"
     t.integer "load"
     t.integer "load_unit"
     t.integer "male_calories"
@@ -99,6 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
     t.integer "distance"
     t.integer "distance_unit"
     t.integer "duration_seconds"
+    t.integer "implement_count"
     t.integer "load"
     t.integer "load_unit"
     t.bigint "log_id"
@@ -305,6 +307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
   end
 
   create_table "workouts", force: :cascade do |t|
+    t.string "content_key"
     t.datetime "created_at", precision: nil, null: false
     t.string "interval"
     t.string "name"
@@ -313,6 +316,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_120000) do
     t.integer "time"
     t.integer "time_cap_seconds"
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["content_key"], name: "index_workouts_on_content_key", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
     t.integer "female_calories"
     t.integer "female_distance"
     t.integer "female_load"
-    t.integer "implement_count", default: 1
+    t.integer "implement_count"
     t.integer "load"
     t.integer "load_unit"
     t.integer "male_calories"
@@ -100,7 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
     t.integer "distance"
     t.integer "distance_unit"
     t.integer "duration_seconds"
-    t.integer "implement_count", default: 1
+    t.integer "implement_count"
     t.integer "load"
     t.integer "load_unit"
     t.bigint "log_id"

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -14,6 +14,15 @@ class MeasurableHelperTest < ActionView::TestCase
     assert_equal 'Pull Up (♀65lb / ♂95lb)', measurable_message(exercise)
   end
 
+  test 'renders multi-implement dumbbell load with a count prefix' do
+    thruster = Movement.create!(name: 'Dumbbell Thruster')
+    exercise = workouts(:fran).exercises.create!(movement: thruster, position: 3, reps: 10,
+                                                 load_unit: :lb, female_load: 35, male_load: 50,
+                                                 implement_count: 2)
+
+    assert_equal '10 Dumbbell Thrusters (2×♀35lb / ♂50lb)', measurable_message(exercise)
+  end
+
   test 'groups multiple sex-specific additional exercise metrics by sex' do
     wall_ball = Movement.create!(name: 'Wall-ball Shot')
     exercise = workouts(:fran).exercises.create!(movement: wall_ball, position: 3,

--- a/test/helpers/metrics_helper_test.rb
+++ b/test/helpers/metrics_helper_test.rb
@@ -24,6 +24,24 @@ class MetricsHelperTest < ActionView::TestCase
     assert_equal '♀65lb / ♂95lb', metric_unit_msg(metric)
   end
 
+  test 'prefixes multi-implement load with the implement count' do
+    metric = Metric.new(measurement: :lb, value: 50, implement_count: 2)
+
+    assert_equal '2×50 lbs', metric_unit_msg(metric)
+  end
+
+  test 'prefixes multi-implement sex-specific load with the implement count' do
+    metric = Metric.new(measurement: :lb, female_value: 35, male_value: 50, implement_count: 2)
+
+    assert_equal '2×♀35lb / ♂50lb', metric_unit_msg(metric)
+  end
+
+  test 'does not prefix single-implement load' do
+    metric = Metric.new(measurement: :lb, value: 50, implement_count: 1)
+
+    assert_equal '50 lbs', metric_unit_msg(metric)
+  end
+
   test 'renders paired female and male height values' do
     metric = Metric.new(measurement: :inch, female_value: 20, male_value: 24)
 

--- a/test/models/exercise_implement_count_test.rb
+++ b/test/models/exercise_implement_count_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ExerciseImplementCountTest < ActiveSupport::TestCase
+  test 'rejects a non-positive implement count' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               load_unit: :lb, load: 50, implement_count: 0)
+
+    assert_not exercise.valid?
+    assert exercise.errors[:implement_count].present?
+  end
+
+  test 'requires a load when an implement count is configured' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               reps: 21, implement_count: 2)
+
+    assert_not exercise.valid?
+    assert_includes exercise.errors[:implement_count], 'requires a load'
+  end
+
+  test 'allows an implement count alongside a load' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
+                                               load_unit: :lb, load: 50, implement_count: 2)
+
+    assert_predicate exercise, :valid?
+  end
+end

--- a/test/models/exercise_implement_count_test.rb
+++ b/test/models/exercise_implement_count_test.rb
@@ -9,14 +9,14 @@ class ExerciseImplementCountTest < ActiveSupport::TestCase
     assert exercise.errors[:implement_count].present?
   end
 
-  test 'defaults a new exercise to a single implement' do
-    assert_equal 1, Exercise.new.implement_count
+  test 'leaves the implement count unset by default' do
+    assert_nil Exercise.new.implement_count
   end
 
-  test 'allows the default single implement without a load' do
+  test 'allows a movement without an implement count or load' do
     exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, reps: 21)
 
-    assert_equal 1, exercise.implement_count
+    assert_nil exercise.implement_count
     assert_predicate exercise, :valid?
   end
 

--- a/test/models/exercise_implement_count_test.rb
+++ b/test/models/exercise_implement_count_test.rb
@@ -9,7 +9,18 @@ class ExerciseImplementCountTest < ActiveSupport::TestCase
     assert exercise.errors[:implement_count].present?
   end
 
-  test 'requires a load when an implement count is configured' do
+  test 'defaults a new exercise to a single implement' do
+    assert_equal 1, Exercise.new.implement_count
+  end
+
+  test 'allows the default single implement without a load' do
+    exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3, reps: 21)
+
+    assert_equal 1, exercise.implement_count
+    assert_predicate exercise, :valid?
+  end
+
+  test 'requires a load when more than one implement is configured' do
     exercise = workouts(:fran).exercises.build(movement: movements(:pullup), position: 3,
                                                reps: 21, implement_count: 2)
 

--- a/test/models/measurement_test.rb
+++ b/test/models/measurement_test.rb
@@ -1,7 +1,17 @@
 require 'test_helper'
 
 class MeasurementTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'defaults to a single implement' do
+    metric = Metric.new(measurement: :lb, value: 50)
+
+    assert_equal 1, metric.implement_count
+    assert_not metric.multiple_implements?
+  end
+
+  test 'treats a count above one as multiple implements' do
+    metric = Metric.new(measurement: :lb, value: 50, implement_count: 2)
+
+    assert_equal 2, metric.implement_count
+    assert_predicate metric, :multiple_implements?
+  end
 end

--- a/test/models/movement_log_test.rb
+++ b/test/models/movement_log_test.rb
@@ -10,11 +10,15 @@ class MovementLogTest < ActiveSupport::TestCase
     assert_equal 2, load_metric.implement_count
   end
 
-  test 'clears the implement count when no load is recorded' do
+  test 'resets the implement count to one when no load is recorded' do
     movement_log = movement_logs(:brooke_fran_thruster)
     movement_log.assign_attributes(load: nil, load_unit: :lb, implement_count: 2)
     movement_log.validate
 
-    assert_nil movement_log.implement_count
+    assert_equal 1, movement_log.implement_count
+  end
+
+  test 'defaults a new movement log to a single implement' do
+    assert_equal 1, MovementLog.new.implement_count
   end
 end

--- a/test/models/movement_log_test.rb
+++ b/test/models/movement_log_test.rb
@@ -10,15 +10,11 @@ class MovementLogTest < ActiveSupport::TestCase
     assert_equal 2, load_metric.implement_count
   end
 
-  test 'resets the implement count to one when no load is recorded' do
+  test 'clears the implement count when no load is recorded' do
     movement_log = movement_logs(:brooke_fran_thruster)
     movement_log.assign_attributes(load: nil, load_unit: :lb, implement_count: 2)
     movement_log.validate
 
-    assert_equal 1, movement_log.implement_count
-  end
-
-  test 'defaults a new movement log to a single implement' do
-    assert_equal 1, MovementLog.new.implement_count
+    assert_nil movement_log.implement_count
   end
 end

--- a/test/models/movement_log_test.rb
+++ b/test/models/movement_log_test.rb
@@ -1,7 +1,20 @@
 require 'test_helper'
 
 class MovementLogTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'records the implement count on the load metric' do
+    movement_log = movement_logs(:brooke_fran_thruster)
+    movement_log.update!(load: 50, load_unit: :lb, implement_count: 2)
+
+    load_metric = movement_log.prescription_metrics.find { |metric| metric.measurement == 'lb' }
+
+    assert_equal 2, load_metric.implement_count
+  end
+
+  test 'clears the implement count when no load is recorded' do
+    movement_log = movement_logs(:brooke_fran_thruster)
+    movement_log.assign_attributes(load: nil, load_unit: :lb, implement_count: 2)
+    movement_log.validate
+
+    assert_nil movement_log.implement_count
+  end
 end

--- a/test/models/movement_test.rb
+++ b/test/models/movement_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class MovementTest < ActiveSupport::TestCase
+  test 'supports implement count for dumbbell and kettlebell movements' do
+    assert_predicate Movement.new(name: 'Dumbbell Thruster'), :supports_implement_count?
+    assert_predicate Movement.new(name: 'kettlebell swing'), :supports_implement_count?
+  end
+
+  test 'does not support implement count for other movements' do
+    assert_not Movement.new(name: 'Back Squat').supports_implement_count?
+    assert_not Movement.new(name: 'Pull Up').supports_implement_count?
+  end
+
+  test 'scopes movements that support implement count' do
+    dumbbell = Movement.create!(name: 'Dumbbell Snatch')
+    kettlebell = Movement.create!(name: 'Kettlebell Clean')
+
+    supported = Movement.supporting_implement_count
+
+    assert_includes supported, dumbbell
+    assert_includes supported, kettlebell
+    assert_not_includes supported, movements(:back_squat)
+  end
+end

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -77,6 +77,25 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
     end
   end
 
+  test 'shows the implements field only for dumbbell and kettlebell movements' do
+    Movement.create!(name: 'Dumbbell Thruster')
+    visit new_workout_url
+
+    click_on 'Add Exercise'
+
+    within first('.exercise') do
+      assert_no_field 'Implements'
+
+      find('.ts-control input').set('Pull')
+      find('.ts-dropdown .option', text: 'Pull Up').click
+      assert_no_field 'Implements'
+
+      find('.ts-control input').set('Dumbbell')
+      find('.ts-dropdown .option', text: 'Dumbbell Thruster').click
+      assert_field 'Implements'
+    end
+  end
+
   test 'opening another card is blocked when the current exercise cannot be saved' do
     visit new_workout_url
 


### PR DESCRIPTION
## Why

Dumbbell and kettlebell movements can be prescribed with one or two implements, and the difference matters: a single 50lb dumbbell thruster is easier than a double (two-dumbbell) 50lb thruster. Today both seed identically as `load: 50`, so the single/double distinction can't be expressed.

## What

The prescribed load is **per implement**, so single and double share the same load value and differ only in how many implements are held. This adds a nullable `implement_count` (blank/`1` = single) to model that.

- **Migration** — `implement_count` integer on `exercises` and `movement_logs`.
- **`Metric`** — carries `implement_count` (defaults to 1) with a `multiple_implements?` predicate.
- **Prescription concerns** — pass the count into the load metric on both `Exercise` and `MovementLog`; the log clears it when no load is recorded.
- **`Exercise` validation** — positive integer, only meaningful alongside a load.
- **Rendering** — `metric_unit_msg` prefixes `2×`, so a double-DB thruster renders `Dumbbell Thrusters (2×♀35lb / ♂50lb)`.
- **Strong params + forms** — exposed in the workout builder and the log recording form.
- **Docs** — `cf/docs/movement-standards.md` documents the convention.

## Testing

- New/updated tests cover rendering (`2×` prefix), validation, defaulting, and movement-log round-trip/clearing.
- Affected suite: `bin/rails test` across the touched helper and model tests — 30 runs, 0 failures.
- RuboCop clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)