### PR TITLE
Backfill implicit segments for top-level exercises

### DIFF
--- a/app/helpers/segments_helper.rb
+++ b/app/helpers/segments_helper.rb
@@ -5,6 +5,10 @@ module SegmentsHelper
     "#{msg}#{segment_prescription(segment)}"
   end
 
+  def segment_objective?(segment)
+    !segment.implicit_workout_part?
+  end
+
   private
 
   def named_max_reps_segment?(segment)

--- a/app/models/concerns/implicit_workout_part.rb
+++ b/app/models/concerns/implicit_workout_part.rb
@@ -4,7 +4,7 @@ module ImplicitWorkoutPart
   # Backfilled wrappers preserve the old workout-part shape: the workout owns the
   # scheme/objective, and this segment only groups the exercises that used to be top-level.
   def implicit_workout_part?
-    blank_wrapper? && workout.present? && segment_scheme == workout_part_scheme
+    persisted? && blank_wrapper? && workout.present? && segment_scheme == workout_part_scheme
   end
 
   private
@@ -22,14 +22,9 @@ module ImplicitWorkoutPart
   end
 
   def workout_part_scheme
-    return {} if unschemed_weight_workout?
-    return nil if unschemed_workout?
+    return {} if unschemed_workout?
 
     workout_real_scheme
-  end
-
-  def unschemed_weight_workout?
-    workout.score_measurement == 'weight' && unschemed_workout?
   end
 
   def unschemed_workout?

--- a/app/models/concerns/implicit_workout_part.rb
+++ b/app/models/concerns/implicit_workout_part.rb
@@ -1,0 +1,54 @@
+module ImplicitWorkoutPart
+  extend ActiveSupport::Concern
+
+  # Backfilled wrappers preserve the old workout-part shape: the workout owns the
+  # scheme/objective, and this segment only groups the exercises that used to be top-level.
+  def implicit_workout_part?
+    blank_wrapper? && workout.present? && segment_scheme == workout_part_scheme
+  end
+
+  private
+
+  def blank_wrapper?
+    name.blank? && rest_seconds.blank? && notes.blank?
+  end
+
+  def segment_scheme
+    {
+      rounds: rounds,
+      time_seconds: time_seconds,
+      interval_scheme: interval_scheme.presence
+    }.compact
+  end
+
+  def workout_part_scheme
+    return {} if unschemed_weight_workout?
+    return nil if unschemed_workout?
+
+    workout_real_scheme
+  end
+
+  def unschemed_weight_workout?
+    workout.score_measurement == 'weight' && unschemed_workout?
+  end
+
+  def unschemed_workout?
+    workout.rounds.to_i <= 1 && workout.time.blank? && workout.interval.blank?
+  end
+
+  def workout_real_scheme
+    {
+      rounds: workout_rounds,
+      time_seconds: workout_time_seconds,
+      interval_scheme: workout.interval.presence
+    }.compact
+  end
+
+  def workout_rounds
+    workout.rounds if workout.rounds.to_i > 1
+  end
+
+  def workout_time_seconds
+    workout.time * 60 if workout.time.present?
+  end
+end

--- a/app/models/concerns/workout_scoring.rb
+++ b/app/models/concerns/workout_scoring.rb
@@ -35,7 +35,10 @@ module WorkoutScoring
   end
 
   def top_level_exercises
-    exercises.reject(&:segment_id)
+    direct_exercises = exercises.reject(&:segment_id)
+    return direct_exercises if direct_exercises.any?
+
+    segments.select(&:implicit_workout_part?).flat_map(&:exercises)
   end
 
   def amrap_score_components

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -1,4 +1,5 @@
 class Segment < ApplicationRecord
+  include ImplicitWorkoutPart
   include RefreshesWorkoutContentKey
 
   belongs_to :workout

--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -1,5 +1,6 @@
 - expanded = f.object.new_record?
