### PR TITLE
[codex] Support find-a-max prescriptions

### DIFF
--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -6,11 +6,16 @@ module MeasurableHelper
   def measurable_movement_msg(measurable)
     rep_metric = measurable.prescription_metrics.find(&:rep?)
     duration_metric = duration_metric(measurable)
+    return max_load_test_msg(measurable, rep_metric, duration_metric) if measurable.respond_to?(:max_load_test?) && measurable.max_load_test?
     return duration_movement_msg(measurable, rep_metric, duration_metric) if duration_metric
 
     lead_metric = leading_work_metric(measurable)
     return leading_work_movement_msg(measurable, lead_metric) if lead_metric
 
+    rep_movement_msg(measurable, rep_metric)
+  end
+
+  def rep_movement_msg(measurable, rep_metric)
     return measurable.movement.name unless rep_metric
 
     movement_name = measurable.movement.name
@@ -48,9 +53,11 @@ module MeasurableHelper
 
   def visible_metric?(metric) = metric.value.present? || metric.sex_specific?
 
-  def duration_metric(measurable)
-    measurable.prescription_metrics.find { |metric| duration_metric?(metric) && metric.value.present? }
+  def max_load_test_msg(measurable, rep_metric, duration_metric)
+    "#{duration_metric_msg(duration_metric)} to find a #{rep_metric.value}-rep max #{measurable.movement.name}"
   end
+
+  def duration_metric(measurable) = measurable.prescription_metrics.find { |metric| duration_metric?(metric) && metric.value.present? }
 
   def duration_metric?(metric) = metric.seconds? || metric.time?
 
@@ -73,11 +80,7 @@ module MeasurableHelper
     "#{value}#{separator}#{unit}"
   end
 
-  def grouped_metric_unit(metric)
-    return 'ft' if metric.foot?
-
-    metric.measurement.singularize
-  end
+  def grouped_metric_unit(metric) = metric.foot? ? 'ft' : metric.measurement.singularize
 
   def pluralize_movement?(metric)
     return metric.value > 1 if metric.value.present?

--- a/app/helpers/workouts_helper.rb
+++ b/app/helpers/workouts_helper.rb
@@ -1,6 +1,7 @@
 module WorkoutsHelper
   def workout_objective(workout)
     return ascending_ladder_objective(workout) if workout.ascending_ladder?
+    return max_finding_objective(workout) if workout.max_finding?
     return "#{pluralize workout.rounds, 'set'} for load" if workout.set_based_lifting?
     return for_time_objective(workout) if workout.rounds_for_time?
 
@@ -37,6 +38,12 @@ module WorkoutsHelper
     return ladder.upcase_first if workout.time.blank?
 
     "As many reps as possible in #{pluralize workout.time, 'minute'}, #{ladder}"
+  end
+
+  def max_finding_objective(workout)
+    return "Find a max load in #{pluralize workout.time, 'minute'}" if workout.time.present?
+
+    'For load'
   end
 
   def total_reps_clock_objective(workout)

--- a/app/models/concerns/exercise_prescription.rb
+++ b/app/models/concerns/exercise_prescription.rb
@@ -19,6 +19,19 @@ module ExercisePrescription
     ].compact
   end
 
+  def max_load_prescription?
+    reps.to_i.positive? &&
+      duration_seconds.present? &&
+      load_unit.present? &&
+      load.blank? &&
+      female_load.blank? &&
+      male_load.blank?
+  end
+
+  def max_load_test?
+    max_load_prescription? && workout&.max_finding?
+  end
+
   private
 
   def rep_prescription_metric

--- a/app/models/concerns/log_scoring.rb
+++ b/app/models/concerns/log_scoring.rb
@@ -33,7 +33,7 @@ module LogScoring
   end
 
   def calculate_set_based_lifting_score
-    return unless workout&.set_based_lifting? && score_measurement == 'weight'
+    return unless workout&.calculated_lifting_score? && score_measurement == 'weight'
 
     score = workout.lifting_score(movement_logs)
     return unless score

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -14,6 +14,14 @@ module WorkoutScoring
       score_measurement == 'weight'
   end
 
+  def max_finding?
+    score_measurement == 'weight' && top_level_max_finding?
+  end
+
+  def calculated_lifting_score?
+    set_based_lifting? || single_max_finding?
+  end
+
   def exercises_for_log_recording
     return exercises unless set_based_lifting?
 
@@ -61,6 +69,22 @@ module WorkoutScoring
       rounds.positive? &&
       time.blank? &&
       interval.blank?
+  end
+
+  def top_level_max_finding?
+    max_finding_exercises?(top_level_exercises)
+  end
+
+  def single_max_finding?
+    max_finding? && max_finding_exercises.one?
+  end
+
+  def max_finding_exercises
+    exercises.select(&:max_load_prescription?)
+  end
+
+  def max_finding_exercises?(exercises)
+    exercises.any? && exercises.all?(&:max_load_prescription?)
   end
 
   def fixed_amrap_reps_per_round

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -77,7 +77,7 @@ class Log < ApplicationRecord
   end
 
   def metrics_for_movement_log(exercise)
