### PR TITLE
Fix db:migrate crash on a fresh database

### DIFF
--- a/db/migrate/20250311174810_change_role_to_enum_in_users.rb
+++ b/db/migrate/20250311174810_change_role_to_enum_in_users.rb
@@ -1,18 +1,22 @@
 class ChangeRoleToEnumInUsers < ActiveRecord::Migration[8.0]
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = 'users'
+  end
+
   def up
     # Step 1: Add a temporary integer column
     add_column :users, :role_int, :integer
 
     # Step 2: Map existing string values to integers
     role_mapping = { 'admin' => 0, 'user' => 1 }
-    User.reset_column_information
-    User.find_each do |user|
+    MigrationUser.reset_column_information
+    MigrationUser.find_each do |user|
       user.update_columns(role_int: role_mapping[user.role]) if role_mapping.key?(user.role)
     end
 
     # Step 3: Remove old string column and rename new column
-    remove_column :users, :role 
-    rename_column :users, :role_int, :role 
+    remove_column :users, :role
+    rename_column :users, :role_int, :role
   end
 
   def down
@@ -20,8 +24,8 @@ class ChangeRoleToEnumInUsers < ActiveRecord::Migration[8.0]
     add_column :users, :role_str, :string
 
     role_mapping = { 0 => 'admin', 1 => 'user' }
-    User.reset_column_information
-    User.find_each do |user|
+    MigrationUser.reset_column_information
+    MigrationUser.find_each do |user|
       user.update_columns(role_str: role_mapping[user.role]) if role_mapping.key?(user.role)
     end
 

--- a/db/migrate/20250311175701_change_measurement_to_enum_in_metric.rb
+++ b/db/migrate/20250311175701_change_measurement_to_enum_in_metric.rb
@@ -1,4 +1,8 @@
 class ChangeMeasurementToEnumInMetric < ActiveRecord::Migration[8.0]
+  class MigrationMetric < ActiveRecord::Base
+    self.table_name = 'metrics'
+  end
+
   def up
     # Step 1: Add a temporary integer column
     add_column :metrics, :measurement_int, :integer
@@ -11,8 +15,8 @@ class ChangeMeasurementToEnumInMetric < ActiveRecord::Migration[8.0]
       'time' => 9, 'weight' => 10, 'height' => 11, 'distance' => 12
     }
 
-    Metric.reset_column_information
-    Metric.find_each do |metric|
+    MigrationMetric.reset_column_information
+    MigrationMetric.find_each do |metric|
       if measurement_mapping.key?(metric.measurement)
         metric.update_columns(measurement_int: measurement_mapping[metric.measurement])
       end
@@ -34,8 +38,8 @@ class ChangeMeasurementToEnumInMetric < ActiveRecord::Migration[8.0]
       9 => 'time', 10 => 'weight', 11 => 'height', 12 => 'distance'
     }
 
-    Metric.reset_column_information
-    Metric.find_each do |metric|
+    MigrationMetric.reset_column_information
+    MigrationMetric.find_each do |metric|
       if measurement_mapping.key?(metric.measurement)
         metric.update_columns(measurement_str: measurement_mapping[metric.measurement])
       end


### PR DESCRIPTION
## Summary
- `ChangeRoleToEnumInUsers` (2025-03-11) referenced the live `User` model via `User.find_each`. On a genuinely fresh database, migrations replay in chronological order, so at this point `User`'s `enum :unit_system` (added by a 2026 migration) has no backing column yet, and Rails 8.1 raises `Undeclared attribute type for enum 'unit_system'`.
- The next migration, `ChangeMeasurementToEnumInMetric`, has the same class of bug: it referenced `Metric`, which has since been refactored from an ActiveRecord model into a plain Ruby value object, so `Metric.reset_column_information` raises `NoMethodError`.
- Both migrations now define a migration-scoped `ActiveRecord::Base` subclass (`MigrationUser`, `MigrationMetric`) instead of touching the app's model classes — the same pattern already used by newer migrations in this repo (e.g. `20260615120000_add_movement_log_performance_fields.rb`).

## Test plan
- [x] Forced a full migration replay against a truly empty database (bypassed Rails' schema-fast-load shortcut) and reproduced the exact crash from the bug report before the fix.
- [x] Confirmed all 55 migrations now run cleanly end-to-end from an empty database after the fix.
- [x] Dumped the resulting `db/schema.rb` and diffed it against the checked-in version — byte-identical, confirming no behavior change to the final schema.
- [x] `bundle exec rubocop --parallel` on both changed files — no new offenses (pre-existing warnings on master are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)