-- summary = f.object.persisted? ? segment_objective(f.object) : 'New segment'
+- implicit_wrapper = f.object.implicit_workout_part?
+- summary = f.object.persisted? ? (implicit_wrapper ? 'Exercises' : segment_objective(f.object)) : 'New segment'
 - exercise_summaries = f.object.exercises.reject(&:marked_for_destruction?).sort_by { |exercise| exercise.position || 0 }.map { |exercise| measurable_message(exercise) }
 
 .nested-fields.card.mb-3.workout-part data-controller="segment-card" data-segment-card-expanded-value=expanded
@@ -19,14 +20,15 @@
   .segment-editor.card-body data-segment-card-target="editor" hidden=(!expanded)
     .workout-sortable-item
       .workout-sortable-item__body
-        .row.g-2
-          .col-12.col-lg-4 = f.input :name, input_html: { data: { 'segment-card-target': 'nameInput' } }
-          .col-6.col-md-3.col-lg-2 = f.input :rounds, input_html: { data: { 'segment-card-target': 'roundsInput' } }
-          .col-6.col-md-3.col-lg-2 = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200', input_html: { data: { 'segment-card-target': 'timeInput' } }
-          .col-12.col-md-6.col-lg-4 = f.input :interval_scheme, placeholder: '21-15-9...', input_html: { data: { 'segment-card-target': 'intervalInput' } }
-        .row.g-2
-          .col-12.col-md-4 = f.input :rest_seconds, input_html: { data: { 'segment-card-target': 'restInput' } }
-          .col-12.col-md-8 = f.input :notes, input_html: { data: { 'segment-card-target': 'notesInput' } }
+        - unless implicit_wrapper
+          .row.g-2
+            .col-12.col-lg-4 = f.input :name, input_html: { data: { 'segment-card-target': 'nameInput' } }
+            .col-6.col-md-3.col-lg-2 = f.input :rounds, input_html: { data: { 'segment-card-target': 'roundsInput' } }
+            .col-6.col-md-3.col-lg-2 = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200', input_html: { data: { 'segment-card-target': 'timeInput' } }
+            .col-12.col-md-6.col-lg-4 = f.input :interval_scheme, placeholder: '21-15-9...', input_html: { data: { 'segment-card-target': 'intervalInput' } }
+          .row.g-2
+            .col-12.col-md-4 = f.input :rest_seconds, input_html: { data: { 'segment-card-target': 'restInput' } }
+            .col-12.col-md-8 = f.input :notes, input_html: { data: { 'segment-card-target': 'notesInput' } }
         .row
           .col#segmented_exercises data-controller="nested-form sortable-list" data-action="nested-form:add->sortable-list#refresh nested-form:remove->sortable-list#refresh" data-nested-form-placeholder-value="CHILD_EXERCISE" data-nested-form-position-exercises-value="true" data-sortable-list-draggable-selector-value=".segment-exercise:not([hidden])"
             .fields data-nested-form-target="container" data-sortable-list-target="container"

--- a/app/views/workouts/show.html.slim
+++ b/app/views/workouts/show.html.slim
@@ -24,7 +24,8 @@
       ul.list-unstyled.mb-3
         - @workout.ordered_parts.each_with_index do |part, index|
           - if part.is_a?(Segment)
-            li = segment_objective(part, then_prefix: index.positive?)
+            - if segment_objective?(part)
+              li = segment_objective(part, then_prefix: index.positive?)
             - part.exercises.each do |exercise|
               li.ms-4 #{measurable_message(exercise)}
           - else

