### PR TITLE
[codex] Revert review app database reset

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 web: bundle exec puma -p $PORT -C ./config/puma.rb
 worker: bundle exec bin/jobs
-# Review Apps are disposable, so reset them on each deploy; persistent apps only migrate.
-release: if [ "$REVIEW_APP" = "true" ]; then bundle exec rails db:schema:load; else bundle exec rails db:migrate; fi
+release: bundle exec rails db:migrate

--- a/app.json
+++ b/app.json
@@ -11,15 +11,6 @@
       "required": true
     }
   },
-  "environments": {
-    "review": {
-      "env": {
-        "REVIEW_APP": {
-          "value": "true"
-        }
-      }
-    }
-  },
   "formation": {
     "web": {
       "quantity": 1,


### PR DESCRIPTION
## Summary

- Revert the Heroku Review App database reset change from #1706.
- Restore the original release phase behavior: `bundle exec rails db:migrate`.
- Restore `app.json` to keep the existing `postdeploy` seed hook without the Review App-specific environment override.

## Why

The prior change was based on an incorrect assumption about `rails db:schema:load` reliably clearing existing Review App data. It also introduced unnecessary Heroku configuration churn around Review App resets.

## Validation

- `ruby -rjson -e 'JSON.parse(File.read("app.json")); puts "app.json OK"'`
- `git diff --check origin/master..HEAD`