### PR TITLE
Recognize the reps-only AMRAP header phrasing ("as many reps as possible")

### DIFF
--- a/app/services/cf_wod/workout_format_classifier.rb
+++ b/app/services/cf_wod/workout_format_classifier.rb
@@ -1,7 +1,7 @@
 module CfWod
   class WorkoutFormatClassifier
     FOR_TIME = /\Afor time:?\z/i
-    AMRAP = /\A(?:complete )?as many rounds(?: and reps)? as possible in (\d+) minutes? of:?\z/i
+    AMRAP = /\A(?:complete )?as many (?:rounds(?: and reps)?|reps) as possible in (\d+) minutes? of:?\z/i
     EVERY_MINUTE = /\Aevery minute on the minute for (\d+) minutes?:?\z/i
     REP_LADDER = /\A(\d+(?:-\d+)+) reps for time of:?\z/i
     FIND_MAX = /\Afind a 1-rep-max (.+?)\.?\z/i

--- a/test/services/cf_wod/workout_format_classifier_test.rb
+++ b/test/services/cf_wod/workout_format_classifier_test.rb
@@ -11,6 +11,11 @@ module CfWod
       assert_equal({ score_type: :rep, time: 10 }, result)
     end
 
+    test 'classifies a reps-only AMRAP header, extracting the time cap' do
+      result = WorkoutFormatClassifier.call('Complete as many reps as possible in 10 minutes of:')
+      assert_equal({ score_type: :rep, time: 10 }, result)
+    end
+
     test 'classifies an every-minute-on-the-minute header, extracting rounds and time' do
       result = WorkoutFormatClassifier.call('Every minute on the minute for 10 minutes:')
       assert_equal({ score_type: :rep, time: 10, rounds: 10 }, result)


### PR DESCRIPTION
## Summary
- `CfWod::WorkoutFormatClassifier`'s `AMRAP` regex only matched "as many rounds as possible" or "as many rounds and reps as possible" — not the "as many **reps** as possible" phrasing CrossFit.com also uses for AMRAPs scored purely by rep count.
- Broadened the regex to accept all three phrasings. Both map to the same `{ score_type: :rep, time: N }` attributes, so this is header-recognition broadening only, not a new handler.

Found while running `ScrapeCfWodJob` (#1727) against today's live WOD:

```
Complete as many reps as possible in 10 minutes of:
3 burpee box jump-overs
3 deadlifts
...
```

Note: fixing this header exposes a second, unrelated, larger gap in the same WOD — the body ends in an open-ended ascending ladder signaled by `"Etc."`, which `CfWod::WorkoutParser` has no heuristic for at all (it's not just a header issue). That's a real new parsing capability, not a small fix, so it's being tracked separately rather than bundled here.

## Test plan
- [x] `test/services/cf_wod/workout_format_classifier_test.rb` — new test for the reps-only phrasing (TDD: confirmed RED before the fix, GREEN after)
- [x] Full classifier/parser/corpus test files, no regressions
- [x] RuboCop clean
- [x] Full suite: 310 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)