### PR TITLE
Seed Otis (open-ended ascending ladder)

### DIFF
--- a/db/seeds/hero_workouts.rb
+++ b/db/seeds/hero_workouts.rb
@@ -2028,6 +2028,21 @@ Workout.find_or_create_by(name: 'Omar') do |workout|
 end
 
 # ==============================================================================
+# Otis
+# AMRAP in 15 minutes, ascending ladder: 1 back squat, 1 shoulder press, 1 deadlift; then 2 of each;
+# then 3 of each; etc. Use 1 1/2 body weight for the squats and deadlifts and 3/4 body weight for the presses.
+Workout.find_or_create_by(name: 'Otis') do |workout|
+  workout.time = 15
+  workout.score_type = :rep
+  workout.ladder_step = 1
+  workout.notes = 'Ascending ladder: 1 rep of each movement, then 2 of each, then 3 of each, and so on ' \
+                  'for as long as 15 minutes allow. Post total reps.'
+  workout.exercises.build(movement: back_squat, position: 1, reps: 1, notes: '1 1/2 body weight')
+  workout.exercises.build(movement: shoulder_press, position: 2, reps: 1, notes: '3/4 body weight')
+  workout.exercises.build(movement: deadlift, position: 3, reps: 1, notes: '1 1/2 body weight')
+end
+
+# ==============================================================================
 # Pat
 # For time: run 800m w/ plate; 14 rounds (5 strict pull-ups, 4 burpee box jumps, 3 cleans); run 800m w/ plate
 Workout.find_or_create_by(name: 'Pat') do |workout|


### PR DESCRIPTION
## Summary

Seeds **Otis**, the one Hero workout that required open-ended ascending-ladder support (#1698):

> As many reps as possible in 15 minutes of: 1 back squat, 1 shoulder press, 1 deadlift; then 2 of each; then 3 of each; etc.

It uses the existing ladder fields (same as the Open seeds in `open_workouts.rb`):

- `time: 15`, `score_type: :rep`, `ladder_step: 1`
- each lift's `reps: 1` is the round-1 start, growing by 1 each round

The bodyweight-relative loads (1½ body weight for the squats and deadlifts, ¾ body weight for the presses) have no structured column, so they ride on the exercise `notes`, matching the benchmark "Girls" convention.

## Verification

Reseeded; Otis is valid, `ascending_ladder? == true`, and `ladder_reps(1..4) == [1, 2, 3, 4]` for each lift. Renders as:

> As many reps as possible in 15 minutes, ascending ladder, +1 reps each round

This is the last workout that #1698 was blocking (tracked in #1700).

🤖 Generated with [Claude Code](https://claude.com/claude-code)