-    metrics = exercise.prescription_metrics
+    metrics = recording_metrics_for(exercise)
     return ordered_recording_metrics(metrics) unless workout.rep_scored_amrap?
 
     component = exercise.score_component
@@ -90,5 +90,11 @@ class Log < ApplicationRecord
 
   def ordered_recording_metrics(metrics)
     metrics.sort_by { |metric| Metric.recording_order(metric.measurement) }
+  end
+
+  def recording_metrics_for(exercise)
+    return exercise.prescription_metrics unless exercise.max_load_test?
+
+    exercise.prescription_metrics.reject { |metric| metric.seconds? || metric.time? }
   end
 end

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -12,9 +12,9 @@
       p = workout_objective @workout
   .row.g-2
     = f.input :score_type, as: :hidden
-    - if @workout.set_based_lifting?
+    - if @workout.calculated_lifting_score?
       .col
-        p.form-text Score will be calculated from the heaviest successful set.
+        p.form-text Score will be calculated from the heaviest successful load.
     - else
       .col = f.input :score_value, as: :group, prepend: @log.score_measurement, label: false
   h2.mt-3 Exercise Recordings

--- a/cf/docs/decisions.md
+++ b/cf/docs/decisions.md
@@ -89,6 +89,26 @@ into an existing one's content yields a single workout, with the edit redirected
 the survivor. Free-text notes are excluded from the fingerprint; canonical load
 identity (lb/kg/pood) is the remaining gap (see #1684).
 
+## 2026-06-29: Find-A-Max Prescriptions Are Weight-Scored Load Tests
+
+A workout part that asks the athlete to find an N-rep max or build to a heavy
+single is modeled as a weight-scored exercise with prescribed reps,
+`duration_seconds`, a load unit, and no fixed prescribed load. The reps define
+the successful attempt requirement; the duration defines the window; the empty
+load with a unit means the athlete must record the load found during that window.
+
+Single-movement max-finding workouts can derive the workout score from the logged
+load once the prescribed reps are completed. Multi-movement max-finding workouts
+preserve each movement's logged load and keep the workout-level score explicit,
+because the published scoring rule may combine loads differently by workout.
+
+Rationale: this reuses the existing direct prescription columns and weight score
+type instead of adding a parallel prescription model. The duration belongs on the
+exercise because the ML-relevant logged fact is that the athlete completed the
+prescribed reps at a recorded load within that exercise's time window. It also
+keeps workouts such as Dragon seedable before the app has a richer multi-component
+score model.
+
 ## 2026-06-17: Document Programming Concepts Before Modeling Them
 
 The app will add programming concepts in this order: intended stimulus, time

--- a/db/seeds/hero_workouts.rb
+++ b/db/seeds/hero_workouts.rb
@@ -477,6 +477,17 @@ Workout.find_or_create_by(name: 'Crain') do |workout|
 end
 
 # ==============================================================================
+# Dragon
+# For max load: 4 minutes to find a 4-rep-max deadlift, then 4 minutes to find a
+# 4-rep-max push jerk.
+Workout.find_or_create_by(name: 'Dragon') do |workout|
+  workout.score_type = :weight
+  workout.notes = 'Post loads for both lifts.'
+  workout.exercises.build(movement: deadlift, position: 1, reps: 4, duration_seconds: 240, load_unit: :lb)
+  workout.exercises.build(movement: push_jerk, position: 2, reps: 4, duration_seconds: 240, load_unit: :lb)
+end
+
+# ==============================================================================
 # Dae Han
 # 3 rounds for time: run 800m with an empty barbell, 3 rope climbs, 12 thrusters
 Workout.find_or_create_by(name: 'Dae Han') do |workout|

--- a/test/helpers/measurable_helper_columns_test.rb
+++ b/test/helpers/measurable_helper_columns_test.rb
@@ -38,6 +38,14 @@ class MeasurableHelperColumnsTest < ActionView::TestCase
     assert_equal 'max reps Toes to Bar', measurable_message(exercise)
   end
 
+  test 'renders a max-load test from columns' do
+    workout = Workout.new(name: 'Back Squat Max', score_type: :weight)
+    exercise = workout.exercises.build(movement: movements(:back_squat), position: 1, reps: 4,
+                                       duration_seconds: 240, load_unit: :lb)
+
+    assert_equal '4:00 to find a 4-rep max Back Squat', measurable_message(exercise)
+  end
+
   test 'prefers direct columns over legacy metrics when both are present' do
     exercise = exercises(:fran_pullup) # carries a rep metric in fixtures
     exercise.assign_attributes(reps: 5)

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -16,6 +16,14 @@ class WorkoutsHelperTest < ActionView::TestCase
     assert_equal '5 sets for load', workout_objective(workout.reload)
   end
 
+  test 'renders timed max-finding workouts as max load clocks' do
+    workout = Workout.new(name: 'Back Squat Max', score_type: :weight)
+    workout.exercises.build(movement: movements(:back_squat), position: 1, reps: 4,
+                            duration_seconds: 240, load_unit: :lb)
+
+    assert_equal 'For load', workout_objective(workout)
+  end
+
   test 'renders fixed-rep amraps as rounds and reps' do
     assert_equal 'As many rounds and reps as possible in 10 minutes', workout_objective(workouts(:amrap_couplet))
   end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -71,4 +71,35 @@ class LogTest < ActiveSupport::TestCase
     assert_equal 'lb', log.score_type
     assert_equal 145, log.score_value
   end
+
+  test 'calculates single max-finding score from a successful logged load' do
+    workout = Workout.create!(name: 'Back Squat Max', score_type: :weight)
+    workout.exercises.create!(movement: movements(:back_squat), position: 1, reps: 4,
+                              duration_seconds: 240, load_unit: :lb)
+    log = workout.logs.build(user: users(:mathew), score_type: :weight)
+    log.build_movement_logs
+
+    assert_equal 1, log.movement_logs.size
+    assert_equal 4, log.movement_logs.first.reps
+    assert_nil log.movement_logs.first.duration_seconds
+    assert_equal 'lb', log.movement_logs.first.load_unit
+
+    log.movement_logs.first.load = 405
+
+    assert log.valid?
+    assert_equal 'lb', log.score_type
+    assert_equal 405, log.score_value
+  end
+
+  test 'does not calculate single max-finding score without completed prescribed reps' do
+    workout = Workout.create!(name: 'Back Squat Max', score_type: :weight)
+    workout.exercises.create!(movement: movements(:back_squat), position: 1, reps: 4,
+                              duration_seconds: 240, load_unit: :lb)
+    log = workout.logs.build(user: users(:mathew), score_type: :weight)
+    log.build_movement_logs
+    log.movement_logs.first.assign_attributes(reps: 3, load: 405)
+
+    assert log.valid?
+    assert_nil log.score_value
+  end
 end

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -51,6 +51,26 @@ class WorkoutTest < ActiveSupport::TestCase
     assert_not workouts(:amrap_couplet).set_based_lifting?
   end
 
+  test 'identifies timed max-finding workouts' do
+    workout = Workout.new(name: 'Back Squat Max', score_type: :weight)
+    workout.exercises.build(movement: movements(:back_squat), position: 1, reps: 4,
+                            duration_seconds: 240, load_unit: :lb)
+
+    assert_predicate workout, :max_finding?
+    assert_predicate workout, :calculated_lifting_score?
+  end
+
+  test 'identifies multi-exercise max-finding workouts without auto-combining scores' do
+    workout = Workout.new(name: 'Dragon', score_type: :weight)
+    workout.exercises.build(movement: movements(:back_squat), position: 1, reps: 4,
+                            duration_seconds: 240, load_unit: :lb)
+    workout.exercises.build(movement: movements(:thruster), position: 2, reps: 4,
+                            duration_seconds: 240, load_unit: :lb)
+
+    assert_predicate workout, :max_finding?
+    assert_not_predicate workout, :calculated_lifting_score?
+  end
+
   test 'does not identify rep-scored rounds with load-bearing exercises as set-based lifting' do
     workout = workouts(:back_squat_5x5)
     workout.update!(score_type: :rep)

--- a/test/system/lifting_workouts_test.rb
+++ b/test/system/lifting_workouts_test.rb
@@ -17,7 +17,7 @@ class LiftingWorkoutsTest < ApplicationSystemTestCase
     click_on 'Log'
 
     assert_no_selector '#log_score_value'
-    assert_text 'Score will be calculated from the heaviest successful set.'
+    assert_text 'Score will be calculated from the heaviest successful load.'
     assert_selector '.card.mb-3', count: 5
     movement_logs = all('.card.mb-3')
     movement_logs.each do |movement_log|


### PR DESCRIPTION
## What changed

- Models max-finding prescriptions as weight-scored exercises with prescribed reps, `duration_seconds`, a load unit, and no fixed load.
- Renders those exercises as timed N-rep max attempts, e.g. `4:00 to find a 4-rep max Deadlift`.
- Builds movement logs for max-load tests with reps/load only, so the athlete records the successful load hit within the programmed time window instead of entering duration as performance.
- Auto-calculates the workout score from the logged load for single-movement max tests once the prescribed reps are completed.
- Leaves multi-movement max tests with explicit workout-level scoring while preserving each movement's logged load for later ML/scoring use.
- Seeds the Hero workout Dragon as two timed top-level max-load exercises.
- Documents the domain decision for find-a-max prescriptions.

## Why

Fixes #1699. Some CrossFit workouts prescribe finding an N-rep max or building to a heavy single within a time window. The important logged fact is that the athlete hit a recorded load for the prescribed reps inside that window. Dragon was blocked by that gap, so it is included as the concrete seeded proof case.

## Validation

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/models/workout_test.rb test/models/log_test.rb test/helpers/workouts_helper_test.rb test/helpers/measurable_helper_columns_test.rb test/helpers/segments_helper_test.rb test/system/lifting_workouts_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rubocop --parallel`
- Targeted Dragon seed-block validation in `test` env, asserting weight score, no segments, two timed top-level exercises, and empty load with `lb` unit.