--- a/db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
+++ b/db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
@@ -1,0 +1,80 @@
+class BackfillSegmentsForTopLevelExercises < ActiveRecord::Migration[8.1]
+  class MigrationWorkout < ActiveRecord::Base
+    self.table_name = 'workouts'
+  end
+
+  class MigrationSegment < ActiveRecord::Base
+    self.table_name = 'segments'
+    self.record_timestamps = false
+  end
+
+  class MigrationExercise < ActiveRecord::Base
+    self.table_name = 'exercises'
+    self.record_timestamps = false
+  end
+
+  def up
+    workout_ids = MigrationExercise.where(segment_id: nil).distinct.pluck(:workout_id)
+
+    say_with_time "Backfilling implicit segments for #{workout_ids.size} workouts" do
+      workout_ids.each { |workout_id| backfill_workout(workout_id) }
+    end
+  end
+
+  def down
+    say 'Data-only migration -- implicit segments created by #up are not restorable to top-level exercises. No-op.'
+  end
+
+  private
+
+  def backfill_workout(workout_id)
+    workout = MigrationWorkout.find(workout_id)
+    exercise_runs = exercise_runs(workout_id)
+    scheme = workout_scheme(workout)
+    reject_ambiguous_runs!(workout, exercise_runs, scheme)
+    exercise_runs.each { |run| wrap_run(workout, run, scheme) }
+  end
+
+  def ordered_parts(workout_id)
+    (MigrationExercise.where(workout_id:, segment_id: nil).to_a + MigrationSegment.where(workout_id:).to_a)
+      .sort_by { |part| [part.position, part.id] }
+  end
+
+  def exercise_runs(workout_id)
+    ordered_parts(workout_id)
+      .chunk_while { |left, right| left.is_a?(MigrationExercise) && right.is_a?(MigrationExercise) }
+      .select { |run| run.first.is_a?(MigrationExercise) }
+  end
+
+  def reject_ambiguous_runs!(workout, exercise_runs, scheme)
+    return unless exercise_runs.size > 1 && scheme
+
+    raise "Workout #{workout.id} has #{exercise_runs.size} top-level exercise runs with rounds=#{workout.rounds.inspect}, " \
+          "time=#{workout.time.inspect}, interval=#{workout.interval.inspect}"
+  end
+
+  def workout_scheme(workout)
+    return if workout.rounds.to_i <= 1 && workout.time.blank? && workout.interval.blank?
+
+    {
+      rounds: (workout.rounds if workout.rounds.to_i > 1),
+      time_seconds: (workout.time * 60 if workout.time.present?),
+      interval_scheme: workout.interval
+    }.compact
+  end
+
+  def wrap_run(workout, run, scheme)
+    segment = MigrationSegment.create!(
+      {
+        workout_id: workout.id,
+        position: run.first.position,
+        created_at: Time.current,
+        updated_at: Time.current
+      }.merge(scheme || {})
+    )
+
+    run.each_with_index do |exercise, index|
+      exercise.update!(segment_id: segment.id, position: index + 1)
+    end
+  end
+end

--- a/db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
+++ b/db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
@@ -1,4 +1,6 @@
 class BackfillSegmentsForTopLevelExercises < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
   class MigrationWorkout < ActiveRecord::Base
     self.table_name = 'workouts'
   end
@@ -14,7 +16,7 @@ class BackfillSegmentsForTopLevelExercises < ActiveRecord::Migration[8.1]
   end
 
   def up
-    workout_ids = MigrationExercise.where(segment_id: nil).distinct.pluck(:workout_id)
+    workout_ids = MigrationExercise.where(segment_id: nil).distinct.pluck(:workout_id).compact
 
     say_with_time "Backfilling implicit segments for #{workout_ids.size} workouts" do
       workout_ids.each { |workout_id| backfill_workout(workout_id) }
@@ -33,7 +35,7 @@ class BackfillSegmentsForTopLevelExercises < ActiveRecord::Migration[8.1]
     scheme = workout_scheme(workout)
     reject_ambiguous_runs!(workout, exercise_runs, scheme)
     exercise_runs.each { |run| wrap_run(workout, run, scheme) }
-    Workout.find(workout_id).refresh_content_key!
+    refresh_and_absorb_duplicate!(workout_id)
   end
 
   def ordered_parts(workout_id)
@@ -60,8 +62,15 @@ class BackfillSegmentsForTopLevelExercises < ActiveRecord::Migration[8.1]
     {
       rounds: (workout.rounds if workout.rounds.to_i > 1),
       time_seconds: (workout.time * 60 if workout.time.present?),
-      interval_scheme: workout.interval
+      interval_scheme: workout.interval.presence
     }.compact
