### PR TITLE
Fix from-scratch db:migrate: decouple metric-enum migration from Metric value object

### DIFF
--- a/db/migrate/20250311175701_change_measurement_to_enum_in_metric.rb
+++ b/db/migrate/20250311175701_change_measurement_to_enum_in_metric.rb
@@ -1,4 +1,10 @@
 class ChangeMeasurementToEnumInMetric < ActiveRecord::Migration[8.0]
+  # Local model so this migration does not depend on the app's Metric class, which has since
+  # become a plain value object (the metrics table was later dropped). Reads the legacy rows directly.
+  class MigrationMetric < ActiveRecord::Base
+    self.table_name = 'metrics'
+  end
+
   def up
     # Step 1: Add a temporary integer column
     add_column :metrics, :measurement_int, :integer
@@ -11,8 +17,8 @@ class ChangeMeasurementToEnumInMetric < ActiveRecord::Migration[8.0]
       'time' => 9, 'weight' => 10, 'height' => 11, 'distance' => 12
     }
 
-    Metric.reset_column_information
-    Metric.find_each do |metric|
+    MigrationMetric.reset_column_information
+    MigrationMetric.find_each do |metric|
       if measurement_mapping.key?(metric.measurement)
         metric.update_columns(measurement_int: measurement_mapping[metric.measurement])
       end
@@ -34,8 +40,8 @@ class ChangeMeasurementToEnumInMetric < ActiveRecord::Migration[8.0]
       9 => 'time', 10 => 'weight', 11 => 'height', 12 => 'distance'
     }
 
-    Metric.reset_column_information
-    Metric.find_each do |metric|
+    MigrationMetric.reset_column_information
+    MigrationMetric.find_each do |metric|
       if measurement_mapping.key?(metric.measurement)
         metric.update_columns(measurement_str: measurement_mapping[metric.measurement])
       end


### PR DESCRIPTION
## Problem

A from-scratch `db:migrate` / `db:setup` fails:

```
NoMethodError: undefined method 'reset_column_information' for class Metric
    Metric.reset_column_information
```

`ChangeMeasurementToEnumInMetric` (2025-03-11) called `Metric.reset_column_information` and `Metric.find_each`. Back then `Metric` was an ActiveRecord model; it has since been refactored into a plain value object and the `metrics` table dropped, so replaying the migration against the app model now raises.

It's the only remaining migration that references the app `Metric` model directly.

## Fix

Introduce a migration-local `MigrationMetric < ActiveRecord::Base` scoped to the `metrics` table and use it for the backfill in both `up` and `down` — the same pattern the newer backfill migrations (`add_exercise_prescription_fields`, `add_movement_log_performance_fields`, …) already use.

## Verification

Ran `db:migrate` from scratch on a fresh database — all 50 migrations apply, including this one (previously it aborted here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)