### PR TITLE
Show literal "1" reps on plain for-time exercise lines

### DIFF
--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -23,7 +23,23 @@ module MeasurableHelper
     movement_name = measurable.movement.name
     return "max reps #{movement_name}" if max_rep_metric?(rep_metric)
 
-    [metric_unit_msg(rep_metric), movement_name_for_rep_metric(movement_name, rep_metric)].compact_blank.join(' ')
+    [rep_movement_count_msg(measurable, rep_metric), movement_name_for_rep_metric(movement_name, rep_metric)]
+      .compact_blank.join(' ')
+  end
+
+  # A bare movement line with no interval-defined rep scheme (e.g. a chipper's standalone "Rope
+  # Climb") means the athlete truly does one rep -- show it, unlike a Fran-style ladder movement
+  # where reps: 1 is a structural placeholder (see Exercise#reps_defined_by_interval?).
+  def rep_movement_count_msg(measurable, rep_metric)
+    return rep_metric.value.to_s if literal_single_rep?(measurable, rep_metric)
+
+    metric_unit_msg(rep_metric)
+  end
+
+  def literal_single_rep?(measurable, rep_metric)
+    rep_metric.value == 1 &&
+      measurable.respond_to?(:reps_defined_by_interval?) &&
+      !measurable.reps_defined_by_interval?
   end
 
   def measurable_reps_msg(measurable)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -59,6 +59,15 @@ class Exercise < ApplicationRecord
     reps + (rung * workout.ladder_step)
   end
 
+  # True when reps: 1 is a structural placeholder for a round-by-round count set by the workout's
+  # (or segment's) interval scheme, e.g. Fran's "21-15-9" -- the same distinction
+  # Metric#calculated_value uses to multiply out total work for interval ladders. False for a bare
+  # movement line with no interval scheme (e.g. a chipper's standalone "Rope Climb"), where reps: 1
+  # is a real, displayable count.
+  def reps_defined_by_interval?
+    (segment.presence || workout).interval?
+  end
+
   def distance_score_component
     distance = distance_metric
     return nil unless scorable_metric?(distance) && distance_units_per_rep.positive?

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -65,6 +65,16 @@ class MeasurableHelperTest < ActionView::TestCase
     assert_equal '4:00 to find a 4-rep max Back Squat', measurable_message(exercise)
   end
 
+  test 'renders a literal single rep on a plain for-time workout, unlike a ladder placeholder' do
+    exercise = workouts(:murph).exercises.create!(movement: movements(:rope_climb), position: 6, reps: 1)
+
+    assert_equal '1 Rope Climb', measurable_message(exercise)
+  end
+
+  test 'does not render a numeral for a Fran-style ladder placeholder rep' do
+    assert_equal 'Pull Up', measurable_message(exercises(:fran_pullup))
+  end
+
   test 'renders timed station movements without pluralizing fixed single-rep movements' do
     exercise = workouts(:fran).exercises.create!(movement: movements(:row), position: 3,
                                                  reps: 1, duration_seconds: 60, calories: 0)

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -129,13 +129,6 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_includes exercise.errors[:base], 'load requires both female and male values'
   end
 
-  test 'reps are interval-defined for a rep-ladder workout like Fran but not for a plain for-time workout' do
-    plain_exercise = workouts(:murph).exercises.build(movement: movements(:pullup), position: 3, reps: 1)
-
-    assert_predicate exercises(:fran_pullup), :reps_defined_by_interval?
-    assert_not plain_exercise.reps_defined_by_interval?
-  end
-
   test 'validates distance units per rep against the column distance' do
     exercise = workouts(:fran).exercises.build(movement: movements(:run), position: 3,
                                                reps: 1, distance: 400, distance_unit: :meter,

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -129,6 +129,13 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_includes exercise.errors[:base], 'load requires both female and male values'
   end
 
+  test 'reps are interval-defined for a rep-ladder workout like Fran but not for a plain for-time workout' do
+    plain_exercise = workouts(:murph).exercises.build(movement: movements(:pullup), position: 3, reps: 1)
+
+    assert_predicate exercises(:fran_pullup), :reps_defined_by_interval?
+    assert_not plain_exercise.reps_defined_by_interval?
+  end
+
   test 'validates distance units per rep against the column distance' do
     exercise = workouts(:fran).exercises.build(movement: movements(:run), position: 3,
                                                reps: 1, distance: 400, distance_unit: :meter,


### PR DESCRIPTION
## Summary
- The last line of a descending-ladder chipper (e.g. `5 / 4 / 3 / 2 / Rope Climb`) parses to `reps: 1`, but `measurable_message` hid the numeral for *every* `reps: 1` exercise, so the last stanza rendered as bare "Rope Climb" instead of "1 Rope Climb" -- inconsistent with its own numbered siblings.
- That suppression is correct for Fran-style ladders (`21-15-9 reps for time of:`), where `reps: 1` is a structural placeholder and the real per-round count comes from `workout.interval`, not the exercise's own reps column.
- Added `Exercise#reps_defined_by_interval?` (mirrors the same `interval?` check `Metric#calculated_value` already uses for scoring) and used it in `MeasurableHelper` to show the literal "1" only when the workout/segment has no interval scheme.

## Test plan
- [x] `bundle exec rails test test/models/exercise_test.rb test/helpers/measurable_helper_test.rb` (30 runs, 0 failures)
- [x] `bundle exec rails test test/services/cf_wod test/helpers test/models` (266 runs, 0 failures) -- confirms Fran and other reps:1 fixtures are unaffected
- [x] `bundle exec rubocop` on changed files (no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)