+  end
+
+  def refresh_and_absorb_duplicate!(workout_id)
+    Workout.find(workout_id).tap do |workout|
+      workout.save!(validate: false)
+      workout.absorb_duplicate!
+    end
   end
 
   def wrap_run(workout, run, scheme)

--- a/db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
+++ b/db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
@@ -33,6 +33,7 @@ class BackfillSegmentsForTopLevelExercises < ActiveRecord::Migration[8.1]
     scheme = workout_scheme(workout)
     reject_ambiguous_runs!(workout, exercise_runs, scheme)
     exercise_runs.each { |run| wrap_run(workout, run, scheme) }
+    Workout.find(workout_id).refresh_content_key!
   end
 
   def ordered_parts(workout_id)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/helpers/segments_helper_test.rb
+++ b/test/helpers/segments_helper_test.rb
@@ -48,16 +48,23 @@ class SegmentsHelperTest < ActionView::TestCase
     assert_equal 'Segment:', segment_objective(Segment.new)
   end
 
-  test 'keeps objectives for explicit unnamed unschemed segments' do
+  test 'keeps objectives for new explicit unnamed unschemed segments' do
     workout = Workout.new(name: 'Plain', score_type: :time)
     segment = workout.segments.build(position: 1)
 
     assert segment_objective?(segment)
   end
 
-  test 'suppresses objectives for implicit workout-part segment wrappers' do
-    workout = Workout.new(name: 'Back Squat 5x5', rounds: 5, score_type: :weight)
-    segment = workout.segments.build(position: 1, rounds: 5)
+  test 'suppresses objectives for scheme-backed implicit workout-part segment wrappers' do
+    workout = Workout.create!(name: 'Back Squat 5x5', rounds: 5, score_type: :weight)
+    segment = workout.segments.create!(position: 1, rounds: 5)
+
+    assert_not segment_objective?(segment)
+  end
+
+  test 'suppresses objectives for unschemed implicit workout-part segment wrappers' do
+    workout = Workout.create!(name: 'Plain Chipper', score_type: :time)
+    segment = workout.segments.create!(position: 1)
 
     assert_not segment_objective?(segment)
   end

--- a/test/helpers/segments_helper_test.rb
+++ b/test/helpers/segments_helper_test.rb
@@ -47,4 +47,18 @@ class SegmentsHelperTest < ActionView::TestCase
   test 'falls back to a generic label for empty segments' do
     assert_equal 'Segment:', segment_objective(Segment.new)
   end
+
+  test 'keeps objectives for explicit unnamed unschemed segments' do
+    workout = Workout.new(name: 'Plain', score_type: :time)
+    segment = workout.segments.build(position: 1)
+
+    assert segment_objective?(segment)
+  end
+
+  test 'suppresses objectives for implicit workout-part segment wrappers' do
+    workout = Workout.new(name: 'Back Squat 5x5', rounds: 5, score_type: :weight)
+    segment = workout.segments.build(position: 1, rounds: 5)
+
+    assert_not segment_objective?(segment)
+  end
 end

