### PR TITLE
Recognize hyphenated compound movement names the catalog spells with spaces

### DIFF
--- a/app/services/cf_wod/movement_lookup.rb
+++ b/app/services/cf_wod/movement_lookup.rb
@@ -12,16 +12,21 @@ module CfWod
     end
 
     def lookup
-      Movement.find_by(name: normalized_name)
+      Movement.find_by(name: normalized_name(/\s+/)) || Movement.find_by(name: normalized_name(/[\s-]+/))
     end
 
     private
 
     attr_reader :name
 
-    def normalized_name
+    # The catalog is inconsistent about whether a compound term is hyphenated (e.g. "Wall-ball
+    # Shot") or fully spaced (e.g. "Toes to Bar"), while prose always hyphenates compounds like
+    # "toes-to-bars" as a single token. Try splitting on whitespace only first (preserving any
+    # internal hyphen, matching the "Wall-ball" style); only if that misses, retry splitting on
+    # hyphens too, so a fully-spaced catalog entry can still be found.
+    def normalized_name(word_separator)
       base = name.to_s.strip.delete_suffix('.').downcase.singularize
-      base.split.each_with_index.map { |word, index| titlecase_word(word, first: index.zero?) }.join(' ')
+      base.split(word_separator).each_with_index.map { |word, index| titlecase_word(word, first: index.zero?) }.join(' ')
     end
 
     def titlecase_word(word, first:)

--- a/test/services/cf_wod/movement_lookup_test.rb
+++ b/test/services/cf_wod/movement_lookup_test.rb
@@ -23,5 +23,10 @@ module CfWod
       clean_and_jerk = Movement.find_or_create_by(name: 'Clean and Jerk')
       assert_equal clean_and_jerk, MovementLookup.call('clean and jerks')
     end
+
+    test 'falls back to treating a hyphenated compound as space-separated words' do
+      toes_to_bar = Movement.find_or_create_by(name: 'Toes to Bar')
+      assert_equal toes_to_bar, MovementLookup.call('toes-to-bars')
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `CfWod::MovementLookup` only split exercise-line text on whitespace before title-casing, so a hyphenated single-token compound like `"toes-to-bars"` normalized to `"Toes-to-bar"` — which never matches the catalog's actual entry, spelled with spaces (`"Toes to Bar"`, per `db/seeds.rb`).
- The catalog is inconsistent about this: some compounds keep an internal hyphen (e.g. `"Wall-ball Shot"`), which already worked, because that phrase has a literal space before "Shot" in prose (`"wall-ball shots"` splits into two whitespace tokens, matching the catalog's own two-word structure).
- Fix: `lookup` now falls back to also splitting on hyphens, but *only* when the whitespace-only normalization finds no match — so already-working hyphen-preserving cases (`pull-ups`, `wall-ball shots`, etc.) are unaffected.

Found while running `ScrapeCfWodJob` (#1727) against a real WOD (`bin/rails "cf_wod:scrape[2026-07-08]"`), which failed with `"unrecognized movement: 'toes-to-bars'"`. Verified the full WOD (`5 rounds for time of: 15 push presses, 20 toes-to-bars`) now parses cleanly end-to-end with the fix.

## Test plan
- [x] `test/services/cf_wod/movement_lookup_test.rb` — new test for the hyphen-as-space fallback (TDD: confirmed RED before the fix, GREEN after)
- [x] Full movement-lookup/parser/corpus/exercise-line test files, no regressions
- [x] Manually re-fetched and re-parsed the actual reported WOD (2026-07-08) against live crossfit.com to confirm it parses cleanly
- [x] RuboCop clean
- [x] Full suite: 311 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)