--- a/test/migrations/backfill_segments_for_top_level_exercises_test.rb
+++ b/test/migrations/backfill_segments_for_top_level_exercises_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20260713120000_backfill_segments_for_top_level_exercises').to_s
+
+class BackfillSegmentsForTopLevelExercisesTest < ActiveSupport::TestCase
+  test 'wraps a flat interval workout in one segment' do
+    workout = Workout.create!(name: 'Fran', score_type: :time, interval: '21-15-9')
+    workout.exercises.create!(movement: movements(:thruster), position: 1, reps: 1)
+    workout.exercises.create!(movement: movements(:pull_up), position: 2, reps: 1)
+
+    BackfillSegmentsForTopLevelExercises.new.up
+
+    assert_equal 1, workout.segments.count
+    segment = workout.reload.segments.first
+    assert_equal '21-15-9', segment.interval_scheme
+    assert_nil segment.rounds
+    assert_equal [1, 2], segment.exercises.order(:position).pluck(:position)
+    assert_empty workout.exercises.where(segment_id: nil)
+  end
+
+  test 'preserves existing segments when wrapping a leading rounds run' do
+    workout = Workout.create!(name: 'Brenton', score_type: :time, rounds: 5)
+    workout.exercises.create!(movement: movements(:run), position: 1, reps: 400)
+    existing_segment = workout.segments.create!(name: 'Carry', position: 2)
+
+    BackfillSegmentsForTopLevelExercises.new.up
+
+    assert_equal 2, workout.segments.count
+    new_segment = workout.segments.find_by!(position: 1)
+    assert_equal 5, new_segment.rounds
+    assert_equal 1, new_segment.position
+    assert_equal 'Carry', existing_segment.reload.name
+    assert_equal 2, existing_segment.position
+  end
+
+  test 'wraps a middle run without a scheme' do
+    workout = Workout.create!(name: 'Alec', score_type: :time, rounds: 1)
+    workout.segments.create!(name: 'First', position: 1)
+    workout.exercises.create!(movement: movements(:run), position: 2, reps: 400)
+    workout.segments.create!(name: 'Last', position: 5)
+
+    BackfillSegmentsForTopLevelExercises.new.up
+
+    assert_equal 3, workout.segments.count
+    middle_segment = workout.segments.find_by!(position: 2)
+    assert_nil middle_segment.rounds
+    assert_nil middle_segment.time_seconds
+    assert_equal [movements(:run)], middle_segment.exercises.map(&:movement)
+  end
+
+  test 'raises for multiple exercise runs in a workout with a scheme' do
+    workout = Workout.create!(name: 'Ambiguous', score_type: :time, rounds: 3)
+    workout.exercises.create!(movement: movements(:run), position: 1, reps: 400)
+    workout.segments.create!(name: 'Break', position: 2)
+    workout.exercises.create!(movement: movements(:pull_up), position: 3, reps: 10)
+
+    assert_raises(RuntimeError) { BackfillSegmentsForTopLevelExercises.new.up }
+  end
+end

--- a/test/migrations/backfill_segments_for_top_level_exercises_test.rb
+++ b/test/migrations/backfill_segments_for_top_level_exercises_test.rb
@@ -6,6 +6,7 @@ class BackfillSegmentsForTopLevelExercisesTest < ActiveSupport::TestCase
     workout = Workout.create!(name: 'Fran', score_type: :time, interval: '21-15-9')
     workout.exercises.create!(movement: movements(:thruster), position: 1, reps: 1)
     workout.exercises.create!(movement: movements(:pull_up), position: 2, reps: 1)
+    stale_content_key = workout.reload.content_key
 
     BackfillSegmentsForTopLevelExercises.new.up
 
@@ -15,6 +16,17 @@ class BackfillSegmentsForTopLevelExercisesTest < ActiveSupport::TestCase
     assert_nil segment.rounds
     assert_equal [1, 2], segment.exercises.order(:position).pluck(:position)
     assert_empty workout.exercises.where(segment_id: nil)
+    assert_not_equal stale_content_key, workout.reload.content_key
+    assert_equal workout.content_fingerprint, workout.content_key
+  end
+
+  test 'converts workout time from minutes to segment seconds' do
+    workout = Workout.create!(name: 'Time Domain', score_type: :time, time: 12)
+    workout.exercises.create!(movement: movements(:run), position: 1, reps: 400)
+
+    BackfillSegmentsForTopLevelExercises.new.up
+
+    assert_equal 720, workout.reload.segments.sole.time_seconds
   end
 
   test 'preserves existing segments when wrapping a leading rounds run' do

--- a/test/migrations/backfill_segments_for_top_level_exercises_test.rb
+++ b/test/migrations/backfill_segments_for_top_level_exercises_test.rb
@@ -106,6 +106,21 @@ class BackfillSegmentsForTopLevelExercisesTest < ActiveSupport::TestCase
     assert_equal [movements(:run)], middle_segment.exercises.map(&:movement)
   end
 
+  test 'wraps a plain unschemed workout as an implicit segment' do
+    workout = Workout.create!(name: 'Plain Chipper', score_type: :time)
+    workout.exercises.create!(movement: movements(:run), position: 1, reps: 400)
+    workout.exercises.create!(movement: movements(:pull_up), position: 2, reps: 10)
+
+    BackfillSegmentsForTopLevelExercises.new.up
+
+    segment = workout.reload.segments.sole
+    assert_predicate segment, :implicit_workout_part?
+    assert_nil segment.rounds
+    assert_nil segment.time_seconds
+    assert_nil segment.interval_scheme
+    assert_empty workout.exercises.where(segment_id: nil)
+  end
+
   test 'raises for multiple exercise runs in a workout with a scheme' do
     workout = Workout.create!(name: 'Ambiguous', score_type: :time, rounds: 3)
     workout.exercises.create!(movement: movements(:run), position: 1, reps: 400)

--- a/test/migrations/backfill_segments_for_top_level_exercises_test.rb
+++ b/test/migrations/backfill_segments_for_top_level_exercises_test.rb
@@ -20,6 +20,35 @@ class BackfillSegmentsForTopLevelExercisesTest < ActiveSupport::TestCase
     assert_equal workout.content_fingerprint, workout.content_key
   end
 
+  test 'normalizes blank interval strings away from generated segments' do
+    workout = Workout.create!(name: 'Blank Interval', score_type: :time, interval: '')
+    workout.exercises.create!(movement: movements(:run), position: 1, reps: 1)
+
+    BackfillSegmentsForTopLevelExercises.new.up
+
+    segment = workout.reload.segments.sole
+    assert_nil segment.interval_scheme
+    assert_nil segment.rounds
+    assert_nil segment.time_seconds
+  end
+
+  test 'ignores malformed top-level exercises without a workout id' do
+    # Simulates legacy/bad data that cannot be built through the app model validations.
+    # rubocop:disable Rails/SkipsModelValidations
+    Exercise.insert!({
+                       movement_id: movements(:run).id,
+                       position: 1,
+                       reps: 1,
+                       created_at: Time.current,
+                       updated_at: Time.current
+                     })
+    # rubocop:enable Rails/SkipsModelValidations
+
+    assert_nothing_raised { BackfillSegmentsForTopLevelExercises.new.up }
+  ensure
+    Exercise.unscoped.where(workout_id: nil).delete_all
+  end
+
   test 'converts workout time from minutes to segment seconds' do
     workout = Workout.create!(name: 'Time Domain', score_type: :time, time: 12)
     workout.exercises.create!(movement: movements(:run), position: 1, reps: 400)
@@ -27,6 +56,24 @@ class BackfillSegmentsForTopLevelExercisesTest < ActiveSupport::TestCase
     BackfillSegmentsForTopLevelExercises.new.up
 
     assert_equal 720, workout.reload.segments.sole.time_seconds
+  end
+
+  test 'absorbs a duplicate created by wrapping exercises into an equivalent segment' do
+    canonical = Workout.create!(name: 'Segmented Fran', score_type: :time, interval: '21-15-9')
+    segment = canonical.segments.create!(position: 1, interval_scheme: '21-15-9')
+    segment.exercises.create!(movement: movements(:thruster), position: 1, reps: 1)
+    segment.exercises.create!(movement: movements(:pull_up), position: 2, reps: 1)
+
+    duplicate = Workout.create!(name: 'Flat Fran', score_type: :time, interval: '21-15-9')
+    duplicate.exercises.create!(movement: movements(:thruster), position: 1, reps: 1)
+    duplicate.exercises.create!(movement: movements(:pull_up), position: 2, reps: 1)
+
+    assert_difference('Workout.count', -1) do
+      BackfillSegmentsForTopLevelExercises.new.up
+    end
+
+    assert_not Workout.exists?(duplicate.id)
+    assert_equal canonical.reload.content_fingerprint, canonical.content_key
   end
 
   test 'preserves existing segments when wrapping a leading rounds run' do

--- a/test/models/implicit_workout_part_test.rb
+++ b/test/models/implicit_workout_part_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class ImplicitWorkoutPartTest < ActiveSupport::TestCase
+  test 'treats implicit segment exercises as former top-level exercises for scoring' do
+    workout = workouts(:back_squat_5x5)
+    exercise = exercises(:back_squat_5x5_back_squat)
+    wrap_in_segment(workout, exercise, rounds: workout.rounds)
+
+    assert_equal [exercise], workout.reload.top_level_exercises
+    assert_predicate workout, :set_based_lifting?
+  end
+
+  test 'builds set-based lifting recordings from an implicit segment wrapper' do
+    workout = workouts(:back_squat_5x5)
+    exercise = exercises(:back_squat_5x5_back_squat)
+    wrap_in_segment(workout, exercise, rounds: workout.rounds)
+
+    log = workout.reload.logs.build(user: users(:mathew), score_type: :weight)
+    log.build_movement_logs
+
+    assert_equal 5, log.movement_logs.size
+    assert_equal [movements(:back_squat)] * 5, log.movement_logs.map(&:movement)
+  end
+
+  test 'calculates single max-finding score from an implicit segment wrapper' do
+    workout = Workout.create!(name: 'Back Squat Max', score_type: :weight)
+    exercise = workout.exercises.create!(movement: movements(:back_squat), position: 1, reps: 4,
+                                         duration_seconds: 240, load: 0)
+    wrap_in_segment(workout, exercise)
+
+    log = workout.reload.logs.build(user: users(:mathew), score_type: :weight)
+    log.build_movement_logs
+    log.movement_logs.first.load = 405
+
+    assert log.valid?
+    assert_equal 'lb', log.score_type
+    assert_equal 405, log.score_value
+  end
+
+  test 'calculates fixed amrap reps from an implicit segment wrapper' do
+    workout = Workout.create!(name: 'Implicit AMRAP', score_type: :rep, time: 10)
+    exercise = workout.exercises.create!(movement: movements(:pushup), position: 1, reps: 15)
+    wrap_in_segment(workout, exercise, time_seconds: 600)
+
+    assert_equal 15, workout.reload.amrap_reps_per_round
+  end
+
+  private
+
+  def wrap_in_segment(workout, exercise, **attrs)
+    segment = workout.segments.create!({ position: 2 }.merge(attrs))
+    exercise.update!(segment:, position: 1)
+    segment.update!(position: 1)
+  end
+end

--- a/test/system/workout_drag_ordering_test.rb
+++ b/test/system/workout_drag_ordering_test.rb
@@ -123,7 +123,8 @@ class WorkoutDragOrderingTest < ApplicationSystemTestCase
     click_on 'Save Workout'
 
     assert_current_path %r{/workouts/\d+}
-    assert_text_order 'Segment:', '400 meter Run', '10 Pull Ups'
+    assert_text_order '400 meter Run', '10 Pull Ups'
+    assert_no_text 'Segment:'
   end
 
   test 'edits a workout with reordered existing parts' do


### PR DESCRIPTION
## Summary
- add a data-only migration that wraps existing top-level exercise runs in implicit segments
- copy workout-level schemes onto generated segments, including time-to-seconds conversion
- refresh affected workout content keys after restructuring
- add focused migration tests for the requested examples and regressions

## Verification
- rvm 4.0.5@wod-tracker do bundle exec rails test test/migrations/backfill_segments_for_top_level_exercises_test.rb
- rvm 4.0.5@wod-tracker do bundle exec rubocop db/migrate/20260713120000_backfill_segments_for_top_level_exercises.rb
- git diff --check

Closes #1752