### PR TITLE
Wrap all seeded workout exercises in segments

### DIFF
--- a/app/helpers/workouts_helper.rb
+++ b/app/helpers/workouts_helper.rb
@@ -55,7 +55,7 @@ module WorkoutsHelper
   end
 
   def total_reps_clock_objective(workout)
-    "On a #{workout.time}-minute clock for total reps"
+    "On a #{workout.segmented_total_reps_minutes}-minute clock for total reps"
   end
 
   def timed_rounds_objective(workout)

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -49,11 +49,21 @@ class Workout < ApplicationRecord
   end
 
   def segmented_total_reps?
-    amrap? &&
+    segmented_total_reps_minutes.present? &&
       score_measurement == 'rep' &&
       segments.any? &&
       exercises.any? &&
       exercises.none? { |exercise| exercise.segment.blank? }
+  end
+
+  def segmented_total_reps_minutes
+    return time if time.present?
+    return if segments.blank?
+
+    segment_seconds = segments.map(&:time_seconds)
+    return if segment_seconds.any?(&:blank?)
+
+    segment_seconds.sum / 60
   end
 
   def emom?

--- a/db/seeds/benchmark_workouts.rb
+++ b/db/seeds/benchmark_workouts.rb
@@ -13,23 +13,22 @@
 # One point is given for each rep, except on the rower where each calorie is 1 point.
 fight_gone_bad = Workout.find_or_create_by(name: 'Fight Gone Bad') do |workout|
   workout.score_type = :rep
-  workout.rounds = 3
-  workout.time = 18
   workout.notes = 'In this workout you move from each of 5 stations after a minute. ' \
                   'This is a 5-minute round after which a 1-minute break is allowed before repeating. ' \
                   'The clock does not reset or stop between exercises. ' \
                   'On the call of "rotate," the athlete(s) must move to the next station immediately for a good score. ' \
                   'One point is given for each rep, except on the rower where each calorie is 1 point.'
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 0, duration_seconds: 60,
+  segment = workout.segments.build(rounds: 3, time_seconds: 1080, position: 1)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 0, duration_seconds: 60,
                           female_load: 14, male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10,
                           distance_unit: :foot)
-  workout.exercises.build(movement: sumo_deadlift_high_pull, position: 2, reps: 0,
+  segment.exercises.build(movement: sumo_deadlift_high_pull, position: 2, reps: 0,
                           duration_seconds: 60, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 0, duration_seconds: 60, distance: 20, distance_unit: :inch)
-  workout.exercises.build(movement: push_press, position: 4, reps: 0, duration_seconds: 60,
+  segment.exercises.build(movement: box_jump, position: 3, reps: 0, duration_seconds: 60, distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: push_press, position: 4, reps: 0, duration_seconds: 60,
                           female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: row, position: 5, reps: 1, calories: 0, duration_seconds: 60)
-  workout.exercises.build(movement: rest, position: 6, reps: 1, duration_seconds: 60)
+  segment.exercises.build(movement: row, position: 5, reps: 1, calories: 0, duration_seconds: 60)
+  segment.exercises.build(movement: rest, position: 6, reps: 1, duration_seconds: 60)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: fight_gone_bad).update(posted_at: Date.new(2018, 2, 1))
@@ -45,10 +44,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: fight_gone_bad).update(poste
 # 100 squats
 angie = Workout.find_or_create_by(name: 'Angie') do |workout|
   workout.score_type = :time
-  workout.exercises.build(movement: pull_up, position: 1, reps: 100)
-  workout.exercises.build(movement: push_up, position: 2, reps: 100)
-  workout.exercises.build(movement: sit_up, position: 3, reps: 100)
-  workout.exercises.build(movement: air_squat, position: 4, reps: 100)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 100)
+  segment.exercises.build(movement: push_up, position: 2, reps: 100)
+  segment.exercises.build(movement: sit_up, position: 3, reps: 100)
+  segment.exercises.build(movement: air_squat, position: 4, reps: 100)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: angie).update(posted_at: Date.new(2018, 1, 30))
@@ -62,13 +62,13 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: angie).update(posted_at: Dat
 # 50 squats
 # Rest precisely 3 minutes between each round
 barbara = Workout.find_or_create_by(name: 'Barbara') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: pull_up, position: 1, reps: 20)
-  workout.exercises.build(movement: push_up, position: 2, reps: 30)
-  workout.exercises.build(movement: sit_up, position: 3, reps: 40)
-  workout.exercises.build(movement: air_squat, position: 4, reps: 50)
-  workout.exercises.build(movement: rest, position: 5, reps: 1, duration_seconds: 180)
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 20)
+  segment.exercises.build(movement: push_up, position: 2, reps: 30)
+  segment.exercises.build(movement: sit_up, position: 3, reps: 40)
+  segment.exercises.build(movement: air_squat, position: 4, reps: 50)
+  segment.exercises.build(movement: rest, position: 5, reps: 1, duration_seconds: 180)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: barbara).update(posted_at: Date.new(2018, 1, 29))
@@ -80,12 +80,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: barbara).update(posted_at: D
 # 10 push-ups
 # 15 squats
 chelsea = Workout.find_or_create_by(name: 'Chelsea') do |workout|
-  workout.rounds = 30
-  workout.time = 30
   workout.score_type = :rep
-  workout.exercises.build(movement: pull_up, position: 1, reps: 5)
-  workout.exercises.build(movement: push_up, position: 2, reps: 10)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 15)
+  segment = workout.segments.build(rounds: 30, time_seconds: 1800, position: 1)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 5)
+  segment.exercises.build(movement: push_up, position: 2, reps: 10)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 15)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: chelsea).update(posted_at: Date.new(2018, 1, 28))
@@ -97,11 +96,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: chelsea).update(posted_at: D
 # 10 push-ups
 # 15 squats
 cindy = Workout.find_or_create_by(name: 'Cindy') do |workout|
-  workout.time = 20
   workout.score_type = :rep
-  workout.exercises.build(movement: pull_up, position: 1, reps: 5)
-  workout.exercises.build(movement: push_up, position: 2, reps: 10)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 15)
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 5)
+  segment.exercises.build(movement: push_up, position: 2, reps: 10)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 15)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: cindy).update(posted_at: Date.new(2018, 1, 27))
@@ -112,10 +111,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: cindy).update(posted_at: Dat
 # 225-lb. deadlifts
 # Handstand push-ups
 diane = Workout.find_or_create_by(name: 'Diane') do |workout|
-  workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 2, reps: 1)
+  segment = workout.segments.build(interval_scheme: '21-15-9', position: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 2, reps: 1)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: diane).update(posted_at: Date.new(2018, 1, 26))
@@ -126,10 +125,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: diane).update(posted_at: Dat
 # 135-lb. cleans
 # Ring dips
 elizabeth = Workout.find_or_create_by(name: 'Elizabeth') do |workout|
-  workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: clean, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: ring_dip, position: 2, reps: 1)
+  segment = workout.segments.build(interval_scheme: '21-15-9', position: 1)
+  segment.exercises.build(movement: clean, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: ring_dip, position: 2, reps: 1)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: elizabeth).update(posted_at: Date.new(2018, 1, 25))
@@ -140,10 +139,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: elizabeth).update(posted_at:
 # 95-lb. thrusters
 # Pull-ups
 fran = Workout.find_or_create_by(name: 'Fran') do |workout|
-  workout.interval = '21-15-9'
   workout.score_type = :time
-  workout.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 1)
+  segment = workout.segments.build(interval_scheme: '21-15-9', position: 1)
+  segment.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 1)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: fran).update(posted_at: Date.new(2018, 1, 24))
@@ -153,9 +152,9 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: fran).update(posted_at: Date
 # 30 reps for time
 # 135-lb. clean and jerks
 grace = Workout.find_or_create_by(name: 'Grace') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: clean_and_jerk, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: clean_and_jerk, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: grace).update(posted_at: Date.new(2018, 1, 23))
@@ -167,11 +166,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: grace).update(posted_at: Dat
 # 1.5-pood kettlebell swings, 21 reps
 # 12 pull-ups
 helen = Workout.find_or_create_by(name: 'Helen') do |workout|
-  workout.rounds = 3
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 21, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 12)
+  segment = workout.segments.build(rounds: 3, position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 21, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 12)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: helen).update(posted_at: Date.new(2018, 1, 22))
@@ -181,9 +180,9 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: helen).update(posted_at: Dat
 # 30 reps for time
 # 135-lb. snatches
 isabel = Workout.find_or_create_by(name: 'Isabel') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: snatch, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: snatch, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: isabel).update(posted_at: Date.new(2018, 1, 21))
@@ -195,11 +194,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: isabel).update(posted_at: Da
 # 45-lb. thrusters, 50 reps
 # 30 pull-ups
 jackie = Workout.find_or_create_by(name: 'Jackie') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: thruster, position: 2, reps: 50, female_load: 35, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 30)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: thruster, position: 2, reps: 50, female_load: 35, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 30)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: jackie).update(posted_at: Date.new(2018, 1, 20))
@@ -209,9 +208,9 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: jackie).update(posted_at: Da
 # For time
 # 150 wall-ball shots, 20-lb. ball
 karen = Workout.find_or_create_by(name: 'Karen') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 150, female_load: 14,
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 150, female_load: 14,
                           male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10,
                           distance_unit: :foot)
 end
@@ -225,11 +224,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: karen).update(posted_at: Dat
 # Body-weight bench presses
 # 3/4 body-weight cleans
 linda = Workout.find_or_create_by(name: 'Linda') do |workout|
-  workout.interval = '10-9-8-7-6-5-4-3-2-1'
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 1, notes: '1 1/2 body weight')
-  workout.exercises.build(movement: bench_press, position: 2, reps: 1, notes: 'body weight')
-  workout.exercises.build(movement: clean, position: 3, reps: 1, notes: '3/4 body weight')
+  segment = workout.segments.build(interval_scheme: '10-9-8-7-6-5-4-3-2-1', position: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 1, notes: '1 1/2 body weight')
+  segment.exercises.build(movement: bench_press, position: 2, reps: 1, notes: 'body weight')
+  segment.exercises.build(movement: clean, position: 3, reps: 1, notes: '3/4 body weight')
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: linda).update(posted_at: Date.new(2018, 1, 18))
@@ -241,11 +240,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: linda).update(posted_at: Dat
 # 10 1-legged squats
 # 15 pull-ups
 mary = Workout.find_or_create_by(name: 'Mary') do |workout|
-  workout.time = 20
   workout.score_type = :rep
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 5)
-  workout.exercises.build(movement: single_leg_squat_pistol, position: 2, reps: 10)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 15)
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 5)
+  segment.exercises.build(movement: single_leg_squat_pistol, position: 2, reps: 10)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 15)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: mary).update(posted_at: Date.new(2018, 1, 17))
@@ -256,10 +255,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: mary).update(posted_at: Date
 # Run 400 meters
 # 95-lb. overhead squats, 15 reps
 nancy = Workout.find_or_create_by(name: 'Nancy') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: overhead_squat, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: overhead_squat, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: nancy).update(posted_at: Date.new(2018, 1, 16))
@@ -272,10 +271,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: nancy).update(posted_at: Dat
 # Double-unders
 # Sit-ups
 annie = Workout.find_or_create_by(name: 'Annie') do |workout|
-  workout.interval = '50-40-30-20-10'
   workout.score_type = :time
-  workout.exercises.build(movement: double_under, position: 1, reps: 1)
-  workout.exercises.build(movement: sit_up, position: 2, reps: 1)
+  segment = workout.segments.build(interval_scheme: '50-40-30-20-10', position: 1)
+  segment.exercises.build(movement: double_under, position: 1, reps: 1)
+  segment.exercises.build(movement: sit_up, position: 2, reps: 1)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: annie).update(posted_at: Date.new(2018, 1, 15))
@@ -287,11 +286,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: annie).update(posted_at: Dat
 # 2-pood kettlebell swings, 30 reps
 # 30 pull-ups
 eva = Workout.find_or_create_by(name: 'Eva') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 30, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 30)
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 30, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 30)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: eva).update(posted_at: Date.new(2018, 1, 14))
@@ -303,11 +302,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: eva).update(posted_at: Date.
 # 30 box jumps, 24-inch box
 # 30 wall-ball shots, 20-lb. ball
 kelly = Workout.find_or_create_by(name: 'Kelly') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 30, female_load: 14,
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 30, female_load: 14,
                           male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10,
                           distance_unit: :foot)
 end
@@ -321,10 +320,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: kelly).update(posted_at: Dat
 # Body-weight bench press
 # Pull-ups
 lynne = Workout.find_or_create_by(name: 'Lynne') do |workout|
-  workout.rounds = 5
   workout.score_type = :rep
-  workout.exercises.build(movement: bench_press, position: 1, reps: 0, notes: 'body weight')
-  workout.exercises.build(movement: pull_up, position: 2, reps: 30)
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: bench_press, position: 1, reps: 0, notes: 'body weight')
+  segment.exercises.build(movement: pull_up, position: 2, reps: 30)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: lynne).update(posted_at: Date.new(2018, 1, 12))
@@ -336,10 +335,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: lynne).update(posted_at: Dat
 # Run 400 meters
 # Max-reps pull-ups
 nicole = Workout.find_or_create_by(name: 'Nicole') do |workout|
-  workout.time = 20
   workout.score_type = :round
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 0)
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 0)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: nicole).update(posted_at: Date.new(2018, 1, 11))
@@ -350,10 +349,10 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: nicole).update(posted_at: Da
 # Muscle-ups
 # 135-lb. snatches
 amanda = Workout.find_or_create_by(name: 'Amanda') do |workout|
-  workout.interval = '9-7-5'
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 1)
-  workout.exercises.build(movement: snatch, position: 2, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
+  segment = workout.segments.build(interval_scheme: '9-7-5', position: 1)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 1)
+  segment.exercises.build(movement: snatch, position: 2, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: amanda).update(posted_at: Date.new(2018, 1, 10))
@@ -365,9 +364,9 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: amanda).update(posted_at: Da
 # Touch and go at floor only. Even a re-grip off the floor is a foul. No dumping.
 # Use same load for each set. Rest as needed between sets.
 gwen = Workout.find_or_create_by(name: 'Gwen') do |workout|
-  workout.interval = '15-12-9'
   workout.score_type = :weight
-  workout.exercises.build(movement: clean_and_jerk, position: 1, reps: 1, load_unit: :lb)
+  segment = workout.segments.build(interval_scheme: '15-12-9', position: 1)
+  segment.exercises.build(movement: clean_and_jerk, position: 1, reps: 1, load_unit: :lb)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: gwen).update(posted_at: Date.new(2018, 1, 9))
@@ -377,13 +376,13 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: gwen).update(posted_at: Date
 # 50 reps for time
 # Burpee/Push-up/Jumping-Jack/Sit-up/Handstand
 marguerita = Workout.find_or_create_by(name: 'Marguerita') do |workout|
-  workout.rounds = 50
   workout.score_type = :time
-  workout.exercises.build(movement: burpee, position: 1, reps: 1)
-  workout.exercises.build(movement: push_up, position: 2, reps: 1)
-  workout.exercises.build(movement: jumping_jack, position: 3, reps: 1)
-  workout.exercises.build(movement: sit_up, position: 4, reps: 1)
-  workout.exercises.build(movement: handstand, position: 5, reps: 1)
+  segment = workout.segments.build(rounds: 50, position: 1)
+  segment.exercises.build(movement: burpee, position: 1, reps: 1)
+  segment.exercises.build(movement: push_up, position: 2, reps: 1)
+  segment.exercises.build(movement: jumping_jack, position: 3, reps: 1)
+  segment.exercises.build(movement: sit_up, position: 4, reps: 1)
+  segment.exercises.build(movement: handstand, position: 5, reps: 1)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: marguerita).update(posted_at: Date.new(2018, 1, 8))
@@ -395,11 +394,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: marguerita).update(posted_at
 # 40 push-ups
 # 60 squats
 candy = Workout.find_or_create_by(name: 'Candy') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: pull_up, position: 1, reps: 20)
-  workout.exercises.build(movement: push_up, position: 2, reps: 40)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 60)
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 20)
+  segment.exercises.build(movement: push_up, position: 2, reps: 40)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 60)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: candy).update(posted_at: Date.new(2018, 1, 7))
@@ -411,11 +410,11 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: candy).update(posted_at: Dat
 # 40 pull-ups
 # 60 one-legged squats, alternating legs
 maggie = Workout.find_or_create_by(name: 'Maggie') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 20)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 40)
-  workout.exercises.build(movement: single_leg_squat_pistol, position: 3, reps: 60)
+  segment = workout.segments.build(rounds: 5, position: 1)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 20)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 40)
+  segment.exercises.build(movement: single_leg_squat_pistol, position: 3, reps: 60)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: maggie).update(posted_at: Date.new(2018, 1, 6))
@@ -434,8 +433,6 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: maggie).update(posted_at: Da
 # stop between exercises. On the call of "rotate," the athlete(s) must move to
 # the next station immediately for a good score. One point is given for each rep.
 hope = Workout.find_or_create_by(name: 'Hope') do |workout|
-  workout.rounds = 3
-  workout.time = 18
   workout.score_type = :rep
   workout.notes = '"Hope" has the same format as Fight Gone Bad. In this ' \
                   'workout you move from each of five stations after a minute. ' \
@@ -444,12 +441,13 @@ hope = Workout.find_or_create_by(name: 'Hope') do |workout|
                   'between exercises. On call of "rotate," the athlete/s must ' \
                   'move to next station immediately for good score. One point ' \
                   'is given for each rep.'
-  workout.exercises.build(movement: burpee, position: 1, reps: 0)
-  workout.exercises.build(movement: snatch, position: 2, reps: 0, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 0, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: thruster, position: 4, reps: 0, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 5, reps: 0)
-  workout.exercises.build(movement: rest, position: 6, reps: 1, duration_seconds: 60)
+  segment = workout.segments.build(rounds: 3, time_seconds: 1080, position: 1)
+  segment.exercises.build(movement: burpee, position: 1, reps: 0)
+  segment.exercises.build(movement: snatch, position: 2, reps: 0, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 0, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: thruster, position: 4, reps: 0, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 5, reps: 0)
+  segment.exercises.build(movement: rest, position: 6, reps: 1, duration_seconds: 60)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: hope).update(posted_at: Date.new(2018, 1, 5))

--- a/db/seeds/cf_workouts.rb
+++ b/db/seeds/cf_workouts.rb
@@ -26,31 +26,25 @@ crossfit_workout_notes = 'Each 5-minute window begins with a 200-meter run, foll
                          'Source: https://www.crossfit.com/260622'
 
 crossfit_workout = Workout.find_or_create_by(name: 'CF-260622') do |workout|
-  workout.time = 20
   workout.score_type = :rep
   workout.notes = crossfit_workout_notes
 
   first_window = workout.segments.build(name: '0:00-5:00', time_seconds: 300, position: 1)
-  workout.exercises.build(movement: run, segment: first_window, position: 1,
-                          reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: freestanding_shoulder_tap, segment: first_window,
-                          position: 2, reps: 0)
+  first_window.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  first_window.exercises.build(movement: freestanding_shoulder_tap, position: 2, reps: 0)
 
   second_window = workout.segments.build(name: '5:00-10:00', time_seconds: 300, position: 2)
-  workout.exercises.build(movement: run, segment: second_window, position: 1,
-                          reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: skin_the_cat, segment: second_window, position: 2, reps: 0)
+  second_window.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  second_window.exercises.build(movement: skin_the_cat, position: 2, reps: 0)
 
   third_window = workout.segments.build(name: '10:00-15:00', time_seconds: 300, position: 3)
-  workout.exercises.build(movement: run, segment: third_window, position: 1,
-                          reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: l_pull_up, segment: third_window, position: 2, reps: 0)
+  third_window.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  third_window.exercises.build(movement: l_pull_up, position: 2, reps: 0)
 
   fourth_window = workout.segments.build(name: '15:00-20:00', time_seconds: 300, position: 4)
-  workout.exercises.build(movement: run, segment: fourth_window, position: 1,
-                          reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: deficit_push_up, segment: fourth_window, position: 2,
-                          reps: 0, female_distance: 2, male_distance: 4, distance_unit: :inch)
+  fourth_window.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  fourth_window.exercises.build(movement: deficit_push_up, position: 2, reps: 0,
+                                female_distance: 2, male_distance: 4, distance_unit: :inch)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: crossfit_workout).update(posted_at: Date.new(2026, 6, 22))
@@ -67,11 +61,13 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: crossfit_workout).update(pos
 # Then, run 800 meters
 segmented = Workout.find_or_create_by!(name: 'CFJ-181202') do |workout|
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  first_run = workout.segments.build(position: 1)
+  first_run.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
   seg = workout.segments.build(rounds: 10, position: 2)
-  workout.exercises.build(movement: handstand_push_up, segment: seg, position: 1, reps: 10)
-  workout.exercises.build(movement: single_leg_squat_pistol, segment: seg, position: 2, reps: 10)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  seg.exercises.build(movement: handstand_push_up, position: 1, reps: 10)
+  seg.exercises.build(movement: single_leg_squat_pistol, position: 2, reps: 10)
+  final_run = workout.segments.build(position: 3)
+  final_run.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: segmented).update(posted_at: Date.new(2018, 12, 2))
@@ -91,26 +87,29 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: segmented).update(posted_at:
 tabata = Workout.find_or_create_by!(name: 'CFJ-181226') do |workout|
   workout.score_type = :rep
   tab1 = workout.segments.build(rounds: 8, position: 1)
-  workout.exercises.build(movement: handstand_push_up, segment: tab1, position: 1, duration_seconds: 20)
-  workout.exercises.build(movement: rest, segment: tab1, position: 2, duration_seconds: 10)
+  tab1.exercises.build(movement: handstand_push_up, position: 1, duration_seconds: 20)
+  tab1.exercises.build(movement: rest, position: 2, duration_seconds: 10)
 
-  workout.exercises.build(movement: rest, position: 2, duration_seconds: 60)
+  rest_after_tab1 = workout.segments.build(position: 2)
+  rest_after_tab1.exercises.build(movement: rest, position: 1, duration_seconds: 60)
 
   tab2 = workout.segments.build(rounds: 8, position: 3)
-  workout.exercises.build(movement: single_leg_squat_pistol, segment: tab2, position: 1, duration_seconds: 20)
-  workout.exercises.build(movement: rest, segment: tab2, position: 2, duration_seconds: 10)
+  tab2.exercises.build(movement: single_leg_squat_pistol, position: 1, duration_seconds: 20)
+  tab2.exercises.build(movement: rest, position: 2, duration_seconds: 10)
 
-  workout.exercises.build(movement: rest, position: 4, duration_seconds: 60)
+  rest_after_tab2 = workout.segments.build(position: 4)
+  rest_after_tab2.exercises.build(movement: rest, position: 1, duration_seconds: 60)
 
   tab3 = workout.segments.build(rounds: 8, position: 5)
-  workout.exercises.build(movement: push_up, segment: tab3, position: 1, duration_seconds: 20)
-  workout.exercises.build(movement: rest, segment: tab3, position: 2, duration_seconds: 10)
+  tab3.exercises.build(movement: push_up, position: 1, duration_seconds: 20)
+  tab3.exercises.build(movement: rest, position: 2, duration_seconds: 10)
 
-  workout.exercises.build(movement: rest, position: 6, duration_seconds: 60)
+  rest_after_tab3 = workout.segments.build(position: 6)
+  rest_after_tab3.exercises.build(movement: rest, position: 1, duration_seconds: 60)
 
   tab4 = workout.segments.build(rounds: 8, position: 7)
-  workout.exercises.build(movement: jumping_lunge, segment: tab4, position: 1, duration_seconds: 20)
-  workout.exercises.build(movement: rest, segment: tab4, position: 2, duration_seconds: 10)
+  tab4.exercises.build(movement: jumping_lunge, position: 1, duration_seconds: 20)
+  tab4.exercises.build(movement: rest, position: 2, duration_seconds: 10)
 end
 
 CF_PROGRAM.schedules.find_or_initialize_by(workout: tabata).update(posted_at: Date.new(2018, 12, 26))
@@ -129,19 +128,19 @@ CF_PROGRAM.schedules.find_or_initialize_by(workout: tabata).update(posted_at: Da
 # number performed depends on how often the athlete breaks and is logged as the
 # total reps actually completed.
 sled_drag_carry = Workout.find_or_create_by!(name: 'CFJ-260620') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.notes = 'Drag the sled 1,600 meters while carrying a barbell in the ' \
                   'front rack; the barbell and sled are loaded the same and the ' \
                   'sled attaches at the waist. Every time you stop, complete 15 ' \
                   'bent-over rows before resuming. Take strategic breaks to hold ' \
                   'a steady pace rather than dragging until forced to stop.'
-  workout.exercises.build(movement: sled_drag, position: 1, reps: 1, distance: 1600, distance_unit: :meter,
-                          female_load: 95, male_load: 135, load_unit: :lb,
-                          notes: 'Carry a barbell in the front rack while dragging the waist sled; ' \
-                                 'barbell and sled loaded the same.')
+  main = workout.segments.build(position: 1)
+  main.exercises.build(movement: sled_drag, position: 1, reps: 1, distance: 1600, distance_unit: :meter,
+                       female_load: 95, male_load: 135, load_unit: :lb,
+                       notes: 'Carry a barbell in the front rack while dragging the waist sled; ' \
+                              'barbell and sled loaded the same.')
   penalty = workout.segments.build(position: 2, name: 'Every time you stop')
-  workout.exercises.build(movement: bent_over_row, segment: penalty, position: 1, reps: 15,
+  penalty.exercises.build(movement: bent_over_row, position: 1, reps: 15,
                           female_load: 95, male_load: 135, load_unit: :lb,
                           notes: 'Performed with the barbell. Log the total reps actually completed.')
 end

--- a/db/seeds/hero_workouts.rb
+++ b/db/seeds/hero_workouts.rb
@@ -15,40 +15,40 @@
 # Abbate
 # For time: 1-mile run, 21 clean and jerks, 800-meter run, 21 clean and jerks, 1-mile run
 Workout.find_or_create_by(name: 'Abbate') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: clean_and_jerk, position: 2, reps: 21, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: clean_and_jerk, position: 4, reps: 21, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: clean_and_jerk, position: 2, reps: 21, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: clean_and_jerk, position: 4, reps: 21, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Adambrown
 # 2 rounds for time: 24 deadlift, 24 box jump, 24 wall-ball, 24 bench press, 24 box jump, 24 wall-ball, 24 clean
 Workout.find_or_create_by(name: 'Adambrown') do |workout|
-  workout.rounds = 2
+  segment = workout.segments.build(rounds: 2, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 24, female_load: 95, male_load: 295, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 24, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 24, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: bench_press, position: 4, reps: 24, female_load: 135, male_load: 195, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 5, reps: 24, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 6, reps: 24, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: clean, position: 7, reps: 24, female_load: 95, male_load: 145, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 24, female_load: 95, male_load: 295, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 24, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 24, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: bench_press, position: 4, reps: 24, female_load: 135, male_load: 195, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 5, reps: 24, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 6, reps: 24, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: clean, position: 7, reps: 24, female_load: 95, male_load: 145, load_unit: :lb)
 end
 
 # ==============================================================================
 # Adrian
 # 7 rounds for time: 3 forward rolls, 5 wall climbs, 7 toes-to-bars, 9 box jumps
 Workout.find_or_create_by(name: 'Adrian') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: forward_roll, position: 1, reps: 3)
-  workout.exercises.build(movement: wall_walk, position: 2, reps: 5)
-  workout.exercises.build(movement: toes_to_bar, position: 3, reps: 7)
-  workout.exercises.build(movement: box_jump, position: 4, reps: 9, female_distance: 24, male_distance: 30, distance_unit: :inch)
+  segment.exercises.build(movement: forward_roll, position: 1, reps: 3)
+  segment.exercises.build(movement: wall_walk, position: 2, reps: 5)
+  segment.exercises.build(movement: toes_to_bar, position: 3, reps: 7)
+  segment.exercises.build(movement: box_jump, position: 4, reps: 9, female_distance: 24, male_distance: 30, distance_unit: :inch)
 end
 
 # ==============================================================================
@@ -56,45 +56,45 @@ end
 # For time: 3 rounds (8 burpees, 28 air squats, 9 push-ups); run 1,000m, 25 over-the-shoulder
 # sandbag cleans, run 1,000m; 5 rounds (10 deadlifts, 14 box jumps, 10 burpees)
 Workout.find_or_create_by(name: 'Alec') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   triplet = workout.segments.build(rounds: 3, position: 1)
-  workout.exercises.build(movement: burpee, segment: triplet, position: 1, reps: 8)
-  workout.exercises.build(movement: air_squat, segment: triplet, position: 2, reps: 28)
-  workout.exercises.build(movement: push_up, segment: triplet, position: 3, reps: 9)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: sandbag_clean, position: 3, reps: 25, notes: 'Over the shoulder.', female_load: 75, male_load: 100, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 1000, distance_unit: :meter)
+  triplet.exercises.build(movement: burpee, position: 1, reps: 8)
+  triplet.exercises.build(movement: air_squat, position: 2, reps: 28)
+  triplet.exercises.build(movement: push_up, position: 3, reps: 9)
+  middle = workout.segments.build(position: 2)
+  middle.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  middle.exercises.build(movement: sandbag_clean, position: 2, reps: 25, notes: 'Over the shoulder.', female_load: 75, male_load: 100, load_unit: :lb)
+  middle.exercises.build(movement: run, position: 3, reps: 1, distance: 1000, distance_unit: :meter)
   finisher = workout.segments.build(rounds: 5, position: 5)
-  workout.exercises.build(movement: deadlift, segment: finisher, position: 1, reps: 10, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, segment: finisher, position: 2, reps: 14, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: burpee, segment: finisher, position: 3, reps: 10)
+  finisher.exercises.build(movement: deadlift, position: 1, reps: 10, female_load: 155, male_load: 225, load_unit: :lb)
+  finisher.exercises.build(movement: box_jump, position: 2, reps: 14, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  finisher.exercises.build(movement: burpee, position: 3, reps: 10)
 end
 
 # ==============================================================================
 # Alexander
 # 5 rounds for time: 31 back squats, 12 power cleans
 Workout.find_or_create_by(name: 'Alexander') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: back_squat, position: 1, reps: 31, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: power_clean, position: 2, reps: 12, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: back_squat, position: 1, reps: 31, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: power_clean, position: 2, reps: 12, female_load: 125, male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
 # Andy
 # For time: 25 thrusters, 50 box jumps, 75 deadlifts, 1.5-mile run, 75 deadlifts, 50 box jumps, 25 thrusters
 Workout.find_or_create_by(name: 'Andy') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 25, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 75, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 2400, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 5, reps: 75, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 6, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: thruster, position: 7, reps: 25, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: thruster, position: 1, reps: 25, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 75, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 2400, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 5, reps: 75, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 6, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: thruster, position: 7, reps: 25, female_load: 75, male_load: 115, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -102,62 +102,62 @@ end
 # With a single kettlebell for time: 21 Turkish get-ups (R), 50 KB swings, 21 overhead squats (L),
 # 50 KB swings, 21 overhead squats (R), 50 KB swings, 21 Turkish get-ups (L)
 Workout.find_or_create_by(name: 'Arnie') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Performed with a single kettlebell.'
-  workout.exercises.build(movement: turkish_get_up, position: 1, reps: 21, notes: 'Right arm.', female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 50, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: overhead_squat, position: 3, reps: 21, notes: 'Left arm.', female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_swing, position: 4, reps: 50, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: overhead_squat, position: 5, reps: 21, notes: 'Right arm.', female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_swing, position: 6, reps: 50, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: turkish_get_up, position: 7, reps: 21, notes: 'Left arm.', female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: turkish_get_up, position: 1, reps: 21, notes: 'Right arm.', female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 50, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: overhead_squat, position: 3, reps: 21, notes: 'Left arm.', female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_swing, position: 4, reps: 50, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: overhead_squat, position: 5, reps: 21, notes: 'Right arm.', female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_swing, position: 6, reps: 50, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: turkish_get_up, position: 7, reps: 21, notes: 'Left arm.', female_load: 53, male_load: 70, load_unit: :lb)
 end
 
 # ==============================================================================
 # Artie
 # AMRAP in 20 minutes: 5 pull-ups, 10 push-ups, 15 squats, 5 pull-ups, 10 thrusters
 Workout.find_or_create_by(name: 'Artie') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: pull_up, position: 1, reps: 5)
-  workout.exercises.build(movement: push_up, position: 2, reps: 10)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 15)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 5)
-  workout.exercises.build(movement: thruster, position: 5, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 5)
+  segment.exercises.build(movement: push_up, position: 2, reps: 10)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 15)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 5)
+  segment.exercises.build(movement: thruster, position: 5, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
 # Badger
 # 3 rounds for time: 30 squat cleans, 30 pull-ups, run 800 meters
 Workout.find_or_create_by(name: 'Badger') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: clean_squat, position: 1, reps: 30, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 30)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 30, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 30)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Barraza
 # AMRAP in 18 minutes: run 200m, 9 deadlifts, 6 burpee bar muscle-ups
 Workout.find_or_create_by(name: 'Barraza') do |workout|
-  workout.time = 18
+  segment = workout.segments.build(time_seconds: 1080, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 9, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: burpee_bar_muscle_up, position: 3, reps: 6)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 9, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: burpee_bar_muscle_up, position: 3, reps: 6)
 end
 
 # ==============================================================================
 # Bell
 # 3 rounds for time: 21 deadlifts, 15 pull-ups, 9 front squats
 Workout.find_or_create_by(name: 'Bell') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 21, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 15)
-  workout.exercises.build(movement: front_squat, position: 3, reps: 9, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 21, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 15)
+  segment.exercises.build(movement: front_squat, position: 3, reps: 9, female_load: 125, male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -165,166 +165,168 @@ end
 # For time: 50 burpees, 400m run, 100 push-ups, 400m run, 150 walking lunges, 400m run,
 # 200 squats, 400m run, 150 walking lunges, 400m run, 100 push-ups, 400m run, 50 burpees
 Workout.find_or_create_by(name: 'Bert') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: burpee, position: 1, reps: 50)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 3, reps: 100)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: walking_lunge, position: 5, reps: 150)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: air_squat, position: 7, reps: 200)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: walking_lunge, position: 9, reps: 150)
-  workout.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 11, reps: 100)
-  workout.exercises.build(movement: run, position: 12, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee, position: 13, reps: 50)
+  segment.exercises.build(movement: burpee, position: 1, reps: 50)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 3, reps: 100)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: walking_lunge, position: 5, reps: 150)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: air_squat, position: 7, reps: 200)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: walking_lunge, position: 9, reps: 150)
+  segment.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 11, reps: 100)
+  segment.exercises.build(movement: run, position: 12, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee, position: 13, reps: 50)
 end
 
 # ==============================================================================
 # Big Sexy
 # 5 rounds for time: 6 deadlifts, 6 burpees, 5 cleans, 5 chest-to-bar pull-ups, 4 thrusters, 4 muscle-ups
 Workout.find_or_create_by(name: 'Big Sexy') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 2, reps: 6)
-  workout.exercises.build(movement: clean, position: 3, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 5)
-  workout.exercises.build(movement: thruster, position: 5, reps: 4, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 6, reps: 4)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 2, reps: 6)
+  segment.exercises.build(movement: clean, position: 3, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 5)
+  segment.exercises.build(movement: thruster, position: 5, reps: 4, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 6, reps: 4)
 end
 
 # ==============================================================================
 # Blake
 # 4 rounds for time: 100-foot overhead walking lunge, 30 box jumps, 20 wall-ball shots, 10 handstand push-ups
 Workout.find_or_create_by(name: 'Blake') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: overhead_walking_lunge, position: 1, reps: 1, distance: 100, distance_unit: :foot, female_load: 25, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 20, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 4, reps: 10)
+  segment.exercises.build(movement: overhead_walking_lunge, position: 1, reps: 1, distance: 100, distance_unit: :foot, female_load: 25, male_load: 45,
+                          load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 20, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 4, reps: 10)
 end
 
 # ==============================================================================
 # Bowen
 # 3 rounds for time: 800m run, 7 deadlifts, 10 burpee pull-ups, 14 single-arm KB thrusters (7 each), 20 box jumps
 Workout.find_or_create_by(name: 'Bowen') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 7, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: burpee_pull_up, position: 3, reps: 10)
-  workout.exercises.build(movement: kettlebell_thruster, position: 4, reps: 14, notes: 'Single arm, 7 each arm.', female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 5, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 7, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: burpee_pull_up, position: 3, reps: 10)
+  segment.exercises.build(movement: kettlebell_thruster, position: 4, reps: 14, notes: 'Single arm, 7 each arm.', female_load: 35, male_load: 53,
+                          load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 5, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
 # Bradley
 # 10 rounds for time: sprint 100m, 10 pull-ups, sprint 100m, 10 burpees, rest 30 seconds
 Workout.find_or_create_by(name: 'Bradley') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: pull_up, position: 2, reps: 10)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: burpee, position: 4, reps: 10)
-  workout.exercises.build(movement: rest, position: 5, duration_seconds: 30)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: pull_up, position: 2, reps: 10)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: burpee, position: 4, reps: 10)
+  segment.exercises.build(movement: rest, position: 5, duration_seconds: 30)
 end
 
 # ==============================================================================
 # Bradshaw
 # 10 rounds for time: 3 handstand push-ups, 6 deadlifts, 12 pull-ups, 24 double-unders
 Workout.find_or_create_by(name: 'Bradshaw') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 3)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 6, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 12)
-  workout.exercises.build(movement: double_under, position: 4, reps: 24)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 3)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 6, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 12)
+  segment.exercises.build(movement: double_under, position: 4, reps: 24)
 end
 
 # ==============================================================================
 # Brehm
 # For time: 10 rope climbs to 15 feet, 20 back squats, 30 handstand push-ups, 40-calorie row
 Workout.find_or_create_by(name: 'Brehm') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 10, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 20, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 3, reps: 30)
-  workout.exercises.build(movement: row, position: 4, reps: 1, calories: 40)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 10, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 20, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 3, reps: 30)
+  segment.exercises.build(movement: row, position: 4, reps: 1, calories: 40)
 end
 
 # ==============================================================================
 # Brenton
 # 5 rounds for time: 100-foot bear crawl, 100-foot broad jump. 3 burpees after every 5 broad jumps.
 Workout.find_or_create_by(name: 'Brenton') do |workout|
-  workout.rounds = 5
   workout.score_type = :time
-  workout.exercises.build(movement: bear_crawl, position: 1, reps: 1, distance: 100, distance_unit: :foot)
-  workout.exercises.build(movement: broad_jump, position: 2, reps: 1, distance: 100, distance_unit: :foot)
+  main = workout.segments.build(rounds: 5, position: 1)
+  main.exercises.build(movement: bear_crawl, position: 1, reps: 1, distance: 100, distance_unit: :foot)
+  main.exercises.build(movement: broad_jump, position: 2, reps: 1, distance: 100, distance_unit: :foot)
   penalty = workout.segments.build(position: 3, name: 'After every 5 broad jumps')
-  workout.exercises.build(movement: burpee, segment: penalty, position: 1, reps: 3)
+  penalty.exercises.build(movement: burpee, position: 1, reps: 3)
 end
 
 # ==============================================================================
 # Brian
 # 3 rounds for time: 5 rope climbs to 15 feet, 25 back squats
 Workout.find_or_create_by(name: 'Brian') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 5, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 25, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 5, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 25, female_load: 125, male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
 # Bruck
 # 4 rounds for time: 400m run, 24 back squats, 24 jerks
 Workout.find_or_create_by(name: 'Bruck') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 24, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: jerk, position: 3, reps: 24, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 24, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: jerk, position: 3, reps: 24, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Bulger
 # 10 rounds for time: 150m run, 7 chest-to-bar pull-ups, 7 front squats, 7 handstand push-ups
 Workout.find_or_create_by(name: 'Bulger') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 150, distance_unit: :meter)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 7)
-  workout.exercises.build(movement: front_squat, position: 3, reps: 7, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 4, reps: 7)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 150, distance_unit: :meter)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 7)
+  segment.exercises.build(movement: front_squat, position: 3, reps: 7, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 4, reps: 7)
 end
 
 # ==============================================================================
 # Bull
 # 2 rounds for time: 200 double-unders, 50 overhead squats, 50 pull-ups, 1-mile run
 Workout.find_or_create_by(name: 'Bull') do |workout|
-  workout.rounds = 2
+  segment = workout.segments.build(rounds: 2, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: double_under, position: 1, reps: 200)
-  workout.exercises.build(movement: overhead_squat, position: 2, reps: 50, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 50)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: double_under, position: 1, reps: 200)
+  segment.exercises.build(movement: overhead_squat, position: 2, reps: 50, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 50)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Buriak
 # AMRAP in 20 minutes: 5 squat cleans, 10 burpees over the bar, 15 pull-ups, 200m run
 Workout.find_or_create_by(name: 'Buriak') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: clean_squat, position: 1, reps: 5, female_load: 135, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: over_the_bar_burpee, position: 2, reps: 10)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 15)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 5, female_load: 135, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: over_the_bar_burpee, position: 2, reps: 10)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 15)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 200, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -333,34 +335,35 @@ end
 # 50 back extensions, 25 ring dips, 50 knees-to-elbows, 25 wall-ball two-for-ones, 50 sit-ups,
 # 5 rope climbs to 15 feet
 Workout.find_or_create_by(name: 'Cameron') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: walking_lunge, position: 1, reps: 50)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 25)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: triple_under, position: 4, reps: 25)
-  workout.exercises.build(movement: back_extensions, position: 5, reps: 50)
-  workout.exercises.build(movement: ring_dip, position: 6, reps: 25)
-  workout.exercises.build(movement: knees_to_elbows, position: 7, reps: 50)
-  workout.exercises.build(movement: wall_ball_two_for_one, position: 8, reps: 25, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: sit_up, position: 9, reps: 50)
-  workout.exercises.build(movement: rope_climb, position: 10, reps: 5, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: walking_lunge, position: 1, reps: 50)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 25)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: triple_under, position: 4, reps: 25)
+  segment.exercises.build(movement: back_extensions, position: 5, reps: 50)
+  segment.exercises.build(movement: ring_dip, position: 6, reps: 25)
+  segment.exercises.build(movement: knees_to_elbows, position: 7, reps: 50)
+  segment.exercises.build(movement: wall_ball_two_for_one, position: 8, reps: 25, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20,
+                          load_unit: :lb)
+  segment.exercises.build(movement: sit_up, position: 9, reps: 50)
+  segment.exercises.build(movement: rope_climb, position: 10, reps: 5, distance: 15, distance_unit: :foot)
 end
 
 # ==============================================================================
 # Capoot
 # For time: 100 push-ups, run 800m, 75 push-ups, run 1,200m, 50 push-ups, run 1,600m, 25 push-ups, run 2,000m
 Workout.find_or_create_by(name: 'Capoot') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: push_up, position: 1, reps: 100)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 3, reps: 75)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 1200, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 5, reps: 50)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 7, reps: 25)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 1, reps: 100)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 3, reps: 75)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 1200, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 5, reps: 50)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 7, reps: 25)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 2000, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -368,23 +371,24 @@ end
 # 21-18-15-12-9-6-3 reps for time: squat cleans, double-unders, deadlifts, box jumps.
 # Begin each round with a 50-meter bear crawl.
 Workout.find_or_create_by(name: 'Carse') do |workout|
-  workout.interval = '21-18-15-12-9-6-3'
+  segment = workout.segments.build(interval_scheme: '21-18-15-12-9-6-3', position: 1)
   workout.score_type = :time
   workout.notes = 'Begin each round with a 50-meter bear crawl.'
-  workout.exercises.build(movement: clean_squat, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 2, reps: 1)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 1, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 4, reps: 1, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 2, reps: 1)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 1, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 4, reps: 1, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
 # CHAD1000x
 # For time: 1,000 weighted box step-ups
 Workout.find_or_create_by(name: 'CHAD1000x') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Performed with a weighted ruck or vest.'
-  workout.exercises.build(movement: box_step_up, position: 1, reps: 1000, notes: 'Weighted.', female_distance: 20, male_distance: 20, distance_unit: :inch, female_load: 35, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: box_step_up, position: 1, reps: 1000, notes: 'Weighted.', female_distance: 20, male_distance: 20, distance_unit: :inch,
+                          female_load: 35, male_load: 45, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -394,37 +398,38 @@ end
 # (105/155 lb). One partner holds the barbell in the front rack while the other
 # completes a full round, then they switch stations.
 Workout.find_or_create_by(name: 'City 100') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner. One partner holds the barbell in the front rack while the other ' \
                   'completes a full round of the complex, then switch stations.'
-  workout.exercises.build(movement: shuttle_run, position: 1, reps: 31, notes: '7 meters down, 7 meters back.')
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: shuttle_run, position: 1, reps: 31, notes: '7 meters down, 7 meters back.')
   complex = workout.segments.build(rounds: 10, position: 2)
-  workout.exercises.build(movement: deadlift, segment: complex, position: 1, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: hang_power_clean, segment: complex, position: 2, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: overhead_walking_lunge, segment: complex, position: 3, reps: 1, distance: 7, distance_unit: :meter, female_load: 105, male_load: 155, load_unit: :lb)
+  complex.exercises.build(movement: deadlift, position: 1, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
+  complex.exercises.build(movement: hang_power_clean, position: 2, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
+  complex.exercises.build(movement: overhead_walking_lunge, position: 3, reps: 1, distance: 7, distance_unit: :meter, female_load: 105, male_load: 155,
+                          load_unit: :lb)
 end
 
 # ==============================================================================
 # Clovis
 # For time: run 10 miles, 150 burpee pull-ups. Partition as needed.
 Workout.find_or_create_by(name: 'Clovis') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Partition the run and burpee pull-ups as needed.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 16000, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_pull_up, position: 2, reps: 150)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 16_000, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_pull_up, position: 2, reps: 150)
 end
 
 # ==============================================================================
 # Coe
 # 10 rounds for time: 10 thrusters, 10 ring push-ups
 Workout.find_or_create_by(name: 'Coe') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: thruster, position: 1, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: ring_push_up, position: 2, reps: 10)
+  segment.exercises.build(movement: thruster, position: 1, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: ring_push_up, position: 2, reps: 10)
 end
 
 # ==============================================================================
@@ -432,44 +437,44 @@ end
 # For time: 800m run, 50 back squats, 50 bench presses, 800m run, 35 back squats, 35 bench presses,
 # 800m run, 20 back squats, 20 bench presses, 800m run, 1 muscle-up
 Workout.find_or_create_by(name: 'Coffey') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 50, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: bench_press, position: 3, reps: 50, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: back_squat, position: 5, reps: 35, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: bench_press, position: 6, reps: 35, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: back_squat, position: 8, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: bench_press, position: 9, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 10, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: muscle_up, position: 11, reps: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 50, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: bench_press, position: 3, reps: 50, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 5, reps: 35, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: bench_press, position: 6, reps: 35, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 8, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: bench_press, position: 9, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 10, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: muscle_up, position: 11, reps: 1)
 end
 
 # ==============================================================================
 # Coffland
 # Hang from a pull-up bar for 6 minutes. Each time you drop, complete 800m run and 30 push-ups.
 Workout.find_or_create_by(name: 'Coffland') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.notes = 'Accumulate a total of 6 minutes hanging from a pull-up bar.'
-  workout.exercises.build(movement: bar_hang, position: 1, duration_seconds: 360)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: bar_hang, position: 1, duration_seconds: 360)
   penalty = workout.segments.build(position: 2, name: 'Each time you drop from the bar')
-  workout.exercises.build(movement: run, segment: penalty, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, segment: penalty, position: 2, reps: 30)
+  penalty.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  penalty.exercises.build(movement: push_up, position: 2, reps: 30)
 end
 
 # ==============================================================================
 # Collin
 # 6 rounds for time: 400m sandbag carry, 12 push presses, 12 box jumps, 12 sumo deadlift high pulls
 Workout.find_or_create_by(name: 'Collin') do |workout|
-  workout.rounds = 6
+  segment = workout.segments.build(rounds: 6, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: sandbag_carry, position: 1, reps: 1, distance: 400, distance_unit: :meter, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: push_press, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 12, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: sumo_deadlift_high_pull, position: 4, reps: 12, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: sandbag_carry, position: 1, reps: 1, distance: 400, distance_unit: :meter, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: push_press, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 12, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: sumo_deadlift_high_pull, position: 4, reps: 12, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -477,22 +482,22 @@ end
 # 2 rounds for time: 34 push-ups, 50-yd sprint, 34 deadlifts, 50-yd sprint, 34 box jumps, 50-yd sprint,
 # 34 clean and jerks, 50-yd sprint, 34 burpees, 50-yd sprint, 34 wall-ball shots, 50-yd sprint, 34 pull-ups, 50-yd sprint
 Workout.find_or_create_by(name: 'Crain') do |workout|
-  workout.rounds = 2
+  segment = workout.segments.build(rounds: 2, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: push_up, position: 1, reps: 34)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
-  workout.exercises.build(movement: deadlift, position: 3, reps: 34, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
-  workout.exercises.build(movement: box_jump, position: 5, reps: 34, female_distance: 24, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
-  workout.exercises.build(movement: clean_and_jerk, position: 7, reps: 34, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
-  workout.exercises.build(movement: burpee, position: 9, reps: 34)
-  workout.exercises.build(movement: run, position: 10, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
-  workout.exercises.build(movement: wall_ball_shot, position: 11, reps: 34, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 12, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
-  workout.exercises.build(movement: pull_up, position: 13, reps: 34)
-  workout.exercises.build(movement: run, position: 14, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: push_up, position: 1, reps: 34)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: deadlift, position: 3, reps: 34, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: box_jump, position: 5, reps: 34, female_distance: 24, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: clean_and_jerk, position: 7, reps: 34, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: burpee, position: 9, reps: 34)
+  segment.exercises.build(movement: run, position: 10, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: wall_ball_shot, position: 11, reps: 34, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 12, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
+  segment.exercises.build(movement: pull_up, position: 13, reps: 34)
+  segment.exercises.build(movement: run, position: 14, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard sprint.')
 end
 
 # ==============================================================================
@@ -502,19 +507,21 @@ end
 Workout.find_or_create_by(name: 'Dragon') do |workout|
   workout.score_type = :weight
   workout.notes = 'Post loads for both lifts.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 4, duration_seconds: 240, load_unit: :lb)
-  workout.exercises.build(movement: push_jerk, position: 2, reps: 4, duration_seconds: 240, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 4, duration_seconds: 240, load_unit: :lb)
+  segment.exercises.build(movement: push_jerk, position: 2, reps: 4, duration_seconds: 240, load_unit: :lb)
 end
 
 # ==============================================================================
 # Dae Han
 # 3 rounds for time: run 800m with an empty barbell, 3 rope climbs, 12 thrusters
 Workout.find_or_create_by(name: 'Dae Han') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry an empty barbell.', female_load: 35, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 2, reps: 3, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: thruster, position: 3, reps: 12, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry an empty barbell.', female_load: 35,
+                          male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 2, reps: 3, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: thruster, position: 3, reps: 12, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -525,32 +532,32 @@ Workout.find_or_create_by(name: 'Dallas 5') do |workout|
   workout.score_type = :rep
   workout.notes = 'Complete as many reps as possible at each 5-minute station. Rest 1 minute between stations.'
   station_one = workout.segments.build(position: 1, name: 'Station 1: burpees', time_seconds: 300)
-  workout.exercises.build(movement: burpee, segment: station_one, position: 1, reps: 0)
+  station_one.exercises.build(movement: burpee, position: 1, reps: 0)
   station_two = workout.segments.build(position: 2, name: 'Station 2', time_seconds: 300)
-  workout.exercises.build(movement: deadlift, segment: station_two, position: 1, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, segment: station_two, position: 2, reps: 7, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  station_two.exercises.build(movement: deadlift, position: 1, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
+  station_two.exercises.build(movement: box_jump, position: 2, reps: 7, female_distance: 20, male_distance: 24, distance_unit: :inch)
   station_three = workout.segments.build(position: 3, name: 'Station 3: Turkish get-ups', time_seconds: 300)
-  workout.exercises.build(movement: turkish_get_up, segment: station_three, position: 1, reps: 0, female_load: 30, male_load: 40, load_unit: :lb)
+  station_three.exercises.build(movement: turkish_get_up, position: 1, reps: 0, female_load: 30, male_load: 40, load_unit: :lb)
   station_four = workout.segments.build(position: 4, name: 'Station 4', time_seconds: 300)
-  workout.exercises.build(movement: snatch, segment: station_four, position: 1, reps: 7, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: push_up, segment: station_four, position: 2, reps: 7)
+  station_four.exercises.build(movement: snatch, position: 1, reps: 7, female_load: 55, male_load: 75, load_unit: :lb)
+  station_four.exercises.build(movement: push_up, position: 2, reps: 7)
   station_five = workout.segments.build(position: 5, name: 'Station 5: row for calories', time_seconds: 300)
-  workout.exercises.build(movement: row, segment: station_five, position: 1, reps: 1, calories: 0)
+  station_five.exercises.build(movement: row, position: 1, reps: 1, calories: 0)
 end
 
 # ==============================================================================
 # Daniel
 # For time: 50 pull-ups, 400m run, 21 thrusters, 800m run, 21 thrusters, 400m run, 50 pull-ups
 Workout.find_or_create_by(name: 'Daniel') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: pull_up, position: 1, reps: 50)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: thruster, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: thruster, position: 5, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: pull_up, position: 7, reps: 50)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 50)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: thruster, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: thruster, position: 5, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: pull_up, position: 7, reps: 50)
 end
 
 # ==============================================================================
@@ -558,28 +565,32 @@ end
 # 5 rounds for time: 25-ft double-KB front-rack lunge, 9 strict pull-ups, 50-ft double-KB overhead carry,
 # 16 hand-release push-ups, 75-ft double-KB front-rack carry, 23 air squats, 100-ft double-KB farmers carry, 400m run
 Workout.find_or_create_by(name: 'Daniel Ray') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'If you have a weight vest or body armor, wear it. All carries use two kettlebells.'
-  workout.exercises.build(movement: dumbbell_front_rack_lunge, position: 1, reps: 1, distance: 25, distance_unit: :foot, notes: 'Double kettlebell, front rack.', female_load: 35, male_load: 53, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: strict_pull_up, position: 2, reps: 9)
-  workout.exercises.build(movement: overhead_walk, position: 3, reps: 1, distance: 50, distance_unit: :foot, notes: 'Double kettlebell.', female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: hand_release_push_up, position: 4, reps: 16)
-  workout.exercises.build(movement: farmers_carry, position: 5, reps: 1, distance: 75, distance_unit: :foot, notes: 'Double kettlebell, front rack.', female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: air_squat, position: 6, reps: 23)
-  workout.exercises.build(movement: farmers_carry, position: 7, reps: 1, distance: 100, distance_unit: :foot, notes: 'Double kettlebell.', female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_front_rack_lunge, position: 1, reps: 1, distance: 25, distance_unit: :foot,
+                          notes: 'Double kettlebell, front rack.', female_load: 35, male_load: 53, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: strict_pull_up, position: 2, reps: 9)
+  segment.exercises.build(movement: overhead_walk, position: 3, reps: 1, distance: 50, distance_unit: :foot, notes: 'Double kettlebell.', female_load: 35,
+                          male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: hand_release_push_up, position: 4, reps: 16)
+  segment.exercises.build(movement: farmers_carry, position: 5, reps: 1, distance: 75, distance_unit: :foot, notes: 'Double kettlebell, front rack.',
+                          female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: air_squat, position: 6, reps: 23)
+  segment.exercises.build(movement: farmers_carry, position: 7, reps: 1, distance: 100, distance_unit: :foot, notes: 'Double kettlebell.', female_load: 35,
+                          male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Danny
 # AMRAP in 20 minutes: 30 box jumps, 20 push presses, 30 pull-ups
 Workout.find_or_create_by(name: 'Danny') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: box_jump, position: 1, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: push_press, position: 2, reps: 20, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 30)
+  segment.exercises.build(movement: box_jump, position: 1, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: push_press, position: 2, reps: 20, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 30)
 end
 
 # ==============================================================================
@@ -587,50 +598,55 @@ end
 # For time: 25 burpees, 400m run w/ med ball, 25 weighted pull-ups w/ dumbbell, 400m run w/ med ball,
 # 25 handstand push-ups, 400m run w/ med ball, 25 chest-to-bar pull-ups, 400m run w/ med ball, 25 burpees
 Workout.find_or_create_by(name: 'Del') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: burpee, position: 1, reps: 25)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: weighted_pull_up, position: 3, reps: 25, notes: 'Holding a dumbbell.', female_load: 15, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 5, reps: 25)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 7, reps: 25)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 9, reps: 25)
+  segment.exercises.build(movement: burpee, position: 1, reps: 25)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: weighted_pull_up, position: 3, reps: 25, notes: 'Holding a dumbbell.', female_load: 15, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 5, reps: 25)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 7, reps: 25)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 9, reps: 25)
 end
 
 # ==============================================================================
 # Desforges
 # 5 rounds for time: 12 deadlifts, 20 pull-ups, 12 clean and jerks, 20 knees-to-elbows
 Workout.find_or_create_by(name: 'Desforges') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 12, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 20)
-  workout.exercises.build(movement: clean_and_jerk, position: 3, reps: 12, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: knees_to_elbows, position: 4, reps: 20)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 12, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 20)
+  segment.exercises.build(movement: clean_and_jerk, position: 3, reps: 12, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: knees_to_elbows, position: 4, reps: 20)
 end
 
 # ==============================================================================
 # DG
 # AMRAP in 10 minutes: 8 toes-to-bars, 8 dumbbell thrusters, 12 dumbbell walking lunges
 Workout.find_or_create_by(name: 'DG') do |workout|
-  workout.time = 10
+  segment = workout.segments.build(time_seconds: 600, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: toes_to_bar, position: 1, reps: 8)
-  workout.exercises.build(movement: dumbbell_thruster, position: 2, reps: 8, female_load: 20, male_load: 35, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: walking_lunge, position: 3, reps: 12, notes: 'Holding dumbbells.', female_load: 20, male_load: 35, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 1, reps: 8)
+  segment.exercises.build(movement: dumbbell_thruster, position: 2, reps: 8, female_load: 20, male_load: 35, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: walking_lunge, position: 3, reps: 12, notes: 'Holding dumbbells.', female_load: 20, male_load: 35, load_unit: :lb)
 end
 
 # ==============================================================================
 # Dobogai
 # 7 rounds for time: 8 muscle-ups, 22-yard farmers carry
 Workout.find_or_create_by(name: 'Dobogai') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 8)
-  workout.exercises.build(movement: farmers_carry, position: 2, reps: 1, distance: 66, distance_unit: :foot, notes: '22-yard carry.', female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 8)
+  segment.exercises.build(movement: farmers_carry, position: 2, reps: 1, distance: 66, distance_unit: :foot, notes: '22-yard carry.', female_load: 35,
+                          male_load: 50, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -641,32 +657,32 @@ Workout.find_or_create_by(name: 'Dominic J. Hall') do |workout|
   workout.score_type = :rep
   workout.notes = 'Running clock. Rest from 12:23 to 15:00. Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
   step = workout.segments.build(position: 1, name: '0:00-12:23', time_seconds: 743)
-  workout.exercises.build(movement: box_step_up, segment: step, position: 1, reps: 0, female_distance: 20, male_distance: 20, distance_unit: :inch)
+  step.exercises.build(movement: box_step_up, position: 1, reps: 0, female_distance: 20, male_distance: 20, distance_unit: :inch)
   amrap = workout.segments.build(position: 2, name: '15:00-48:00', time_seconds: 1980)
-  workout.exercises.build(movement: deadlift, segment: amrap, position: 1, reps: 9, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: run, segment: amrap, position: 2, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, segment: amrap, position: 3, reps: 22)
+  amrap.exercises.build(movement: deadlift, position: 1, reps: 9, female_load: 185, male_load: 275, load_unit: :lb)
+  amrap.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
+  amrap.exercises.build(movement: push_up, position: 3, reps: 22)
 end
 
 # ==============================================================================
 # Donny
 # 21-15-9-9-15-21 reps for time: deadlifts, burpees
 Workout.find_or_create_by(name: 'Donny') do |workout|
-  workout.interval = '21-15-9-9-15-21'
+  segment = workout.segments.build(interval_scheme: '21-15-9-9-15-21', position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 2, reps: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 2, reps: 1)
 end
 
 # ==============================================================================
 # Dork
 # 6 rounds for time: 60 double-unders, 30 kettlebell swings, 15 burpees
 Workout.find_or_create_by(name: 'Dork') do |workout|
-  workout.rounds = 6
+  segment = workout.segments.build(rounds: 6, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: double_under, position: 1, reps: 60)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 30, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 3, reps: 15)
+  segment.exercises.build(movement: double_under, position: 1, reps: 60)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 30, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 3, reps: 15)
 end
 
 # ==============================================================================
@@ -674,52 +690,52 @@ end
 # For time (each round honors a fallen hero): Kraus, Scott, Good, Cully each with a run, pull-ups,
 # hand-release push-ups, 4 deadlifts and a 30-second rest, then Night Stalkers: 269 step-ups
 Workout.find_or_create_by(name: 'Drew') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter, notes: 'Kraus.')
-  workout.exercises.build(movement: pull_up, position: 2, reps: 30)
-  workout.exercises.build(movement: hand_release_push_up, position: 3, reps: 30)
-  workout.exercises.build(movement: deadlift, position: 4, reps: 4)
-  workout.exercises.build(movement: rest, position: 5, duration_seconds: 30)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter, notes: 'Scott.')
-  workout.exercises.build(movement: pull_up, position: 7, reps: 25)
-  workout.exercises.build(movement: hand_release_push_up, position: 8, reps: 25)
-  workout.exercises.build(movement: deadlift, position: 9, reps: 4)
-  workout.exercises.build(movement: rest, position: 10, duration_seconds: 30)
-  workout.exercises.build(movement: run, position: 11, reps: 1, distance: 600, distance_unit: :meter, notes: 'Good.')
-  workout.exercises.build(movement: pull_up, position: 12, reps: 20)
-  workout.exercises.build(movement: hand_release_push_up, position: 13, reps: 20)
-  workout.exercises.build(movement: deadlift, position: 14, reps: 4)
-  workout.exercises.build(movement: rest, position: 15, duration_seconds: 30)
-  workout.exercises.build(movement: run, position: 16, reps: 1, distance: 800, distance_unit: :meter, notes: 'Cully.')
-  workout.exercises.build(movement: pull_up, position: 17, reps: 15)
-  workout.exercises.build(movement: hand_release_push_up, position: 18, reps: 15)
-  workout.exercises.build(movement: deadlift, position: 19, reps: 4)
-  workout.exercises.build(movement: rest, position: 20, duration_seconds: 30)
-  workout.exercises.build(movement: box_step_up, position: 21, reps: 269, notes: 'Night Stalkers.')
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter, notes: 'Kraus.')
+  segment.exercises.build(movement: pull_up, position: 2, reps: 30)
+  segment.exercises.build(movement: hand_release_push_up, position: 3, reps: 30)
+  segment.exercises.build(movement: deadlift, position: 4, reps: 4)
+  segment.exercises.build(movement: rest, position: 5, duration_seconds: 30)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter, notes: 'Scott.')
+  segment.exercises.build(movement: pull_up, position: 7, reps: 25)
+  segment.exercises.build(movement: hand_release_push_up, position: 8, reps: 25)
+  segment.exercises.build(movement: deadlift, position: 9, reps: 4)
+  segment.exercises.build(movement: rest, position: 10, duration_seconds: 30)
+  segment.exercises.build(movement: run, position: 11, reps: 1, distance: 600, distance_unit: :meter, notes: 'Good.')
+  segment.exercises.build(movement: pull_up, position: 12, reps: 20)
+  segment.exercises.build(movement: hand_release_push_up, position: 13, reps: 20)
+  segment.exercises.build(movement: deadlift, position: 14, reps: 4)
+  segment.exercises.build(movement: rest, position: 15, duration_seconds: 30)
+  segment.exercises.build(movement: run, position: 16, reps: 1, distance: 800, distance_unit: :meter, notes: 'Cully.')
+  segment.exercises.build(movement: pull_up, position: 17, reps: 15)
+  segment.exercises.build(movement: hand_release_push_up, position: 18, reps: 15)
+  segment.exercises.build(movement: deadlift, position: 19, reps: 4)
+  segment.exercises.build(movement: rest, position: 20, duration_seconds: 30)
+  segment.exercises.build(movement: box_step_up, position: 21, reps: 269, notes: 'Night Stalkers.')
 end
 
 # ==============================================================================
 # DT
 # 5 rounds for time: 12 deadlifts, 9 hang power cleans, 6 push jerks
 Workout.find_or_create_by(name: 'DT') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 12, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: hang_power_clean, position: 2, reps: 9, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: push_jerk, position: 3, reps: 6, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 12, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: hang_power_clean, position: 2, reps: 9, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: push_jerk, position: 3, reps: 6, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
 # Dunn
 # AMRAP in 19 minutes: 3 muscle-ups, 1 shuttle sprint (5/10/15 yds), 6 burpee box jump-overs
 Workout.find_or_create_by(name: 'Dunn') do |workout|
-  workout.time = 19
+  segment = workout.segments.build(time_seconds: 1140, position: 1)
   workout.score_type = :rep
   workout.notes = 'On the burpees, jump over the box without touching it.'
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 3)
-  workout.exercises.build(movement: shuttle_run, position: 2, reps: 1, notes: '5 yards, 10 yards, 15 yards.')
-  workout.exercises.build(movement: burpee_box_jump_over, position: 3, reps: 6, female_distance: 20, male_distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 3)
+  segment.exercises.build(movement: shuttle_run, position: 2, reps: 1, notes: '5 yards, 10 yards, 15 yards.')
+  segment.exercises.build(movement: burpee_box_jump_over, position: 3, reps: 6, female_distance: 20, male_distance: 20, distance_unit: :inch)
 end
 
 # ==============================================================================
@@ -727,56 +743,62 @@ end
 # For time: 1-mile run w/ med ball; 8 rounds (10 wall-ball shots, 1 rope climb); 800m run w/ med ball;
 # 4 rounds (10 wall-ball shots, 1 rope climb); 400m run w/ med ball; 2 rounds (10 wall-ball shots, 1 rope climb)
 Workout.find_or_create_by(name: 'DVB') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
   round_eight = workout.segments.build(rounds: 8, position: 2)
-  workout.exercises.build(movement: wall_ball_shot, segment: round_eight, position: 1, reps: 10, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, segment: round_eight, position: 2, reps: 1)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
+  round_eight.exercises.build(movement: wall_ball_shot, position: 1, reps: 10, female_load: 14, male_load: 20, load_unit: :lb)
+  round_eight.exercises.build(movement: rope_climb, position: 2, reps: 1)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
   round_four = workout.segments.build(rounds: 4, position: 4)
-  workout.exercises.build(movement: wall_ball_shot, segment: round_four, position: 1, reps: 10, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, segment: round_four, position: 2, reps: 1)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
+  round_four.exercises.build(movement: wall_ball_shot, position: 1, reps: 10, female_load: 14, male_load: 20, load_unit: :lb)
+  round_four.exercises.build(movement: rope_climb, position: 2, reps: 1)
+  segment = workout.segments.build(position: 5)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
   round_two = workout.segments.build(rounds: 2, position: 6)
-  workout.exercises.build(movement: wall_ball_shot, segment: round_two, position: 1, reps: 10, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, segment: round_two, position: 2, reps: 1)
+  round_two.exercises.build(movement: wall_ball_shot, position: 1, reps: 10, female_load: 14, male_load: 20, load_unit: :lb)
+  round_two.exercises.build(movement: rope_climb, position: 2, reps: 1)
 end
 
 # ==============================================================================
 # Emily
 # 10 rounds for time: 30 double-unders, 15 pull-ups, 30 squats, 100m sprint. Rest 2 minutes.
 Workout.find_or_create_by(name: 'Emily') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 2 minutes between rounds.'
-  workout.exercises.build(movement: double_under, position: 1, reps: 30)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 15)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 30)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: double_under, position: 1, reps: 30)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 15)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 30)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
 # Erin
 # 5 rounds for time: 15 dumbbell split cleans, 21 pull-ups
 Workout.find_or_create_by(name: 'Erin') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: dumbbell_split_clean, position: 1, reps: 15, female_load: 30, male_load: 40, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 21)
+  segment.exercises.build(movement: dumbbell_split_clean, position: 1, reps: 15, female_load: 30, male_load: 40, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 21)
 end
 
 # ==============================================================================
 # Estrada
 # 100 box step-ups with a weighted backpack; then 3 rounds: 800m run, 17-calorie bike, 25 front squats
 Workout.find_or_create_by(name: 'Estrada') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: box_step_up, position: 1, reps: 100, notes: 'With a weighted backpack.', female_distance: 20, male_distance: 20, distance_unit: :inch, female_load: 35, male_load: 50, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: box_step_up, position: 1, reps: 100, notes: 'With a weighted backpack.', female_distance: 20, male_distance: 20,
+                          distance_unit: :inch, female_load: 35, male_load: 50, load_unit: :lb)
   triplet = workout.segments.build(rounds: 3, position: 2)
-  workout.exercises.build(movement: run, segment: triplet, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: bike, segment: triplet, position: 2, reps: 1, calories: 17)
-  workout.exercises.build(movement: front_squat, segment: triplet, position: 3, reps: 25, female_load: 135, male_load: 185, load_unit: :lb)
+  triplet.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  triplet.exercises.build(movement: bike, position: 2, reps: 1, calories: 17)
+  triplet.exercises.build(movement: front_squat, position: 3, reps: 25, female_load: 135, male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -784,38 +806,39 @@ end
 # 5 rounds for time with a partner: 24 double-unders (each), 19 toes-to-bar (total),
 # 2 clean and jerks (135/205 lb, total), 400-meter run (together)
 Workout.find_or_create_by(name: 'Eva Strong') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner. Reps are marked “each” or “total” per movement.'
-  workout.exercises.build(movement: double_under, position: 1, reps: 24, notes: 'Each partner.')
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 19, notes: 'Total, split between partners.')
-  workout.exercises.build(movement: clean_and_jerk, position: 3, reps: 2, female_load: 135, male_load: 205, load_unit: :lb, notes: 'Total, split between partners.')
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run together.')
+  segment.exercises.build(movement: double_under, position: 1, reps: 24, notes: 'Each partner.')
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 19, notes: 'Total, split between partners.')
+  segment.exercises.build(movement: clean_and_jerk, position: 3, reps: 2, female_load: 135, male_load: 205, load_unit: :lb,
+                          notes: 'Total, split between partners.')
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run together.')
 end
 
 # ==============================================================================
 # Falkel
 # AMRAP in 25 minutes: 8 handstand push-ups, 8 box jumps, 1 rope climb to 15 feet
 Workout.find_or_create_by(name: 'Falkel') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 8)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 8, female_distance: 24, male_distance: 30, distance_unit: :inch)
-  workout.exercises.build(movement: rope_climb, position: 3, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 8)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 8, female_distance: 24, male_distance: 30, distance_unit: :inch)
+  segment.exercises.build(movement: rope_climb, position: 3, reps: 1, distance: 15, distance_unit: :foot)
 end
 
 # ==============================================================================
 # Feeks
 # For time: ascending pairs (2,4,...,16) of 100m shuttle sprints and dumbbell squat clean thrusters
 Workout.find_or_create_by(name: 'Feeks') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   position = 1
   [2, 4, 6, 8, 10, 12, 14, 16].each do |reps|
-    workout.exercises.build(movement: shuttle_run, position:, reps:, notes: '100-meter shuttle sprints.')
+    segment.exercises.build(movement: shuttle_run, position:, reps:, notes: '100-meter shuttle sprints.')
     position += 1
-    workout.exercises.build(movement: dumbbell_squat_clean_thruster, position:, reps:, female_load: 45, male_load: 65, load_unit: :lb, implement_count: 2)
+    segment.exercises.build(movement: dumbbell_squat_clean_thruster, position:, reps:, female_load: 45, male_load: 65, load_unit: :lb, implement_count: 2)
     position += 1
   end
 end
@@ -824,31 +847,31 @@ end
 # FERN
 # 60-minute cap, for time: 2-mile run; 9 rounds (20-cal row, 20 burpees); 3 rounds (30 push-ups, 30 pull-ups, 30 burpees)
 Workout.find_or_create_by(name: 'FERN') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
   workout.time_cap = '60:00'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 3200, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 3200, distance_unit: :meter)
   couplet = workout.segments.build(rounds: 9, position: 2)
-  workout.exercises.build(movement: row, segment: couplet, position: 1, reps: 1, calories: 20)
-  workout.exercises.build(movement: burpee, segment: couplet, position: 2, reps: 20)
+  couplet.exercises.build(movement: row, position: 1, reps: 1, calories: 20)
+  couplet.exercises.build(movement: burpee, position: 2, reps: 20)
   triplet = workout.segments.build(rounds: 3, position: 3)
-  workout.exercises.build(movement: push_up, segment: triplet, position: 1, reps: 30)
-  workout.exercises.build(movement: pull_up, segment: triplet, position: 2, reps: 30)
-  workout.exercises.build(movement: burpee, segment: triplet, position: 3, reps: 30)
+  triplet.exercises.build(movement: push_up, position: 1, reps: 30)
+  triplet.exercises.build(movement: pull_up, position: 2, reps: 30)
+  triplet.exercises.build(movement: burpee, position: 3, reps: 30)
 end
 
 # ==============================================================================
 # Finseth
 # 18-minute clock for reps: 83 wall-ball shots, then AMRAP of 2 power cleans, 18 push-ups, 24 double-unders
 Workout.find_or_create_by(name: 'Finseth') do |workout|
-  workout.time = 18
+  segment = workout.segments.build(time_seconds: 1080, position: 1)
   workout.score_type = :rep
   workout.notes = 'Complete 83 wall-ball shots first, then AMRAP the triplet in the remaining time.'
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 83, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: power_clean, position: 2, reps: 2, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: push_up, position: 3, reps: 18)
-  workout.exercises.build(movement: double_under, position: 4, reps: 24)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 83, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: power_clean, position: 2, reps: 2, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: push_up, position: 3, reps: 18)
+  segment.exercises.build(movement: double_under, position: 4, reps: 24)
 end
 
 # ==============================================================================
@@ -856,68 +879,70 @@ end
 # For time: 13 bench presses; then AMRAP in 20 minutes: 7 chest-to-bar pull-ups, 77 double-unders,
 # 2 squat clean thrusters, 28 sit-ups
 Workout.find_or_create_by(name: 'Foo') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
   workout.notes = 'Complete 13 bench presses first, then the 20-minute AMRAP.'
-  workout.exercises.build(movement: bench_press, position: 1, reps: 13, female_load: 110, male_load: 170, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 7)
-  workout.exercises.build(movement: double_under, position: 3, reps: 77)
-  workout.exercises.build(movement: squat_clean_thruster, position: 4, reps: 2, female_load: 110, male_load: 170, load_unit: :lb)
-  workout.exercises.build(movement: sit_up, position: 5, reps: 28)
+  segment.exercises.build(movement: bench_press, position: 1, reps: 13, female_load: 110, male_load: 170, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 7)
+  segment.exercises.build(movement: double_under, position: 3, reps: 77)
+  segment.exercises.build(movement: squat_clean_thruster, position: 4, reps: 2, female_load: 110, male_load: 170, load_unit: :lb)
+  segment.exercises.build(movement: sit_up, position: 5, reps: 28)
 end
 
 # ==============================================================================
 # Forrest
 # 3 rounds for time: 20 L pull-ups, 30 toes-to-bars, 40 burpees, run 800m
 Workout.find_or_create_by(name: 'Forrest') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: l_pull_up, position: 1, reps: 20)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 30)
-  workout.exercises.build(movement: burpee, position: 3, reps: 40)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: l_pull_up, position: 1, reps: 20)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 30)
+  segment.exercises.build(movement: burpee, position: 3, reps: 40)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Fournier
 # For time: 50 shoulder-to-overheads, 50-ft sled pull, 40 burpees, 50-ft sled pull, 30 SDHP, 50-ft sled pull
 Workout.find_or_create_by(name: 'Fournier') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'For the sled pull, use a load that is challenging but does not require extended rest periods.'
-  workout.exercises.build(movement: shoulder_to_overhead, position: 1, reps: 50, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: sled_pull, position: 2, reps: 1, distance: 50, distance_unit: :foot, notes: 'Arm-over-arm.')
-  workout.exercises.build(movement: burpee, position: 3, reps: 40)
-  workout.exercises.build(movement: sled_pull, position: 4, reps: 1, distance: 50, distance_unit: :foot, notes: 'Arm-over-arm.')
-  workout.exercises.build(movement: sumo_deadlift_high_pull, position: 5, reps: 30, female_load: 55, male_load: 85, load_unit: :lb)
-  workout.exercises.build(movement: sled_pull, position: 6, reps: 1, distance: 50, distance_unit: :foot, notes: 'Arm-over-arm.')
+  segment.exercises.build(movement: shoulder_to_overhead, position: 1, reps: 50, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: sled_pull, position: 2, reps: 1, distance: 50, distance_unit: :foot, notes: 'Arm-over-arm.')
+  segment.exercises.build(movement: burpee, position: 3, reps: 40)
+  segment.exercises.build(movement: sled_pull, position: 4, reps: 1, distance: 50, distance_unit: :foot, notes: 'Arm-over-arm.')
+  segment.exercises.build(movement: sumo_deadlift_high_pull, position: 5, reps: 30, female_load: 55, male_load: 85, load_unit: :lb)
+  segment.exercises.build(movement: sled_pull, position: 6, reps: 1, distance: 50, distance_unit: :foot, notes: 'Arm-over-arm.')
 end
 
 # ==============================================================================
 # Gage
 # For time: 1,996m row; 3 rounds (12 power cleans, 11 back squats, 3 rope climbs to 15 feet, 27 burpees); 2,024m row
 Workout.find_or_create_by(name: 'Gage') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1996, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1996, distance_unit: :meter)
   triplet = workout.segments.build(rounds: 3, position: 2)
-  workout.exercises.build(movement: power_clean, segment: triplet, position: 1, reps: 12, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: back_squat, segment: triplet, position: 2, reps: 11, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, segment: triplet, position: 3, reps: 3, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: burpee, segment: triplet, position: 4, reps: 27)
-  workout.exercises.build(movement: row, position: 3, reps: 1, distance: 2024, distance_unit: :meter)
+  triplet.exercises.build(movement: power_clean, position: 1, reps: 12, female_load: 105, male_load: 155, load_unit: :lb)
+  triplet.exercises.build(movement: back_squat, position: 2, reps: 11, female_load: 105, male_load: 155, load_unit: :lb)
+  triplet.exercises.build(movement: rope_climb, position: 3, reps: 3, distance: 15, distance_unit: :foot)
+  triplet.exercises.build(movement: burpee, position: 4, reps: 27)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 2024, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Gale Force
 # AMRAP in 30 minutes: 20 box step-ups w/ weighted backpack, 23 burpees-over-backpack, 19 air squats
 Workout.find_or_create_by(name: 'Gale Force') do |workout|
-  workout.time = 30
+  segment = workout.segments.build(time_seconds: 1800, position: 1)
   workout.score_type = :rep
   workout.notes = 'When 30 minutes elapse, complete one more set of 19 squats together as a group.'
-  workout.exercises.build(movement: box_step_up, position: 1, reps: 20, notes: 'With a weighted backpack.', female_distance: 20, male_distance: 24, distance_unit: :inch, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 2, reps: 23, notes: 'Over the backpack.')
-  workout.exercises.build(movement: air_squat, position: 3, reps: 19)
+  segment.exercises.build(movement: box_step_up, position: 1, reps: 20, notes: 'With a weighted backpack.', female_distance: 20, male_distance: 24,
+                          distance_unit: :inch, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 2, reps: 23, notes: 'Over the backpack.')
+  segment.exercises.build(movement: air_squat, position: 3, reps: 19)
 end
 
 # ==============================================================================
@@ -925,75 +950,78 @@ end
 # For time: 1-mile run w/ med ball, 60 burpee pull-ups, 800m run w/ med ball, 30 burpee pull-ups,
 # 400m run w/ med ball, 15 burpee pull-ups
 Workout.find_or_create_by(name: 'Gallant') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: burpee_pull_up, position: 2, reps: 60)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: burpee_pull_up, position: 4, reps: 30)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: burpee_pull_up, position: 6, reps: 15)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: burpee_pull_up, position: 2, reps: 60)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: burpee_pull_up, position: 4, reps: 30)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 14,
+                          male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: burpee_pull_up, position: 6, reps: 15)
 end
 
 # ==============================================================================
 # Garbo
 # On a 21-minute clock: 400m run, then AMRAP: 10 hand-release push-ups, 4 strict pull-ups, 20 KB swings, 10 KB goblet squats
 Workout.find_or_create_by(name: 'Garbo') do |workout|
-  workout.time = 21
+  segment = workout.segments.build(time_seconds: 1260, position: 1)
   workout.score_type = :rep
   workout.notes = 'Run 400 meters, then AMRAP the quad in the remaining time.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: hand_release_push_up, position: 2, reps: 10)
-  workout.exercises.build(movement: strict_pull_up, position: 3, reps: 4)
-  workout.exercises.build(movement: kettlebell_swing, position: 4, reps: 20, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_goblet_squat, position: 5, reps: 10, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: hand_release_push_up, position: 2, reps: 10)
+  segment.exercises.build(movement: strict_pull_up, position: 3, reps: 4)
+  segment.exercises.build(movement: kettlebell_swing, position: 4, reps: 20, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_goblet_squat, position: 5, reps: 10, female_load: 35, male_load: 53, load_unit: :lb)
 end
 
 # ==============================================================================
 # Garrett
 # 3 rounds for time: 75 squats, 25 ring handstand push-ups, 25 L pull-ups
 Workout.find_or_create_by(name: 'Garrett') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: air_squat, position: 1, reps: 75)
-  workout.exercises.build(movement: ring_handstand_push_up, position: 2, reps: 25)
-  workout.exercises.build(movement: l_pull_up, position: 3, reps: 25)
+  segment.exercises.build(movement: air_squat, position: 1, reps: 75)
+  segment.exercises.build(movement: ring_handstand_push_up, position: 2, reps: 25)
+  segment.exercises.build(movement: l_pull_up, position: 3, reps: 25)
 end
 
 # ==============================================================================
 # Gator
 # 8 rounds for time: 5 front squats, 26 ring push-ups
 Workout.find_or_create_by(name: 'Gator') do |workout|
-  workout.rounds = 8
+  segment = workout.segments.build(rounds: 8, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: front_squat, position: 1, reps: 5, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: ring_push_up, position: 2, reps: 26)
+  segment.exercises.build(movement: front_squat, position: 1, reps: 5, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: ring_push_up, position: 2, reps: 26)
 end
 
 # ==============================================================================
 # Gaza
 # 5 rounds for time: 35 kettlebell swings, 30 push-ups, 25 pull-ups, 20 box jumps, 1-mile run
 Workout.find_or_create_by(name: 'Gaza') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: kettlebell_swing, position: 1, reps: 35, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: push_up, position: 2, reps: 30)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 25)
-  workout.exercises.build(movement: box_jump, position: 4, reps: 20, female_distance: 24, male_distance: 30, distance_unit: :inch)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 1, reps: 35, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: push_up, position: 2, reps: 30)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 25)
+  segment.exercises.build(movement: box_jump, position: 4, reps: 20, female_distance: 24, male_distance: 30, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Glen
 # For time: 30 clean and jerks, run 1 mile, 10 rope climbs to 15 feet, run 1 mile, 100 burpees
 Workout.find_or_create_by(name: 'Glen') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: clean_and_jerk, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: rope_climb, position: 3, reps: 10, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: burpee, position: 5, reps: 100)
+  segment.exercises.build(movement: clean_and_jerk, position: 1, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: rope_climb, position: 3, reps: 10, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: burpee, position: 5, reps: 100)
 end
 
 # ==============================================================================
@@ -1002,65 +1030,67 @@ end
 # 15 thrusters (95/135 lb), 15 kettlebell swings (53/70 lb); then a 400-meter run
 # carrying a plate (25/45 lb)
 Workout.find_or_create_by(name: 'Goose') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 106, female_load: 95, male_load: 135, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 106, female_load: 95, male_load: 135, load_unit: :lb)
   triplet = workout.segments.build(rounds: 7, position: 2)
-  workout.exercises.build(movement: rope_climb, segment: triplet, position: 1, reps: 3)
-  workout.exercises.build(movement: thruster, segment: triplet, position: 2, reps: 15, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_swing, segment: triplet, position: 3, reps: 15, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter, female_load: 25, male_load: 45, load_unit: :lb, notes: 'Carry a plate; both partners carry.')
+  triplet.exercises.build(movement: rope_climb, position: 1, reps: 3)
+  triplet.exercises.build(movement: thruster, position: 2, reps: 15, female_load: 95, male_load: 135, load_unit: :lb)
+  triplet.exercises.build(movement: kettlebell_swing, position: 3, reps: 15, female_load: 53, male_load: 70, load_unit: :lb)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter, female_load: 25, male_load: 45, load_unit: :lb,
+                          notes: 'Carry a plate; both partners carry.')
 end
 
 # ==============================================================================
 # Griff
 # For time: run 800m, run 400m backwards, run 800m, run 400m backwards
 Workout.find_or_create_by(name: 'Griff') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run backwards.')
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run backwards.')
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run backwards.')
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run backwards.')
 end
 
 # ==============================================================================
 # Hall
 # 5 rounds for time: 3 cleans, 200m sprint, 20 kettlebell snatches (10 each arm). Rest 2 minutes between rounds.
 Workout.find_or_create_by(name: 'Hall') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 2 minutes between rounds.'
-  workout.exercises.build(movement: clean, position: 1, reps: 3, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 200, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: kettlebell_snatch, position: 3, reps: 20, notes: '10 each arm.', female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: clean, position: 1, reps: 3, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 200, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: kettlebell_snatch, position: 3, reps: 20, notes: '10 each arm.', female_load: 35, male_load: 53, load_unit: :lb)
 end
 
 # ==============================================================================
 # Hamilton
 # 3 rounds for time: row 1,000m, 50 push-ups, run 1,000m, 50 pull-ups
 Workout.find_or_create_by(name: 'Hamilton') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 2, reps: 50)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 50)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 2, reps: 50)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 50)
 end
 
 # ==============================================================================
 # Hammer
 # 5 rounds, each for time: 5 power cleans, 10 front squats, 5 jerks, 20 pull-ups. Rest 90 seconds between rounds.
 Workout.find_or_create_by(name: 'Hammer') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'Each round is for time. Rest 90 seconds between rounds.'
-  workout.exercises.build(movement: power_clean, position: 1, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: front_squat, position: 2, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: jerk, position: 3, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 20)
+  segment.exercises.build(movement: power_clean, position: 1, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: front_squat, position: 2, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: jerk, position: 3, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 20)
 end
 
 # ==============================================================================
@@ -1069,69 +1099,70 @@ end
 # 20 strict pull-ups, 400m run, 20 burpee box jumps, 10 ring muscle-ups, 400m run, 40 burpees to target,
 # 20 strict pull-ups, 800m run, 80 box step-overs, 40 hand-release push-ups, 1,200m run
 Workout.find_or_create_by(name: 'Hammy') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1200, distance_unit: :meter)
-  workout.exercises.build(movement: box_step_over, position: 2, reps: 80, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: hand_release_push_up, position: 3, reps: 40)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_to_target, position: 5, reps: 40, distance: 6, distance_unit: :inch)
-  workout.exercises.build(movement: strict_pull_up, position: 6, reps: 20)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_box_jump, position: 8, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: ring_muscle_up, position: 9, reps: 10)
-  workout.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_to_target, position: 11, reps: 40, distance: 6, distance_unit: :inch)
-  workout.exercises.build(movement: strict_pull_up, position: 12, reps: 20)
-  workout.exercises.build(movement: run, position: 13, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: box_step_over, position: 14, reps: 80, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: hand_release_push_up, position: 15, reps: 40)
-  workout.exercises.build(movement: run, position: 16, reps: 1, distance: 1200, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1200, distance_unit: :meter)
+  segment.exercises.build(movement: box_step_over, position: 2, reps: 80, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: hand_release_push_up, position: 3, reps: 40)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_to_target, position: 5, reps: 40, distance: 6, distance_unit: :inch)
+  segment.exercises.build(movement: strict_pull_up, position: 6, reps: 20)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_box_jump, position: 8, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: ring_muscle_up, position: 9, reps: 10)
+  segment.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_to_target, position: 11, reps: 40, distance: 6, distance_unit: :inch)
+  segment.exercises.build(movement: strict_pull_up, position: 12, reps: 20)
+  segment.exercises.build(movement: run, position: 13, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: box_step_over, position: 14, reps: 80, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: hand_release_push_up, position: 15, reps: 40)
+  segment.exercises.build(movement: run, position: 16, reps: 1, distance: 1200, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Hansen
 # 5 rounds for time: 30 kettlebell swings, 30 burpees, 30 GHD sit-ups
 Workout.find_or_create_by(name: 'Hansen') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: kettlebell_swing, position: 1, reps: 30, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 2, reps: 30)
-  workout.exercises.build(movement: ghd_sit_up, position: 3, reps: 30)
+  segment.exercises.build(movement: kettlebell_swing, position: 1, reps: 30, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 2, reps: 30)
+  segment.exercises.build(movement: ghd_sit_up, position: 3, reps: 30)
 end
 
 # ==============================================================================
 # Harper
 # AMRAP in 23 minutes: 9 chest-to-bar pull-ups, 15 power cleans, 21 squats, 400m run with a plate
 Workout.find_or_create_by(name: 'Harper') do |workout|
-  workout.time = 23
+  segment = workout.segments.build(time_seconds: 1380, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 9)
-  workout.exercises.build(movement: power_clean, position: 2, reps: 15, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 21)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 9)
+  segment.exercises.build(movement: power_clean, position: 2, reps: 15, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 21)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45,
+                          load_unit: :lb)
 end
 
 # ==============================================================================
 # Havana
 # AMRAP in 25 minutes: 150 double-unders, 50 push-ups, 15 power cleans
 Workout.find_or_create_by(name: 'Havana') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: double_under, position: 1, reps: 150)
-  workout.exercises.build(movement: push_up, position: 2, reps: 50)
-  workout.exercises.build(movement: power_clean, position: 3, reps: 15, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 1, reps: 150)
+  segment.exercises.build(movement: push_up, position: 2, reps: 50)
+  segment.exercises.build(movement: power_clean, position: 3, reps: 15, female_load: 125, male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
 # Helton
 # 3 rounds for time: 800m run, 30 dumbbell squat cleans, 30 burpees
 Workout.find_or_create_by(name: 'Helton') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: dumbbell_squat_clean, position: 2, reps: 30, female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: burpee, position: 3, reps: 30)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_squat_clean, position: 2, reps: 30, female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: burpee, position: 3, reps: 30)
 end
 
 # ==============================================================================
@@ -1139,96 +1170,96 @@ end
 # For time: run 2 miles, rest 2 min, 20 squat cleans, 20 box jumps, 20 overhead walking lunges,
 # 20 box jumps, 20 squat cleans, rest 2 min, run 2 miles
 Workout.find_or_create_by(name: 'Hidalgo') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'If you’ve got a 20-lb vest or body armor, wear it. ' \
                   'The PDF prints the ' \
                   'male squat-clean barbell as 35 lb (a dropped-digit typo, below the 95-lb ' \
                   'female load); corrected here to 135 lb.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 3200, distance_unit: :meter)
-  workout.exercises.build(movement: rest, position: 2, duration_seconds: 120)
-  workout.exercises.build(movement: clean_squat, position: 3, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 4, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: overhead_walking_lunge, position: 5, reps: 20, female_load: 25, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 6, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: clean_squat, position: 7, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: rest, position: 8, duration_seconds: 120)
-  workout.exercises.build(movement: run, position: 9, reps: 1, distance: 3200, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 3200, distance_unit: :meter)
+  segment.exercises.build(movement: rest, position: 2, duration_seconds: 120)
+  segment.exercises.build(movement: clean_squat, position: 3, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 4, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: overhead_walking_lunge, position: 5, reps: 20, female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 6, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: clean_squat, position: 7, reps: 20, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: rest, position: 8, duration_seconds: 120)
+  segment.exercises.build(movement: run, position: 9, reps: 1, distance: 3200, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Hildy
 # For time: 100-calorie row, 75 thrusters, 50 pull-ups, 75 wall-ball shots, 100-calorie row
 Workout.find_or_create_by(name: 'Hildy') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, calories: 100)
-  workout.exercises.build(movement: thruster, position: 2, reps: 75, female_load: 35, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 50)
-  workout.exercises.build(movement: wall_ball_shot, position: 4, reps: 75, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: row, position: 5, reps: 1, calories: 100)
+  segment.exercises.build(movement: row, position: 1, reps: 1, calories: 100)
+  segment.exercises.build(movement: thruster, position: 2, reps: 75, female_load: 35, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 50)
+  segment.exercises.build(movement: wall_ball_shot, position: 4, reps: 75, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 5, reps: 1, calories: 100)
 end
 
 # ==============================================================================
 # Holbrook
 # 10 rounds, each for time: 5 thrusters, 10 pull-ups, 100m sprint. Rest 1 minute between rounds.
 Workout.find_or_create_by(name: 'Holbrook') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
   workout.notes = 'Each round is for time. Rest 1 minute between rounds.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 5, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 10)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: thruster, position: 1, reps: 5, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 10)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
 # Holleyman
 # 30 rounds for time: 5 wall-ball shots, 3 handstand push-ups, 1 power clean
 Workout.find_or_create_by(name: 'Holleyman') do |workout|
-  workout.rounds = 30
+  segment = workout.segments.build(rounds: 30, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 5, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 2, reps: 3)
-  workout.exercises.build(movement: power_clean, position: 3, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 5, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 2, reps: 3)
+  segment.exercises.build(movement: power_clean, position: 3, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
 end
 
 # ==============================================================================
 # Hollywood
 # For time: run 2,000m, 22 wall-ball shots, 22 muscle-ups, 22 wall-ball shots, 22 power cleans, 22 wall-ball shots, run 2,000m
 Workout.find_or_create_by(name: 'Hollywood') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 2000, distance_unit: :meter)
-  workout.exercises.build(movement: wall_ball_shot, position: 2, reps: 22, distance: 9, distance_unit: :foot, female_load: 20, male_load: 30, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 3, reps: 22)
-  workout.exercises.build(movement: wall_ball_shot, position: 4, reps: 22, female_load: 20, male_load: 30, load_unit: :lb, distance: 9, distance_unit: :foot)
-  workout.exercises.build(movement: power_clean, position: 5, reps: 22, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, position: 6, reps: 22, female_load: 20, male_load: 30, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: wall_ball_shot, position: 2, reps: 22, distance: 9, distance_unit: :foot, female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 3, reps: 22)
+  segment.exercises.build(movement: wall_ball_shot, position: 4, reps: 22, female_load: 20, male_load: 30, load_unit: :lb, distance: 9, distance_unit: :foot)
+  segment.exercises.build(movement: power_clean, position: 5, reps: 22, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 6, reps: 22, female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 2000, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Hoover
 # 8 rounds for time: run 400m, 15 burpee box jump-overs, 10-calorie bike, 6 alternating dumbbell snatches
 Workout.find_or_create_by(name: 'Hoover') do |workout|
-  workout.rounds = 8
+  segment = workout.segments.build(rounds: 8, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 2, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: bike, position: 3, reps: 1, calories: 10)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 4, reps: 6, notes: 'Alternating arms.', female_load: 50, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 2, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: bike, position: 3, reps: 1, calories: 10)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 4, reps: 6, notes: 'Alternating arms.', female_load: 50, male_load: 75, load_unit: :lb)
 end
 
 # ==============================================================================
 # Hortman
 # AMRAP in 45 minutes: run 800m, 80 squats, 8 muscle-ups
 Workout.find_or_create_by(name: 'Hortman') do |workout|
-  workout.time = 45
+  segment = workout.segments.build(time_seconds: 2700, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: air_squat, position: 2, reps: 80)
-  workout.exercises.build(movement: muscle_up, position: 3, reps: 8)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: air_squat, position: 2, reps: 80)
+  segment.exercises.build(movement: muscle_up, position: 3, reps: 8)
 end
 
 # ==============================================================================
@@ -1236,38 +1267,38 @@ end
 # 9 rounds for time with a partner: 9 bar muscle-ups, 11 clean-and-jerks (115/155 lb),
 # 50-yard buddy carry
 Workout.find_or_create_by(name: 'Horton') do |workout|
-  workout.rounds = 9
+  segment = workout.segments.build(rounds: 9, position: 1)
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner.'
-  workout.exercises.build(movement: bar_muscle_up, position: 1, reps: 9)
-  workout.exercises.build(movement: clean_and_jerk, position: 2, reps: 11, female_load: 115, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: buddy_carry, position: 3, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard buddy carry.')
+  segment.exercises.build(movement: bar_muscle_up, position: 1, reps: 9)
+  segment.exercises.build(movement: clean_and_jerk, position: 2, reps: 11, female_load: 115, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: buddy_carry, position: 3, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard buddy carry.')
 end
 
 # ==============================================================================
 # Hotshots 19
 # 6 rounds for time: 30 squats, 19 power cleans, 7 strict pull-ups, 400m run
 Workout.find_or_create_by(name: 'Hotshots 19') do |workout|
-  workout.rounds = 6
+  segment = workout.segments.build(rounds: 6, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: air_squat, position: 1, reps: 30)
-  workout.exercises.build(movement: power_clean, position: 2, reps: 19, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: strict_pull_up, position: 3, reps: 7)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: air_squat, position: 1, reps: 30)
+  segment.exercises.build(movement: power_clean, position: 2, reps: 19, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: strict_pull_up, position: 3, reps: 7)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # J.J.
 # For time: ascending squat cleans (1..10) paired with descending parallette handstand push-ups (10..1)
 Workout.find_or_create_by(name: 'J.J.') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   position = 1
   (1..10).each do |round|
-    workout.exercises.build(movement: clean_squat, position:, reps: round, female_load: 125, male_load: 185, load_unit: :lb)
+    segment.exercises.build(movement: clean_squat, position:, reps: round, female_load: 125, male_load: 185, load_unit: :lb)
     position += 1
-    workout.exercises.build(movement: parallette_handstand_push_up, position:, reps: 11 - round)
+    segment.exercises.build(movement: parallette_handstand_push_up, position:, reps: 11 - round)
     position += 1
   end
 end
@@ -1276,11 +1307,11 @@ end
 # Jack
 # AMRAP in 20 minutes: 10 push presses, 10 kettlebell swings, 10 box jumps
 Workout.find_or_create_by(name: 'Jack') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: push_press, position: 1, reps: 10, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 10, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 10, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: push_press, position: 1, reps: 10, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 10, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 10, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
@@ -1290,109 +1321,109 @@ end
 Workout.find_or_create_by(name: "Jack's Triangle") do |workout|
   workout.score_type = :rep
   opening = workout.segments.build(position: 1, name: '0:00-2:00 max deadlifts', time_seconds: 120)
-  workout.exercises.build(movement: deadlift, segment: opening, position: 1, reps: 0, female_load: 155, male_load: 225, load_unit: :lb)
+  opening.exercises.build(movement: deadlift, position: 1, reps: 0, female_load: 155, male_load: 225, load_unit: :lb)
   amrap = workout.segments.build(position: 2, name: '2:00-21:00 AMRAP', time_seconds: 1140)
-  workout.exercises.build(movement: strict_pull_up, segment: amrap, position: 1, reps: 4)
-  workout.exercises.build(movement: box_jump, segment: amrap, position: 2, reps: 11)
-  workout.exercises.build(movement: hand_release_push_up, segment: amrap, position: 3, reps: 13)
-  workout.exercises.build(movement: bike, segment: amrap, position: 4, reps: 1, calories: 23)
+  amrap.exercises.build(movement: strict_pull_up, position: 1, reps: 4)
+  amrap.exercises.build(movement: box_jump, position: 2, reps: 11)
+  amrap.exercises.build(movement: hand_release_push_up, position: 3, reps: 13)
+  amrap.exercises.build(movement: bike, position: 4, reps: 1, calories: 23)
   closing = workout.segments.build(position: 3, name: '21:00-23:00 max deadlifts', time_seconds: 120)
-  workout.exercises.build(movement: deadlift, segment: closing, position: 1, reps: 0, female_load: 155, male_load: 225, load_unit: :lb)
+  closing.exercises.build(movement: deadlift, position: 1, reps: 0, female_load: 155, male_load: 225, load_unit: :lb)
 end
 
 # ==============================================================================
 # Jag 28
 # For time: run 800m, 28 KB swings, 28 strict pull-ups, 28 KB clean and jerks, 28 strict pull-ups, run 800m
 Workout.find_or_create_by(name: 'Jag 28') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 28, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: strict_pull_up, position: 3, reps: 28)
-  workout.exercises.build(movement: kettlebell_clean_and_jerk, position: 4, reps: 28, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: strict_pull_up, position: 5, reps: 28)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 28, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: strict_pull_up, position: 3, reps: 28)
+  segment.exercises.build(movement: kettlebell_clean_and_jerk, position: 4, reps: 28, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: strict_pull_up, position: 5, reps: 28)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Jared
 # 4 rounds for time: run 800m, 40 pull-ups, 70 push-ups
 Workout.find_or_create_by(name: 'Jared') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 40)
-  workout.exercises.build(movement: push_up, position: 3, reps: 70)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 40)
+  segment.exercises.build(movement: push_up, position: 3, reps: 70)
 end
 
 # ==============================================================================
 # Jason
 # For time: 100 squats, 5 muscle-ups, 75 squats, 10 muscle-ups, 50 squats, 15 muscle-ups, 25 squats, 20 muscle-ups
 Workout.find_or_create_by(name: 'Jason') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: air_squat, position: 1, reps: 100)
-  workout.exercises.build(movement: muscle_up, position: 2, reps: 5)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 75)
-  workout.exercises.build(movement: muscle_up, position: 4, reps: 10)
-  workout.exercises.build(movement: air_squat, position: 5, reps: 50)
-  workout.exercises.build(movement: muscle_up, position: 6, reps: 15)
-  workout.exercises.build(movement: air_squat, position: 7, reps: 25)
-  workout.exercises.build(movement: muscle_up, position: 8, reps: 20)
+  segment.exercises.build(movement: air_squat, position: 1, reps: 100)
+  segment.exercises.build(movement: muscle_up, position: 2, reps: 5)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 75)
+  segment.exercises.build(movement: muscle_up, position: 4, reps: 10)
+  segment.exercises.build(movement: air_squat, position: 5, reps: 50)
+  segment.exercises.build(movement: muscle_up, position: 6, reps: 15)
+  segment.exercises.build(movement: air_squat, position: 7, reps: 25)
+  segment.exercises.build(movement: muscle_up, position: 8, reps: 20)
 end
 
 # ==============================================================================
 # JBo
 # AMRAP in 28 minutes: 9 overhead squats, 12 bench presses
 Workout.find_or_create_by(name: 'JBo') do |workout|
-  workout.time = 28
+  segment = workout.segments.build(time_seconds: 1680, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: overhead_squat, position: 1, reps: 9, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: bench_press, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: overhead_squat, position: 1, reps: 9, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: bench_press, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
 end
 
 # ==============================================================================
 # Jennifer
 # AMRAP in 26 minutes: 10 pull-ups, 15 kettlebell swings, 20 box jumps
 Workout.find_or_create_by(name: 'Jennifer') do |workout|
-  workout.time = 26
+  segment = workout.segments.build(time_seconds: 1560, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: pull_up, position: 1, reps: 10)
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 15, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 10)
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 15, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
 # Jenny
 # AMRAP in 20 minutes: 20 overhead squats, 20 back squats, 400m run
 Workout.find_or_create_by(name: 'Jenny') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: overhead_squat, position: 1, reps: 20, female_load: 35, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 20, female_load: 35, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: overhead_squat, position: 1, reps: 20, female_load: 35, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 20, female_load: 35, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Jerry
 # For time: run 1 mile, row 2K, run 1 mile
 Workout.find_or_create_by(name: 'Jerry') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: row, position: 2, reps: 1, distance: 2000, distance_unit: :meter)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: row, position: 2, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Johnson
 # AMRAP in 20 minutes: 9 deadlifts, 8 muscle-ups, 9 squat cleans
 Workout.find_or_create_by(name: 'Johnson') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 9, female_load: 165, male_load: 245, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 2, reps: 8)
-  workout.exercises.build(movement: clean_squat, position: 3, reps: 9, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 9, female_load: 165, male_load: 245, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 2, reps: 8)
+  segment.exercises.build(movement: clean_squat, position: 3, reps: 9, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -1400,17 +1431,18 @@ end
 # For time: 1,500m row; 2 rounds (53 push-ups, 11 pull-ups, 5 shoulder presses, 100m farmers carry,
 # 50m sled push, 300m sprint); 1,500m row
 Workout.find_or_create_by(name: 'Jonathon Farmer') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1500, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1500, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 2, position: 2)
-  workout.exercises.build(movement: push_up, segment: rounds, position: 1, reps: 53)
-  workout.exercises.build(movement: pull_up, segment: rounds, position: 2, reps: 11)
-  workout.exercises.build(movement: shoulder_press, segment: rounds, position: 3, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: farmers_carry, segment: rounds, position: 4, reps: 1, distance: 100, distance_unit: :meter, female_load: 35, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: sled_push, segment: rounds, position: 5, reps: 1, distance: 50, distance_unit: :meter, female_load: 45, male_load: 90, load_unit: :lb)
-  workout.exercises.build(movement: run, segment: rounds, position: 6, reps: 1, distance: 300, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: row, position: 3, reps: 1, distance: 1500, distance_unit: :meter)
+  rounds.exercises.build(movement: push_up, position: 1, reps: 53)
+  rounds.exercises.build(movement: pull_up, position: 2, reps: 11)
+  rounds.exercises.build(movement: shoulder_press, position: 3, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
+  rounds.exercises.build(movement: farmers_carry, position: 4, reps: 1, distance: 100, distance_unit: :meter, female_load: 35, male_load: 70, load_unit: :lb)
+  rounds.exercises.build(movement: sled_push, position: 5, reps: 1, distance: 50, distance_unit: :meter, female_load: 45, male_load: 90, load_unit: :lb)
+  rounds.exercises.build(movement: run, position: 6, reps: 1, distance: 300, distance_unit: :meter, notes: 'Sprint.')
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1500, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -1418,32 +1450,32 @@ end
 # For time: 30 GHD sit-ups, 15 squat cleans, 24 GHD sit-ups, 12 squat cleans, 18 GHD sit-ups, 9 squat cleans,
 # 12 GHD sit-ups, 6 squat cleans, 6 GHD sit-ups, 3 squat cleans
 Workout.find_or_create_by(name: 'Jorge') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: ghd_sit_up, position: 1, reps: 30)
-  workout.exercises.build(movement: clean_squat, position: 2, reps: 15, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: ghd_sit_up, position: 3, reps: 24)
-  workout.exercises.build(movement: clean_squat, position: 4, reps: 12, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: ghd_sit_up, position: 5, reps: 18)
-  workout.exercises.build(movement: clean_squat, position: 6, reps: 9, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: ghd_sit_up, position: 7, reps: 12)
-  workout.exercises.build(movement: clean_squat, position: 8, reps: 6, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: ghd_sit_up, position: 9, reps: 6)
-  workout.exercises.build(movement: clean_squat, position: 10, reps: 3, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: ghd_sit_up, position: 1, reps: 30)
+  segment.exercises.build(movement: clean_squat, position: 2, reps: 15, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: ghd_sit_up, position: 3, reps: 24)
+  segment.exercises.build(movement: clean_squat, position: 4, reps: 12, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: ghd_sit_up, position: 5, reps: 18)
+  segment.exercises.build(movement: clean_squat, position: 6, reps: 9, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: ghd_sit_up, position: 7, reps: 12)
+  segment.exercises.build(movement: clean_squat, position: 8, reps: 6, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: ghd_sit_up, position: 9, reps: 6)
+  segment.exercises.build(movement: clean_squat, position: 10, reps: 3, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
 # Josh
 # For time: 21 overhead squats, 42 pull-ups, 15 overhead squats, 30 pull-ups, 9 overhead squats, 18 pull-ups
 Workout.find_or_create_by(name: 'Josh') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: overhead_squat, position: 1, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 42)
-  workout.exercises.build(movement: overhead_squat, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 30)
-  workout.exercises.build(movement: overhead_squat, position: 5, reps: 9, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 6, reps: 18)
+  segment.exercises.build(movement: overhead_squat, position: 1, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 42)
+  segment.exercises.build(movement: overhead_squat, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 30)
+  segment.exercises.build(movement: overhead_squat, position: 5, reps: 9, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 6, reps: 18)
 end
 
 # ==============================================================================
@@ -1453,106 +1485,109 @@ end
 # 2 rounds of 44 dumbbell deadlifts, 44 dumbbell bent-over rows, 44 dumbbell lunges;
 # 400-meter run. Run together and split all other work as needed. Use two dumbbells.
 Workout.find_or_create_by(name: 'Josh-O') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner. Run together and split all other work as needed. Use two dumbbells.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run together.')
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run together.')
   first_couplet = workout.segments.build(rounds: 2, position: 2)
-  workout.exercises.build(movement: dumbbell_front_squat, segment: first_couplet, position: 1, reps: 44)
-  workout.exercises.build(movement: dumbbell_floor_press, segment: first_couplet, position: 2, reps: 44)
-  workout.exercises.build(movement: dumbbell_hang_clean_and_jerk, segment: first_couplet, position: 3, reps: 44)
-  workout.exercises.build(movement: row, position: 3, reps: 1, distance: 1979, distance_unit: :meter)
+  first_couplet.exercises.build(movement: dumbbell_front_squat, position: 1, reps: 44)
+  first_couplet.exercises.build(movement: dumbbell_floor_press, position: 2, reps: 44)
+  first_couplet.exercises.build(movement: dumbbell_hang_clean_and_jerk, position: 3, reps: 44)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1979, distance_unit: :meter)
   second_couplet = workout.segments.build(rounds: 2, position: 4)
-  workout.exercises.build(movement: dumbbell_deadlift, segment: second_couplet, position: 1, reps: 44)
-  workout.exercises.build(movement: dumbbell_bent_over_row, segment: second_couplet, position: 2, reps: 44)
-  workout.exercises.build(movement: dumbbell_lunge, segment: second_couplet, position: 3, reps: 44)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run together.')
+  second_couplet.exercises.build(movement: dumbbell_deadlift, position: 1, reps: 44)
+  second_couplet.exercises.build(movement: dumbbell_bent_over_row, position: 2, reps: 44)
+  second_couplet.exercises.build(movement: dumbbell_lunge, position: 3, reps: 44)
+  segment = workout.segments.build(position: 5)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter, notes: 'Run together.')
 end
 
 # ==============================================================================
 # Joshie
 # 3 rounds for time: 21 dumbbell snatches (R), 21 L pull-ups, 21 dumbbell snatches (L), 21 L pull-ups
 Workout.find_or_create_by(name: 'Joshie') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 1, reps: 21, notes: 'Right arm.', female_load: 25, male_load: 40, load_unit: :lb)
-  workout.exercises.build(movement: l_pull_up, position: 2, reps: 21)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 21, notes: 'Left arm.', female_load: 25, male_load: 40, load_unit: :lb)
-  workout.exercises.build(movement: l_pull_up, position: 4, reps: 21)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 1, reps: 21, notes: 'Right arm.', female_load: 25, male_load: 40, load_unit: :lb)
+  segment.exercises.build(movement: l_pull_up, position: 2, reps: 21)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 21, notes: 'Left arm.', female_load: 25, male_load: 40, load_unit: :lb)
+  segment.exercises.build(movement: l_pull_up, position: 4, reps: 21)
 end
 
 # ==============================================================================
 # Josie
 # For time: 1-mile run; 3 rounds (30 burpees, 4 power cleans, 6 front squats); 1-mile run
 Workout.find_or_create_by(name: 'Josie') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
   triplet = workout.segments.build(rounds: 3, position: 2)
-  workout.exercises.build(movement: burpee, segment: triplet, position: 1, reps: 30)
-  workout.exercises.build(movement: power_clean, segment: triplet, position: 2, reps: 4, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: front_squat, segment: triplet, position: 3, reps: 6, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 1600, distance_unit: :meter)
+  triplet.exercises.build(movement: burpee, position: 1, reps: 30)
+  triplet.exercises.build(movement: power_clean, position: 2, reps: 4, female_load: 105, male_load: 155, load_unit: :lb)
+  triplet.exercises.build(movement: front_squat, position: 3, reps: 6, female_load: 105, male_load: 155, load_unit: :lb)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # JT
 # 21-15-9 reps for time: handstand push-ups, ring dips, push-ups
 Workout.find_or_create_by(name: 'JT') do |workout|
-  workout.interval = '21-15-9'
+  segment = workout.segments.build(interval_scheme: '21-15-9', position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 1)
-  workout.exercises.build(movement: ring_dip, position: 2, reps: 1)
-  workout.exercises.build(movement: push_up, position: 3, reps: 1)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 1)
+  segment.exercises.build(movement: ring_dip, position: 2, reps: 1)
+  segment.exercises.build(movement: push_up, position: 3, reps: 1)
 end
 
 # ==============================================================================
 # Justin
 # 30-20-10 reps for time: back squats, bench presses, strict pull-ups
 Workout.find_or_create_by(name: 'Justin') do |workout|
-  workout.interval = '30-20-10'
+  segment = workout.segments.build(interval_scheme: '30-20-10', position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: back_squat, position: 1, reps: 1)
-  workout.exercises.build(movement: bench_press, position: 2, reps: 1)
-  workout.exercises.build(movement: strict_pull_up, position: 3, reps: 1)
+  segment.exercises.build(movement: back_squat, position: 1, reps: 1)
+  segment.exercises.build(movement: bench_press, position: 2, reps: 1)
+  segment.exercises.build(movement: strict_pull_up, position: 3, reps: 1)
 end
 
 # ==============================================================================
 # K27
 # 27 rounds for time: 5 hang power cleans, 5 burpees, 15 double-unders
 Workout.find_or_create_by(name: 'K27') do |workout|
-  workout.rounds = 27
+  segment = workout.segments.build(rounds: 27, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: hang_power_clean, position: 1, reps: 5, female_load: 105, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 2, reps: 5)
-  workout.exercises.build(movement: double_under, position: 3, reps: 15)
+  segment.exercises.build(movement: hang_power_clean, position: 1, reps: 5, female_load: 105, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 2, reps: 5)
+  segment.exercises.build(movement: double_under, position: 3, reps: 15)
 end
 
 # ==============================================================================
 # Kelly Brown
 # 5 rounds for time: row 440m, 10 box jumps, 10 deadlifts, 10 wall-ball shots
 Workout.find_or_create_by(name: 'Kelly Brown') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 440, distance_unit: :meter)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 10, female_distance: 24, male_distance: 30, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 10, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, position: 4, reps: 10, female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 440, distance_unit: :meter)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 10, female_distance: 24, male_distance: 30, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 10, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 4, reps: 10, female_load: 20, male_load: 30, load_unit: :lb)
 end
 
 # ==============================================================================
 # Kerrie
 # 10 rounds for time: 100m sprint, 5 burpees, 20 sit-ups, 15 push-ups, 100m sprint. Rest 2 minutes.
 Workout.find_or_create_by(name: 'Kerrie') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 2 minutes between rounds.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: burpee, position: 2, reps: 5)
-  workout.exercises.build(movement: sit_up, position: 3, reps: 20)
-  workout.exercises.build(movement: push_up, position: 4, reps: 15)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: burpee, position: 2, reps: 5)
+  segment.exercises.build(movement: sit_up, position: 3, reps: 20)
+  segment.exercises.build(movement: push_up, position: 4, reps: 15)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
@@ -1561,57 +1596,59 @@ end
 # burpees (synchronized), 9 bar muscle-ups (each), 55-foot partner barbell carry
 # (205/315 lb)
 Workout.find_or_create_by(name: 'Kev') do |workout|
-  workout.time = 26
+  segment = workout.segments.build(time_seconds: 1560, position: 1)
   workout.score_type = :rep
   workout.team_size = 2
   workout.notes = 'With a partner.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 205, male_load: 315, load_unit: :lb, notes: 'Each partner.')
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 9, notes: 'Synchronized.')
-  workout.exercises.build(movement: bar_muscle_up, position: 3, reps: 9, notes: 'Each partner.')
-  workout.exercises.build(movement: barbell_carry, position: 4, reps: 1, distance: 55, distance_unit: :foot, female_load: 205, male_load: 315, load_unit: :lb, notes: 'Partner barbell carry.')
+  segment.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 205, male_load: 315, load_unit: :lb, notes: 'Each partner.')
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 9, notes: 'Synchronized.')
+  segment.exercises.build(movement: bar_muscle_up, position: 3, reps: 9, notes: 'Each partner.')
+  segment.exercises.build(movement: barbell_carry, position: 4, reps: 1, distance: 55, distance_unit: :foot, female_load: 205, male_load: 315, load_unit: :lb,
+                          notes: 'Partner barbell carry.')
 end
 
 # ==============================================================================
 # Kevin
 # 3 rounds for time: 32 deadlifts, 32 hanging hip touches (alternating), 800m running farmers carry
 Workout.find_or_create_by(name: 'Kevin') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 32, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: hanging_hip_touch, position: 2, reps: 32, notes: 'Alternating arms.')
-  workout.exercises.build(movement: farmers_carry, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Running farmers carry.', female_load: 10, male_load: 15, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 32, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: hanging_hip_touch, position: 2, reps: 32, notes: 'Alternating arms.')
+  segment.exercises.build(movement: farmers_carry, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Running farmers carry.',
+                          female_load: 10, male_load: 15, load_unit: :lb)
 end
 
 # ==============================================================================
 # Klepto
 # 4 rounds for time: 27 box jumps, 20 burpees, 11 squat cleans
 Workout.find_or_create_by(name: 'Klepto') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: box_jump, position: 1, reps: 27, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: burpee, position: 2, reps: 20)
-  workout.exercises.build(movement: clean_squat, position: 3, reps: 11, female_load: 95, male_load: 145, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 1, reps: 27, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: burpee, position: 2, reps: 20)
+  segment.exercises.build(movement: clean_squat, position: 3, reps: 11, female_load: 95, male_load: 145, load_unit: :lb)
 end
 
 # ==============================================================================
 # Kutschbach
 # 7 rounds for time: 11 back squats, 10 jerks
 Workout.find_or_create_by(name: 'Kutschbach') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: back_squat, position: 1, reps: 11, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: jerk, position: 2, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: back_squat, position: 1, reps: 11, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: jerk, position: 2, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Larry
 # 21-18-15-12-9-6-3 reps for time: front squats, bar-facing burpees
 Workout.find_or_create_by(name: 'Larry') do |workout|
-  workout.interval = '21-18-15-12-9-6-3'
+  segment = workout.segments.build(interval_scheme: '21-18-15-12-9-6-3', position: 1)
   workout.score_type = :time
   workout.notes = 'Use a 50-lb (♀) / 80-lb (♂) sandbag.'
-  workout.exercises.build(movement: front_squat, position: 1, reps: 1, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
+  segment.exercises.build(movement: front_squat, position: 1, reps: 1, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
 end
 
 # ==============================================================================
@@ -1619,38 +1656,38 @@ end
 # AMRAP in 21 minutes with a partner: 30-calorie row, 20 burpees over the rower,
 # 10 power cleans (105/155 lb). One partner works while the other rests.
 Workout.find_or_create_by(name: 'Laura') do |workout|
-  workout.time = 21
+  segment = workout.segments.build(time_seconds: 1260, position: 1)
   workout.score_type = :rep
   workout.team_size = 2
   workout.notes = 'With a partner; one works while the other rests.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, calories: 30)
-  workout.exercises.build(movement: burpee_over_rower, position: 2, reps: 20)
-  workout.exercises.build(movement: power_clean, position: 3, reps: 10, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 1, reps: 1, calories: 30)
+  segment.exercises.build(movement: burpee_over_rower, position: 2, reps: 20)
+  segment.exercises.build(movement: power_clean, position: 3, reps: 10, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
 # Ledesma
 # AMRAP in 20 minutes: 5 parallette handstand push-ups, 10 toes-to-rings, 15 medicine-ball cleans
 Workout.find_or_create_by(name: 'Ledesma') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: parallette_handstand_push_up, position: 1, reps: 5)
-  workout.exercises.build(movement: toes_to_rings, position: 2, reps: 10)
-  workout.exercises.build(movement: medicine_ball_clean, position: 3, reps: 15, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: parallette_handstand_push_up, position: 1, reps: 5)
+  segment.exercises.build(movement: toes_to_rings, position: 2, reps: 10)
+  segment.exercises.build(movement: medicine_ball_clean, position: 3, reps: 15, female_load: 14, male_load: 20, load_unit: :lb)
 end
 
 # ==============================================================================
 # Lee
 # 5 rounds for time: 400m run, 1 deadlift, 3 squat cleans, 5 push jerks, 3 muscle-ups, 1 rope climb to 15 feet
 Workout.find_or_create_by(name: 'Lee') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 1, female_load: 225, male_load: 345, load_unit: :lb)
-  workout.exercises.build(movement: clean_squat, position: 3, reps: 3, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: push_jerk, position: 4, reps: 5, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 5, reps: 3)
-  workout.exercises.build(movement: rope_climb, position: 6, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 1, female_load: 225, male_load: 345, load_unit: :lb)
+  segment.exercises.build(movement: clean_squat, position: 3, reps: 3, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: push_jerk, position: 4, reps: 5, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 5, reps: 3)
+  segment.exercises.build(movement: rope_climb, position: 6, reps: 1, distance: 15, distance_unit: :foot)
 end
 
 # ==============================================================================
@@ -1659,76 +1696,81 @@ end
 Workout.find_or_create_by(name: 'Leehan') do |workout|
   workout.score_type = :time
   rounds = workout.segments.build(rounds: 7, position: 1)
-  workout.exercises.build(movement: deadlift, segment: rounds, position: 1, reps: 6, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: air_squat, segment: rounds, position: 2, reps: 6)
-  workout.exercises.build(movement: box_jump, segment: rounds, position: 3, reps: 6, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: row, position: 2, reps: 1, distance: 1742, distance_unit: :meter)
+  rounds.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 125, male_load: 185, load_unit: :lb)
+  rounds.exercises.build(movement: air_squat, position: 2, reps: 6)
+  rounds.exercises.build(movement: box_jump, position: 3, reps: 6, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment = workout.segments.build(position: 2)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1742, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Liam
 # For time: run 800m w/ plate, 100 toes-to-bars, 50 front squats, 10 rope climbs to 15 feet, run 800m w/ plate. Partition.
 Workout.find_or_create_by(name: 'Liam') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Partition the toes-to-bars, front squats, and rope climbs as needed.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 100)
-  workout.exercises.build(movement: front_squat, position: 3, reps: 50, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 4, reps: 10, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45,
+                          load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 100)
+  segment.exercises.build(movement: front_squat, position: 3, reps: 50, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 4, reps: 10, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45,
+                          load_unit: :lb)
 end
 
 # ==============================================================================
 # Locke
 # For time: 565m row or run; 7 rounds (9 deadlifts, 25 push-ups, 21 box step-ups); 565m row or run
 Workout.find_or_create_by(name: 'Locke') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 565, distance_unit: :meter, notes: 'Row or run.')
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 565, distance_unit: :meter, notes: 'Row or run.')
   rounds = workout.segments.build(rounds: 7, position: 2)
-  workout.exercises.build(movement: deadlift, segment: rounds, position: 1, reps: 9, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: push_up, segment: rounds, position: 2, reps: 25)
-  workout.exercises.build(movement: box_step_up, segment: rounds, position: 3, reps: 21, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: row, position: 3, reps: 1, distance: 565, distance_unit: :meter, notes: 'Row or run.')
+  rounds.exercises.build(movement: deadlift, position: 1, reps: 9, female_load: 125, male_load: 185, load_unit: :lb)
+  rounds.exercises.build(movement: push_up, position: 2, reps: 25)
+  rounds.exercises.build(movement: box_step_up, position: 3, reps: 21, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 565, distance_unit: :meter, notes: 'Row or run.')
 end
 
 # ==============================================================================
 # Loredo
 # 6 rounds for time: 24 squats, 24 push-ups, 24 walking lunge steps, run 400m
 Workout.find_or_create_by(name: 'Loredo') do |workout|
-  workout.rounds = 6
+  segment = workout.segments.build(rounds: 6, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: air_squat, position: 1, reps: 24)
-  workout.exercises.build(movement: push_up, position: 2, reps: 24)
-  workout.exercises.build(movement: walking_lunge, position: 3, reps: 24)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: air_squat, position: 1, reps: 24)
+  segment.exercises.build(movement: push_up, position: 2, reps: 24)
+  segment.exercises.build(movement: walking_lunge, position: 3, reps: 24)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Lorenzo
 # For time: run 1,000m; 5 rounds (15 push-ups, 20 medicine-ball cleans, 21 burpees); run 1,000m
 Workout.find_or_create_by(name: 'Lorenzo') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 5, position: 2)
-  workout.exercises.build(movement: push_up, segment: rounds, position: 1, reps: 15)
-  workout.exercises.build(movement: medicine_ball_clean, segment: rounds, position: 2, reps: 20)
-  workout.exercises.build(movement: burpee, segment: rounds, position: 3, reps: 21)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 1000, distance_unit: :meter)
+  rounds.exercises.build(movement: push_up, position: 1, reps: 15)
+  rounds.exercises.build(movement: medicine_ball_clean, position: 2, reps: 20)
+  rounds.exercises.build(movement: burpee, position: 3, reps: 21)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Luce
 # Wearing a weight vest, 3 rounds for time: 1K run, 10 muscle-ups, 100 squats
 Workout.find_or_create_by(name: 'Luce') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: muscle_up, position: 2, reps: 10)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 100)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: muscle_up, position: 2, reps: 10)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 100)
 end
 
 # ==============================================================================
@@ -1736,21 +1778,22 @@ end
 # For time: run 400m, 15 clean and jerks, run 400m, 30 toes-to-bars, run 400m, 45 wall-ball shots,
 # run 400m, 45 kettlebell swings, run 400m, 30 ring dips, run 400m, 15 front-rack weighted lunges, run 400m
 Workout.find_or_create_by(name: 'Luke') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: clean_and_jerk, position: 2, reps: 15, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: toes_to_bar, position: 4, reps: 30)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: wall_ball_shot, position: 6, reps: 45, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: kettlebell_swing, position: 8, reps: 45, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 9, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: ring_dip, position: 10, reps: 30)
-  workout.exercises.build(movement: run, position: 11, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: barbell_front_rack_lunge, position: 12, reps: 15, notes: 'Front-rack weighted lunge.', female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 13, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: clean_and_jerk, position: 2, reps: 15, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: toes_to_bar, position: 4, reps: 30)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: wall_ball_shot, position: 6, reps: 45, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 8, reps: 45, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 9, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: ring_dip, position: 10, reps: 30)
+  segment.exercises.build(movement: run, position: 11, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: barbell_front_rack_lunge, position: 12, reps: 15, notes: 'Front-rack weighted lunge.', female_load: 105, male_load: 155,
+                          load_unit: :lb)
+  segment.exercises.build(movement: run, position: 13, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -1758,79 +1801,79 @@ end
 # For time: 20 deadlifts, run 400m, 20 KB swings, run 400m, 20 overhead squats, run 400m, 20 burpees,
 # run 400m, 20 chest-to-bar pull-ups, run 400m, 20 box jumps, run 400m, 20 dumbbell squat cleans, run 400m
 Workout.find_or_create_by(name: 'Lumberjack 20') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 20, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 20, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: overhead_squat, position: 5, reps: 20, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee, position: 7, reps: 20)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 9, reps: 20)
-  workout.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: box_jump, position: 11, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: run, position: 12, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: dumbbell_squat_clean, position: 13, reps: 20, female_load: 30, male_load: 45, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: run, position: 14, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 20, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 20, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: overhead_squat, position: 5, reps: 20, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 6, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee, position: 7, reps: 20)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 9, reps: 20)
+  segment.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: box_jump, position: 11, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 12, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_squat_clean, position: 13, reps: 20, female_load: 30, male_load: 45, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: run, position: 14, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Maloney
 # 6 rounds for time: 300m shuttle run, 16 deadlifts, 6 hang power cleans. Rest 2 minutes between sets.
 Workout.find_or_create_by(name: 'Maloney') do |workout|
-  workout.rounds = 6
+  segment = workout.segments.build(rounds: 6, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 2 minutes between sets. The shuttle run is 50m out and back x6 or 100m out and back x3.'
-  workout.exercises.build(movement: shuttle_run, position: 1, reps: 1, distance: 300, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: hang_power_clean, position: 3, reps: 6, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: shuttle_run, position: 1, reps: 1, distance: 300, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: hang_power_clean, position: 3, reps: 6, female_load: 125, male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
 # Manion
 # 7 rounds for time: 400m run, 29 back squats
 Workout.find_or_create_by(name: 'Manion') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 29, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 29, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Manuel
 # 5 rounds: 3 min rope climbs, 2 min squats, 2 min push-ups, 3 min to run 400m (rest remainder)
 Workout.find_or_create_by(name: 'Manuel') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :rep
   workout.notes = 'After the 400m run, rest for the remainder of the 3 minutes before the next round.'
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 0, duration_seconds: 180)
-  workout.exercises.build(movement: air_squat, position: 2, reps: 0, duration_seconds: 120)
-  workout.exercises.build(movement: push_up, position: 3, reps: 0, duration_seconds: 120)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, duration_seconds: 180)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 0, duration_seconds: 180)
+  segment.exercises.build(movement: air_squat, position: 2, reps: 0, duration_seconds: 120)
+  segment.exercises.build(movement: push_up, position: 3, reps: 0, duration_seconds: 120)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter, duration_seconds: 180)
 end
 
 # ==============================================================================
 # Marco
 # 3 rounds for time: 21 pull-ups, 15 handstand push-ups, 9 thrusters
 Workout.find_or_create_by(name: 'Marco') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: pull_up, position: 1, reps: 21)
-  workout.exercises.build(movement: handstand_push_up, position: 2, reps: 15)
-  workout.exercises.build(movement: thruster, position: 3, reps: 9, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 21)
+  segment.exercises.build(movement: handstand_push_up, position: 2, reps: 15)
+  segment.exercises.build(movement: thruster, position: 3, reps: 9, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Marston
 # AMRAP in 20 minutes: 1 deadlift, 10 toes-to-bars, 15 bar-facing burpees
 Workout.find_or_create_by(name: 'Marston') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 275, male_load: 405, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 10)
-  workout.exercises.build(movement: bar_facing_burpee, position: 3, reps: 15)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 275, male_load: 405, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 10)
+  segment.exercises.build(movement: bar_facing_burpee, position: 3, reps: 15)
 end
 
 # ==============================================================================
@@ -1839,50 +1882,50 @@ end
 # (30/43 kg), 1,000-meter row, 100 hand-release push-ups, 50 pull-ups, 500-meter row,
 # 100 AbMat sit-ups, 100 wall-ball shots (14/20 lb)
 Workout.find_or_create_by(name: 'Martin') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner. Deadlifts at bodyweight.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 2000, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 100, notes: 'Bodyweight.')
-  workout.exercises.build(movement: thruster, position: 3, reps: 50, female_load: 30, male_load: 43, load_unit: :kg)
-  workout.exercises.build(movement: row, position: 4, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: hand_release_push_up, position: 5, reps: 100)
-  workout.exercises.build(movement: pull_up, position: 6, reps: 50)
-  workout.exercises.build(movement: row, position: 7, reps: 1, distance: 500, distance_unit: :meter)
-  workout.exercises.build(movement: abmat_sit_up, position: 8, reps: 100)
-  workout.exercises.build(movement: wall_ball_shot, position: 9, reps: 100, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 100, notes: 'Bodyweight.')
+  segment.exercises.build(movement: thruster, position: 3, reps: 50, female_load: 30, male_load: 43, load_unit: :kg)
+  segment.exercises.build(movement: row, position: 4, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: hand_release_push_up, position: 5, reps: 100)
+  segment.exercises.build(movement: pull_up, position: 6, reps: 50)
+  segment.exercises.build(movement: row, position: 7, reps: 1, distance: 500, distance_unit: :meter)
+  segment.exercises.build(movement: abmat_sit_up, position: 8, reps: 100)
+  segment.exercises.build(movement: wall_ball_shot, position: 9, reps: 100, female_load: 14, male_load: 20, load_unit: :lb)
 end
 
 # ==============================================================================
 # Matt 16
 # For time: 16 deadlifts, 16 hang power cleans, 16 push presses, run 800m (x3 sets, runs between)
 Workout.find_or_create_by(name: 'Matt 16') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 16, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: hang_power_clean, position: 2, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: push_press, position: 3, reps: 16, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 5, reps: 16, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: hang_power_clean, position: 6, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: push_press, position: 7, reps: 16, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 8, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 9, reps: 16, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: hang_power_clean, position: 10, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: push_press, position: 11, reps: 16, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 16, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: hang_power_clean, position: 2, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: push_press, position: 3, reps: 16, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 5, reps: 16, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: hang_power_clean, position: 6, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: push_press, position: 7, reps: 16, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 8, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 9, reps: 16, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: hang_power_clean, position: 10, reps: 16, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: push_press, position: 11, reps: 16, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Maupin
 # 4 rounds for time: 800m run, 49 push-ups, 49 sit-ups, 49 squats
 Workout.find_or_create_by(name: 'Maupin') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 2, reps: 49)
-  workout.exercises.build(movement: sit_up, position: 3, reps: 49)
-  workout.exercises.build(movement: air_squat, position: 4, reps: 49)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 2, reps: 49)
+  segment.exercises.build(movement: sit_up, position: 3, reps: 49)
+  segment.exercises.build(movement: air_squat, position: 4, reps: 49)
 end
 
 # ==============================================================================
@@ -1891,31 +1934,31 @@ end
 # wall sit. Then each athlete: 56 burpees, 56 flutter kicks, 56 walking lunges,
 # 56 hand-release push-ups, 56 air squats. Cash-out: 5,600-meter run.
 Workout.find_or_create_by(name: 'Maxim 56') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner.'
   buy_in = workout.segments.build(position: 1, name: 'Buy-in')
-  workout.exercises.build(movement: handstand_hold, segment: buy_in, position: 1, reps: 1, duration_seconds: 56, notes: 'Each partner; or a 56-second wall sit.')
-  workout.exercises.build(movement: burpee, position: 2, reps: 56, notes: 'Each partner.')
-  workout.exercises.build(movement: flutter_kick, position: 3, reps: 56, notes: 'Each partner; 4-count.')
-  workout.exercises.build(movement: walking_lunge, position: 4, reps: 56, notes: 'Each partner.')
-  workout.exercises.build(movement: hand_release_push_up, position: 5, reps: 56, notes: 'Each partner.')
-  workout.exercises.build(movement: air_squat, position: 6, reps: 56, notes: 'Each partner.')
+  buy_in.exercises.build(movement: handstand_hold, position: 1, reps: 1, duration_seconds: 56, notes: 'Each partner; or a 56-second wall sit.')
+  segment = workout.segments.build(position: 2)
+  segment.exercises.build(movement: burpee, position: 1, reps: 56, notes: 'Each partner.')
+  segment.exercises.build(movement: flutter_kick, position: 2, reps: 56, notes: 'Each partner; 4-count.')
+  segment.exercises.build(movement: walking_lunge, position: 3, reps: 56, notes: 'Each partner.')
+  segment.exercises.build(movement: hand_release_push_up, position: 4, reps: 56, notes: 'Each partner.')
+  segment.exercises.build(movement: air_squat, position: 5, reps: 56, notes: 'Each partner.')
   cash_out = workout.segments.build(position: 7, name: 'Cash-out')
-  workout.exercises.build(movement: run, segment: cash_out, position: 1, reps: 1, distance: 5600, distance_unit: :meter, notes: 'Run together.')
+  cash_out.exercises.build(movement: run, position: 1, reps: 1, distance: 5600, distance_unit: :meter, notes: 'Run together.')
 end
 
 # ==============================================================================
 # Maxton
 # 13 rounds for time: 8 strict pull-ups, 26 box step-ups, 21 burpees
 Workout.find_or_create_by(name: 'Maxton') do |workout|
-  workout.rounds = 13
+  segment = workout.segments.build(rounds: 13, position: 1)
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: strict_pull_up, position: 1, reps: 8)
-  workout.exercises.build(movement: box_step_up, position: 2, reps: 26, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: burpee, position: 3, reps: 21)
+  segment.exercises.build(movement: strict_pull_up, position: 1, reps: 8)
+  segment.exercises.build(movement: box_step_up, position: 2, reps: 26, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: burpee, position: 3, reps: 21)
 end
 
 # ==============================================================================
@@ -1924,87 +1967,89 @@ end
 # 34 kettlebell swings (53/70 lb), 484 double-unders, 108 burpees, 2,000-meter row,
 # 18 deadlifts (155/225 lb)
 Workout.find_or_create_by(name: 'McCartney') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.team_size = 3
   workout.notes = 'As a 3-person team.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 2000, distance_unit: :meter)
-  workout.exercises.build(movement: dumbbell_thruster, position: 2, reps: 14, female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 34, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 4, reps: 484)
-  workout.exercises.build(movement: burpee, position: 5, reps: 108)
-  workout.exercises.build(movement: row, position: 6, reps: 1, distance: 2000, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 7, reps: 18, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_thruster, position: 2, reps: 14, female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 34, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 4, reps: 484)
+  segment.exercises.build(movement: burpee, position: 5, reps: 108)
+  segment.exercises.build(movement: row, position: 6, reps: 1, distance: 2000, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 7, reps: 18, female_load: 155, male_load: 225, load_unit: :lb)
 end
 
 # ==============================================================================
 # McCluskey
 # 3 rounds for time: 9 muscle-ups, 15 burpee pull-ups, 21 pull-ups, run 800m
 Workout.find_or_create_by(name: 'McCluskey') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 9)
-  workout.exercises.build(movement: burpee_pull_up, position: 2, reps: 15)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 21)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 9)
+  segment.exercises.build(movement: burpee_pull_up, position: 2, reps: 15)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 21)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 # ==============================================================================
 # McGhee
 # AMRAP in 30 minutes: 5 deadlifts, 13 push-ups, 9 box jumps
 Workout.find_or_create_by(name: 'McGhee') do |workout|
-  workout.time = 30
+  segment = workout.segments.build(time_seconds: 1800, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 5, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: push_up, position: 2, reps: 13)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 9, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 5, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: push_up, position: 2, reps: 13)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 9, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
 # Meadows
 # For time: 20 muscle-ups, 25 inverted ring lowers, 30 ring handstand push-ups, 35 ring rows, 40 ring push-ups
 Workout.find_or_create_by(name: 'Meadows') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 20)
-  workout.exercises.build(movement: inverted_ring_lower, position: 2, reps: 25, notes: 'Lower slowly with straight body and arms.')
-  workout.exercises.build(movement: ring_handstand_push_up, position: 3, reps: 30)
-  workout.exercises.build(movement: ring_row, position: 4, reps: 35)
-  workout.exercises.build(movement: ring_push_up, position: 5, reps: 40)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 20)
+  segment.exercises.build(movement: inverted_ring_lower, position: 2, reps: 25, notes: 'Lower slowly with straight body and arms.')
+  segment.exercises.build(movement: ring_handstand_push_up, position: 3, reps: 30)
+  segment.exercises.build(movement: ring_row, position: 4, reps: 35)
+  segment.exercises.build(movement: ring_push_up, position: 5, reps: 40)
 end
 
 # ==============================================================================
 # Michael
 # 3 rounds for time: run 800m, 50 back extensions, 50 sit-ups
 Workout.find_or_create_by(name: 'Michael') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: back_extensions, position: 2, reps: 50)
-  workout.exercises.build(movement: sit_up, position: 3, reps: 50)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: back_extensions, position: 2, reps: 50)
+  segment.exercises.build(movement: sit_up, position: 3, reps: 50)
 end
 
 # ==============================================================================
 # Miron
 # 5 rounds for time: 800m run, 23 back squats, 13 deadlifts
 Workout.find_or_create_by(name: 'Miron') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 23)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 13)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 23)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 13)
 end
 
 # ==============================================================================
 # Monti
 # 5 rounds for time: 50 barbell step-ups, 15 cleans, 50 barbell step-ups, 10 snatches
 Workout.find_or_create_by(name: 'Monti') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: barbell_step_up, position: 1, reps: 50, female_load: 35, male_load: 45, load_unit: :lb, female_distance: 20, male_distance: 20, distance_unit: :inch)
-  workout.exercises.build(movement: clean, position: 2, reps: 15, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: barbell_step_up, position: 3, reps: 50, female_load: 35, male_load: 45, load_unit: :lb, female_distance: 20, male_distance: 20, distance_unit: :inch)
-  workout.exercises.build(movement: snatch, position: 4, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: barbell_step_up, position: 1, reps: 50, female_load: 35, male_load: 45, load_unit: :lb, female_distance: 20,
+                          male_distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: clean, position: 2, reps: 15, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: barbell_step_up, position: 3, reps: 50, female_load: 35, male_load: 45, load_unit: :lb, female_distance: 20,
+                          male_distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: snatch, position: 4, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -2012,131 +2057,134 @@ end
 # 7 rounds for time: 10 dumbbell hang split snatches (R), 1 rope climb to 15 feet,
 # 10 dumbbell hang split snatches (L), 1 rope climb. Alternate feet on the split snatches.
 Workout.find_or_create_by(name: 'Moon') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
   workout.notes = 'Alternate feet on the split snatches.'
-  workout.exercises.build(movement: dumbbell_hang_split_snatch, position: 1, reps: 10, notes: 'Right arm.', female_load: 30, male_load: 40, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 2, reps: 1, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: dumbbell_hang_split_snatch, position: 3, reps: 10, notes: 'Left arm.', female_load: 30, male_load: 40, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 4, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: dumbbell_hang_split_snatch, position: 1, reps: 10, notes: 'Right arm.', female_load: 30, male_load: 40, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 2, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: dumbbell_hang_split_snatch, position: 3, reps: 10, notes: 'Left arm.', female_load: 30, male_load: 40, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 4, reps: 1, distance: 15, distance_unit: :foot)
 end
 
 # ==============================================================================
 # Moore
 # AMRAP in 20 minutes: 1 rope climb to 15 feet, run 400m, max-rep handstand push-ups
 Workout.find_or_create_by(name: 'Moore') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :round
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 1, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: handstand_push_up, position: 3, reps: 0)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: handstand_push_up, position: 3, reps: 0)
 end
 
 # ==============================================================================
 # Morrison
 # 50-40-30-20-10 reps for time: wall-ball shots, box jumps, kettlebell swings
 Workout.find_or_create_by(name: 'Morrison') do |workout|
-  workout.interval = '50-40-30-20-10'
+  segment = workout.segments.build(interval_scheme: '50-40-30-20-10', position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 1, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 1, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 1, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 1, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 1, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 1, female_load: 35, male_load: 53, load_unit: :lb)
 end
 
 # ==============================================================================
 # Mr. Joshua
 # 5 rounds for time: run 400m, 30 GHD sit-ups, 15 deadlifts
 Workout.find_or_create_by(name: 'Mr. Joshua') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: ghd_sit_up, position: 2, reps: 30)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 15, female_load: 175, male_load: 250, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: ghd_sit_up, position: 2, reps: 30)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 15, female_load: 175, male_load: 250, load_unit: :lb)
 end
 
 # ==============================================================================
 # Muller
 # For time: run 1,000m, 710m plate carry; 5 rounds (13 burpee pull-ups, 13 deadlifts); 710m plate carry, run 1,000m
 Workout.find_or_create_by(name: 'Muller') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: plate_carry, position: 2, reps: 1, distance: 710, distance_unit: :meter, female_load: 25, male_load: 45, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: plate_carry, position: 2, reps: 1, distance: 710, distance_unit: :meter, female_load: 25, male_load: 45, load_unit: :lb)
   rounds = workout.segments.build(rounds: 5, position: 3)
-  workout.exercises.build(movement: burpee_pull_up, segment: rounds, position: 1, reps: 13)
-  workout.exercises.build(movement: deadlift, segment: rounds, position: 2, reps: 13, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: plate_carry, position: 4, reps: 1, distance: 710, distance_unit: :meter, female_load: 25, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 1000, distance_unit: :meter)
+  rounds.exercises.build(movement: burpee_pull_up, position: 1, reps: 13)
+  rounds.exercises.build(movement: deadlift, position: 2, reps: 13, female_load: 155, male_load: 225, load_unit: :lb)
+  segment = workout.segments.build(position: 4)
+  segment.exercises.build(movement: plate_carry, position: 1, reps: 1, distance: 710, distance_unit: :meter, female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 1000, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Murph
 # For time: 1-mile run, 100 pull-ups, 200 push-ups, 300 squats, 1-mile run. Partition as needed.
 Workout.find_or_create_by(name: 'Murph') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Partition the pull-ups, push-ups, and squats as needed.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 100)
-  workout.exercises.build(movement: push_up, position: 3, reps: 200)
-  workout.exercises.build(movement: air_squat, position: 4, reps: 300)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 100)
+  segment.exercises.build(movement: push_up, position: 3, reps: 200)
+  segment.exercises.build(movement: air_squat, position: 4, reps: 300)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Nate
 # AMRAP in 20 minutes: 2 muscle-ups, 4 handstand push-ups, 8 kettlebell swings
 Workout.find_or_create_by(name: 'Nate') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 2)
-  workout.exercises.build(movement: handstand_push_up, position: 2, reps: 4)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 8, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 2)
+  segment.exercises.build(movement: handstand_push_up, position: 2, reps: 4)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 8, female_load: 53, male_load: 70, load_unit: :lb)
 end
 
 # ==============================================================================
 # Ned
 # 7 rounds for time: 11 back squats, 1,000m row
 Workout.find_or_create_by(name: 'Ned') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: back_squat, position: 1, reps: 11)
-  workout.exercises.build(movement: row, position: 2, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 1, reps: 11)
+  segment.exercises.build(movement: row, position: 2, reps: 1, distance: 1000, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Nick
 # 12 rounds for time: 10 dumbbell hang squat cleans, 6 handstand push-ups on dumbbells
 Workout.find_or_create_by(name: 'Nick') do |workout|
-  workout.rounds = 12
+  segment = workout.segments.build(rounds: 12, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: dumbbell_hang_squat_clean, position: 1, reps: 10, female_load: 30, male_load: 45, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: handstand_push_up, position: 2, reps: 6, notes: 'On dumbbells.')
+  segment.exercises.build(movement: dumbbell_hang_squat_clean, position: 1, reps: 10, female_load: 30, male_load: 45, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: handstand_push_up, position: 2, reps: 6, notes: 'On dumbbells.')
 end
 
 # ==============================================================================
 # Nickman
 # 10 rounds for time: 200m farmers carry, 10 weighted pull-ups, 20 dumbbell alternating power snatches
 Workout.find_or_create_by(name: 'Nickman') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: farmers_carry, position: 1, reps: 1, distance: 200, distance_unit: :meter, female_load: 40, male_load: 55, load_unit: :lb)
-  workout.exercises.build(movement: weighted_pull_up, position: 2, reps: 10, female_load: 20, male_load: 35, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 20, notes: 'Alternating arms.', female_load: 40, male_load: 55, load_unit: :lb)
+  segment.exercises.build(movement: farmers_carry, position: 1, reps: 1, distance: 200, distance_unit: :meter, female_load: 40, male_load: 55, load_unit: :lb)
+  segment.exercises.build(movement: weighted_pull_up, position: 2, reps: 10, female_load: 20, male_load: 35, load_unit: :lb)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 20, notes: 'Alternating arms.', female_load: 40, male_load: 55, load_unit: :lb)
 end
 
 # ==============================================================================
 # Northrup
 # For time: 26 barbell back-rack step-ups; 3 rounds (17 power cleans, 19 sit-ups, 21 deadlifts); 31-calorie row
 Workout.find_or_create_by(name: 'Northrup') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: barbell_back_rack_step_up, position: 1, reps: 26, female_distance: 20, male_distance: 24, distance_unit: :inch, female_load: 65, male_load: 95, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: barbell_back_rack_step_up, position: 1, reps: 26, female_distance: 20, male_distance: 24, distance_unit: :inch,
+                          female_load: 65, male_load: 95, load_unit: :lb)
   rounds = workout.segments.build(rounds: 3, position: 2)
-  workout.exercises.build(movement: power_clean, segment: rounds, position: 1, reps: 17, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: sit_up, segment: rounds, position: 2, reps: 19)
-  workout.exercises.build(movement: deadlift, segment: rounds, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: row, position: 3, reps: 1, calories: 31)
+  rounds.exercises.build(movement: power_clean, position: 1, reps: 17, female_load: 65, male_load: 95, load_unit: :lb)
+  rounds.exercises.build(movement: sit_up, position: 2, reps: 19)
+  rounds.exercises.build(movement: deadlift, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: row, position: 1, reps: 1, calories: 31)
 end
 
 # ==============================================================================
@@ -2146,14 +2194,14 @@ Workout.find_or_create_by(name: 'Nukes') do |workout|
   workout.score_type = :rep
   workout.notes = 'Do not rest between rounds.'
   station_one = workout.segments.build(position: 1, name: '8-minute station', time_seconds: 480)
-  workout.exercises.build(movement: run, segment: station_one, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, segment: station_one, position: 2, reps: 0, female_load: 205, male_load: 315, load_unit: :lb)
+  station_one.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  station_one.exercises.build(movement: deadlift, position: 2, reps: 0, female_load: 205, male_load: 315, load_unit: :lb)
   station_two = workout.segments.build(position: 2, name: '10-minute station', time_seconds: 600)
-  workout.exercises.build(movement: run, segment: station_two, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: power_clean, segment: station_two, position: 2, reps: 0, female_load: 155, male_load: 225, load_unit: :lb)
+  station_two.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  station_two.exercises.build(movement: power_clean, position: 2, reps: 0, female_load: 155, male_load: 225, load_unit: :lb)
   station_three = workout.segments.build(position: 3, name: '12-minute station', time_seconds: 720)
-  workout.exercises.build(movement: run, segment: station_three, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: overhead_squat, segment: station_three, position: 2, reps: 0, female_load: 95, male_load: 135, load_unit: :lb)
+  station_three.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  station_three.exercises.build(movement: overhead_squat, position: 2, reps: 0, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -2161,20 +2209,20 @@ end
 # For time: 800m run, 60 burpee box jump-overs, 50 pull-ups, 40 squats; 600m run, 30 burpee box jump-overs,
 # 25 chest-to-bar pull-ups, 20 squats; 400m run, 15 burpee box jump-overs, 12 bar muscle-ups, 10 squat cleans
 Workout.find_or_create_by(name: 'Nunez') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 2, reps: 60, female_distance: 20, male_distance: 20, distance_unit: :inch)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 50)
-  workout.exercises.build(movement: air_squat, position: 4, reps: 40, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 600, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 6, reps: 30, female_distance: 20, male_distance: 20, distance_unit: :inch)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 7, reps: 25)
-  workout.exercises.build(movement: air_squat, position: 8, reps: 20, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 9, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 10, reps: 15, female_distance: 20, male_distance: 20, distance_unit: :inch)
-  workout.exercises.build(movement: bar_muscle_up, position: 11, reps: 12)
-  workout.exercises.build(movement: clean_squat, position: 12, reps: 10, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 2, reps: 60, female_distance: 20, male_distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 50)
+  segment.exercises.build(movement: air_squat, position: 4, reps: 40, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 600, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 6, reps: 30, female_distance: 20, male_distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 7, reps: 25)
+  segment.exercises.build(movement: air_squat, position: 8, reps: 20, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 9, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 10, reps: 15, female_distance: 20, male_distance: 20, distance_unit: :inch)
+  segment.exercises.build(movement: bar_muscle_up, position: 11, reps: 12)
+  segment.exercises.build(movement: clean_squat, position: 12, reps: 10, female_load: 155, male_load: 225, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -2182,41 +2230,42 @@ end
 # For time: 10 handstand push-ups, 15 deadlifts, 25 box jumps, 50 pull-ups, 100 wall-ball shots,
 # 200 double-unders, 400m run with a plate
 Workout.find_or_create_by(name: 'Nutts') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 10)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 15, female_load: 175, male_load: 250, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 25, female_distance: 24, male_distance: 30, distance_unit: :inch)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 50)
-  workout.exercises.build(movement: wall_ball_shot, position: 5, reps: 100, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 6, reps: 200)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 10)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 15, female_load: 175, male_load: 250, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 25, female_distance: 24, male_distance: 30, distance_unit: :inch)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 50)
+  segment.exercises.build(movement: wall_ball_shot, position: 5, reps: 100, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 6, reps: 200)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45,
+                          load_unit: :lb)
 end
 
 # ==============================================================================
 # ODA 7313
 # 7 rounds for time: 300m jog, 10 left-arm DB thrusters, 10 right-arm DB thrusters, 7 strict pull-ups
 Workout.find_or_create_by(name: 'ODA 7313') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 300, distance_unit: :meter, notes: 'Jog.')
-  workout.exercises.build(movement: dumbbell_thruster, position: 2, reps: 10, notes: 'Left arm.', female_load: 20, male_load: 30, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_thruster, position: 3, reps: 10, notes: 'Right arm.', female_load: 20, male_load: 30, load_unit: :lb)
-  workout.exercises.build(movement: strict_pull_up, position: 4, reps: 7)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 300, distance_unit: :meter, notes: 'Jog.')
+  segment.exercises.build(movement: dumbbell_thruster, position: 2, reps: 10, notes: 'Left arm.', female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: dumbbell_thruster, position: 3, reps: 10, notes: 'Right arm.', female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: strict_pull_up, position: 4, reps: 7)
 end
 
 # ==============================================================================
 # Omar
 # For time: 10 thrusters, 15 bar-facing burpees, 20 thrusters, 25 bar-facing burpees, 30 thrusters, 35 bar-facing burpees
 Workout.find_or_create_by(name: 'Omar') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: thruster, position: 1, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 15)
-  workout.exercises.build(movement: thruster, position: 3, reps: 20, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 4, reps: 25)
-  workout.exercises.build(movement: thruster, position: 5, reps: 30, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 6, reps: 35)
+  segment.exercises.build(movement: thruster, position: 1, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 15)
+  segment.exercises.build(movement: thruster, position: 3, reps: 20, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 4, reps: 25)
+  segment.exercises.build(movement: thruster, position: 5, reps: 30, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 6, reps: 35)
 end
 
 # ==============================================================================
@@ -2224,14 +2273,14 @@ end
 # AMRAP in 15 minutes, ascending ladder: 1 back squat, 1 shoulder press, 1 deadlift; then 2 of each;
 # then 3 of each; etc. Use 1 1/2 body weight for the squats and deadlifts and 3/4 body weight for the presses.
 Workout.find_or_create_by(name: 'Otis') do |workout|
-  workout.time = 15
+  segment = workout.segments.build(time_seconds: 900, position: 1)
   workout.score_type = :rep
   workout.ladder_step = 1
   workout.notes = 'Ascending ladder: 1 rep of each movement, then 2 of each, then 3 of each, and so on ' \
                   'for as long as 15 minutes allow. Post total reps.'
-  workout.exercises.build(movement: back_squat, position: 1, reps: 1, notes: '1 1/2 body weight')
-  workout.exercises.build(movement: shoulder_press, position: 2, reps: 1, notes: '3/4 body weight')
-  workout.exercises.build(movement: deadlift, position: 3, reps: 1, notes: '1 1/2 body weight')
+  segment.exercises.build(movement: back_squat, position: 1, reps: 1, notes: '1 1/2 body weight')
+  segment.exercises.build(movement: shoulder_press, position: 2, reps: 1, notes: '3/4 body weight')
+  segment.exercises.build(movement: deadlift, position: 3, reps: 1, notes: '1 1/2 body weight')
 end
 
 # ==============================================================================
@@ -2240,51 +2289,58 @@ end
 # 50-meter single-dumbbell waiters walk (right arm), 50-meter single-dumbbell waiters
 # walk (left arm). One partner works at a time. (35/45 lb)
 Workout.find_or_create_by(name: 'Partner Weston') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.team_size = 2
   workout.notes = 'With a partner; one partner works at a time.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: dumbbell_farmers_carry, position: 2, reps: 1, distance: 200, distance_unit: :meter, female_load: 35, male_load: 45, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: dumbbell_waiters_walk, position: 3, reps: 1, distance: 50, distance_unit: :meter, female_load: 35, male_load: 45, load_unit: :lb, notes: 'Right arm.')
-  workout.exercises.build(movement: dumbbell_waiters_walk, position: 4, reps: 1, distance: 50, distance_unit: :meter, female_load: 35, male_load: 45, load_unit: :lb, notes: 'Left arm.')
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_farmers_carry, position: 2, reps: 1, distance: 200, distance_unit: :meter, female_load: 35, male_load: 45,
+                          load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: dumbbell_waiters_walk, position: 3, reps: 1, distance: 50, distance_unit: :meter, female_load: 35, male_load: 45,
+                          load_unit: :lb, notes: 'Right arm.')
+  segment.exercises.build(movement: dumbbell_waiters_walk, position: 4, reps: 1, distance: 50, distance_unit: :meter, female_load: 35, male_load: 45,
+                          load_unit: :lb, notes: 'Left arm.')
 end
 
 # ==============================================================================
 # Pat
 # For time: run 800m w/ plate; 14 rounds (5 strict pull-ups, 4 burpee box jumps, 3 cleans); run 800m w/ plate
 Workout.find_or_create_by(name: 'Pat') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 25, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 25,
+                          load_unit: :lb)
   rounds = workout.segments.build(rounds: 14, position: 2)
-  workout.exercises.build(movement: strict_pull_up, segment: rounds, position: 1, reps: 5)
-  workout.exercises.build(movement: burpee_box_jump, segment: rounds, position: 2, reps: 4, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: clean, segment: rounds, position: 3, reps: 3, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 25, load_unit: :lb)
+  rounds.exercises.build(movement: strict_pull_up, position: 1, reps: 5)
+  rounds.exercises.build(movement: burpee_box_jump, position: 2, reps: 4, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  rounds.exercises.build(movement: clean, position: 3, reps: 3, female_load: 125, male_load: 185, load_unit: :lb)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 25,
+                          load_unit: :lb)
 end
 
 # ==============================================================================
 # Paul
 # 5 rounds for time: 50 double-unders, 35 knees-to-elbows, 20-yard overhead walk
 Workout.find_or_create_by(name: 'Paul') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: double_under, position: 1, reps: 50)
-  workout.exercises.build(movement: knees_to_elbows, position: 2, reps: 35)
-  workout.exercises.build(movement: overhead_walk, position: 3, reps: 1, distance: 60, distance_unit: :foot, notes: '20-yard overhead walk.', female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 1, reps: 50)
+  segment.exercises.build(movement: knees_to_elbows, position: 2, reps: 35)
+  segment.exercises.build(movement: overhead_walk, position: 3, reps: 1, distance: 60, distance_unit: :foot, notes: '20-yard overhead walk.', female_load: 125,
+                          male_load: 185, load_unit: :lb)
 end
 
 # ==============================================================================
 # Paul Pena
 # 7 rounds, each for time: 100m sprint, 19 kettlebell swings, 10 burpee box jumps. Rest 3 minutes between rounds.
 Workout.find_or_create_by(name: 'Paul Pena') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
   workout.notes = 'Each round is for time. Rest 3 minutes between rounds.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: kettlebell_swing, position: 2, reps: 19, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump, position: 3, reps: 10, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: kettlebell_swing, position: 2, reps: 19, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump, position: 3, reps: 10, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
@@ -2292,39 +2348,39 @@ end
 # AMRAP in 20 minutes: 10 chest-to-bar pull-ups, 10 dumbbell thrusters (40 double-unders every 2 min,
 # including 0:00). At the 20:00 mark, run 2 miles.
 Workout.find_or_create_by(name: 'Peyton') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :round
   workout.notes = 'Stop and perform 40 double-unders every 2 minutes, including at 0:00. ' \
                   'At the 20:00 mark, complete a 2-mile run.'
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 10)
-  workout.exercises.build(movement: dumbbell_thruster, position: 2, reps: 10)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 10)
+  segment.exercises.build(movement: dumbbell_thruster, position: 2, reps: 10)
 end
 
 # ==============================================================================
 # Pheezy
 # 3 rounds for time: 5 front squats, 18 pull-ups, 5 deadlifts, 18 toes-to-bars, 5 push jerks, 18 hand-release push-ups
 Workout.find_or_create_by(name: 'Pheezy') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: front_squat, position: 1, reps: 5, female_load: 115, male_load: 165, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 18)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 4, reps: 18)
-  workout.exercises.build(movement: push_jerk, position: 5, reps: 5, female_load: 115, male_load: 165, load_unit: :lb)
-  workout.exercises.build(movement: hand_release_push_up, position: 6, reps: 18)
+  segment.exercises.build(movement: front_squat, position: 1, reps: 5, female_load: 115, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 18)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 4, reps: 18)
+  segment.exercises.build(movement: push_jerk, position: 5, reps: 5, female_load: 115, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: hand_release_push_up, position: 6, reps: 18)
 end
 
 # ==============================================================================
 # Pike
 # 5 rounds for time: 20 thrusters, 10 strict ring dips, 20 push-ups, 10 strict handstand push-ups, 50m bear crawl
 Workout.find_or_create_by(name: 'Pike') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: thruster, position: 1, reps: 20, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: ring_dip, position: 2, reps: 10, notes: 'Strict.')
-  workout.exercises.build(movement: push_up, position: 3, reps: 20)
-  workout.exercises.build(movement: strict_handstand_push_up, position: 4, reps: 10)
-  workout.exercises.build(movement: bear_crawl, position: 5, reps: 1, distance: 50, distance_unit: :meter)
+  segment.exercises.build(movement: thruster, position: 1, reps: 20, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: ring_dip, position: 2, reps: 10, notes: 'Strict.')
+  segment.exercises.build(movement: push_up, position: 3, reps: 20)
+  segment.exercises.build(movement: strict_handstand_push_up, position: 4, reps: 10)
+  segment.exercises.build(movement: bear_crawl, position: 5, reps: 1, distance: 50, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -2332,86 +2388,86 @@ end
 # For time: run 400m, 12 burpee bar muscle-ups, 15 squat snatches, run 800m, 12 burpee bar muscle-ups,
 # 20 clean and jerks, run 800m, 12 burpee bar muscle-ups, 18 thrusters, run 400m
 Workout.find_or_create_by(name: 'Pikey') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_bar_muscle_up, position: 2, reps: 12)
-  workout.exercises.build(movement: squat_snatch, position: 3, reps: 15, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_bar_muscle_up, position: 5, reps: 12)
-  workout.exercises.build(movement: clean_and_jerk, position: 6, reps: 20, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_bar_muscle_up, position: 8, reps: 12)
-  workout.exercises.build(movement: thruster, position: 9, reps: 18, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_bar_muscle_up, position: 2, reps: 12)
+  segment.exercises.build(movement: squat_snatch, position: 3, reps: 15, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_bar_muscle_up, position: 5, reps: 12)
+  segment.exercises.build(movement: clean_and_jerk, position: 6, reps: 20, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_bar_muscle_up, position: 8, reps: 12)
+  segment.exercises.build(movement: thruster, position: 9, reps: 18, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 10, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # PK
 # 5 rounds for time: 10 back squats, 10 deadlifts, 400m sprint. Rest 2 minutes between rounds.
 Workout.find_or_create_by(name: 'PK') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 2 minutes between rounds.'
-  workout.exercises.build(movement: back_squat, position: 1, reps: 10, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: back_squat, position: 1, reps: 10, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
 # Rahoi
 # AMRAP in 12 minutes: 12 box jumps, 6 thrusters, 6 bar-facing burpees
 Workout.find_or_create_by(name: 'Rahoi') do |workout|
-  workout.time = 12
+  segment = workout.segments.build(time_seconds: 720, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: box_jump, position: 1, reps: 12, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: thruster, position: 2, reps: 6, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 3, reps: 6)
+  segment.exercises.build(movement: box_jump, position: 1, reps: 12, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: thruster, position: 2, reps: 6, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 3, reps: 6)
 end
 
 # ==============================================================================
 # Ralph
 # 4 rounds for time: 8 deadlifts, 16 burpees, 3 rope climbs to 15 feet, run 600m
 Workout.find_or_create_by(name: 'Ralph') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 8, female_load: 175, male_load: 250, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 2, reps: 16)
-  workout.exercises.build(movement: rope_climb, position: 3, reps: 3, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 600, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 8, female_load: 175, male_load: 250, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 2, reps: 16)
+  segment.exercises.build(movement: rope_climb, position: 3, reps: 3, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Randy
 # For time: 75 power snatches
 Workout.find_or_create_by(name: 'Randy') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: power_snatch, position: 1, reps: 75, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: power_snatch, position: 1, reps: 75, female_load: 55, male_load: 75, load_unit: :lb)
 end
 
 # ==============================================================================
 # Rankel
 # AMRAP in 20 minutes: 6 deadlifts, 7 burpee pull-ups, 10 kettlebell swings, 200m run
 Workout.find_or_create_by(name: 'Rankel') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: burpee_pull_up, position: 2, reps: 7)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 10, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 6, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: burpee_pull_up, position: 2, reps: 7)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 10, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 200, distance_unit: :meter)
 end
 
 # ==============================================================================
 # René
 # 7 rounds for time: 400m run, 21 walking lunges, 15 pull-ups, 9 burpees
 Workout.find_or_create_by(name: 'René') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: walking_lunge, position: 2, reps: 21)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 15)
-  workout.exercises.build(movement: burpee, position: 4, reps: 9)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: walking_lunge, position: 2, reps: 21)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 15)
+  segment.exercises.build(movement: burpee, position: 4, reps: 9)
 end
 
 # ==============================================================================
@@ -2419,116 +2475,118 @@ end
 # 5 rounds for time: 400m run, 7 strict pull-ups, 7 strict handstand push-ups, 20 toes-to-bars,
 # 22 alternating dumbbell snatches (35/50 lb), 200m dumbbell carry
 Workout.find_or_create_by(name: 'Restrepo') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: strict_pull_up, position: 2, reps: 7)
-  workout.exercises.build(movement: strict_handstand_push_up, position: 3, reps: 7)
-  workout.exercises.build(movement: toes_to_bar, position: 4, reps: 20)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 22, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Alternating arms.')
-  workout.exercises.build(movement: dumbbell_farmers_carry, position: 6, reps: 1, distance: 200, distance_unit: :meter, female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: strict_pull_up, position: 2, reps: 7)
+  segment.exercises.build(movement: strict_handstand_push_up, position: 3, reps: 7)
+  segment.exercises.build(movement: toes_to_bar, position: 4, reps: 20)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 22, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Alternating arms.')
+  segment.exercises.build(movement: dumbbell_farmers_carry, position: 6, reps: 1, distance: 200, distance_unit: :meter, female_load: 35, male_load: 50,
+                          load_unit: :lb, implement_count: 2)
 end
 
 # ==============================================================================
 # Rich
 # For time: 13 squat snatches; 10 rounds (10 pull-ups, 100m sprint); 13 squat cleans
 Workout.find_or_create_by(name: 'Rich') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: squat_snatch, position: 1, reps: 13, female_load: 105, male_load: 155, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: squat_snatch, position: 1, reps: 13, female_load: 105, male_load: 155, load_unit: :lb)
   rounds = workout.segments.build(rounds: 10, position: 2)
-  workout.exercises.build(movement: pull_up, segment: rounds, position: 1, reps: 10)
-  workout.exercises.build(movement: run, segment: rounds, position: 2, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: clean_squat, position: 3, reps: 13, female_load: 105, male_load: 155, load_unit: :lb)
+  rounds.exercises.build(movement: pull_up, position: 1, reps: 10)
+  rounds.exercises.build(movement: run, position: 2, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 13, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
 # Ricky
 # AMRAP in 20 minutes: 10 pull-ups, 5 dumbbell deadlifts, 8 push presses
 Workout.find_or_create_by(name: 'Ricky') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: pull_up, position: 1, reps: 10)
-  workout.exercises.build(movement: dumbbell_deadlift, position: 2, reps: 5, female_load: 50, male_load: 75, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: push_press, position: 3, reps: 8, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 10)
+  segment.exercises.build(movement: dumbbell_deadlift, position: 2, reps: 5, female_load: 50, male_load: 75, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: push_press, position: 3, reps: 8, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Riley
 # For time: run 1.5 miles, 150 burpees, run 1.5 miles
 Workout.find_or_create_by(name: 'Riley') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 2400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee, position: 2, reps: 150)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 2400, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 2400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee, position: 2, reps: 150)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 2400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # RJ
 # 5 rounds for time: 800m run, 5 rope climbs to 15 feet, 50 push-ups
 Workout.find_or_create_by(name: 'RJ') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: rope_climb, position: 2, reps: 5, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: push_up, position: 3, reps: 50)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: rope_climb, position: 2, reps: 5, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: push_up, position: 3, reps: 50)
 end
 
 # ==============================================================================
 # Robbie
 # AMRAP in 25 minutes: 8 freestanding handstand push-ups, 1 L-sit rope climb to 15 feet
 Workout.find_or_create_by(name: 'Robbie') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :round
-  workout.exercises.build(movement: freestanding_handstand_push_up, position: 1, reps: 8)
-  workout.exercises.build(movement: l_sit_rope_climb, position: 2, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: freestanding_handstand_push_up, position: 1, reps: 8)
+  segment.exercises.build(movement: l_sit_rope_climb, position: 2, reps: 1, distance: 15, distance_unit: :foot)
 end
 
 # ==============================================================================
 # Rocket
 # AMRAP in 30 minutes: 50-yard swim, 10 push-ups, 15 squats
 Workout.find_or_create_by(name: 'Rocket') do |workout|
-  workout.time = 30
+  segment = workout.segments.build(time_seconds: 1800, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: swim, position: 1, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard swim.')
-  workout.exercises.build(movement: push_up, position: 2, reps: 10)
-  workout.exercises.build(movement: air_squat, position: 3, reps: 15)
+  segment.exercises.build(movement: swim, position: 1, reps: 1, distance: 150, distance_unit: :foot, notes: '50-yard swim.')
+  segment.exercises.build(movement: push_up, position: 2, reps: 10)
+  segment.exercises.build(movement: air_squat, position: 3, reps: 15)
 end
 
 # ==============================================================================
 # Roney
 # 4 rounds for time: 200m run, 11 thrusters, 200m run, 11 push presses, 200m run, 11 bench presses
 Workout.find_or_create_by(name: 'Roney') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: thruster, position: 2, reps: 11, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: push_press, position: 4, reps: 11, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: bench_press, position: 6, reps: 11, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: thruster, position: 2, reps: 11, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: push_press, position: 4, reps: 11, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: bench_press, position: 6, reps: 11, female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Roy
 # 5 rounds for time: 15 deadlifts, 20 box jumps, 25 pull-ups
 Workout.find_or_create_by(name: 'Roy') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 15, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 25)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 15, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 20, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 25)
 end
 
 # ==============================================================================
 # Ryan
 # 5 rounds for time: 7 muscle-ups, 21 burpees
 Workout.find_or_create_by(name: 'Ryan') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 7)
-  workout.exercises.build(movement: burpee, position: 2, reps: 21)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 7)
+  segment.exercises.build(movement: burpee, position: 2, reps: 21)
 end
 
 # ==============================================================================
@@ -2537,18 +2595,19 @@ end
 # then 10 rounds of 13 deadlifts, 13 pull-ups, 13-calorie row, 13 back squats,
 # 13 burpees; then 1,065-foot versa climb (or 1,065-meter row or ski). (165/225 lb)
 Workout.find_or_create_by(name: 'Ryan Comas') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.team_size = 3
   workout.notes = 'As a 3-person team.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1065, distance_unit: :meter, notes: '1,065-foot versa climb, 1,065-meter row, or ski.')
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1065, distance_unit: :meter, notes: '1,065-foot versa climb, 1,065-meter row, or ski.')
   rounds = workout.segments.build(rounds: 10, position: 2)
-  workout.exercises.build(movement: deadlift, segment: rounds, position: 1, reps: 13, female_load: 165, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, segment: rounds, position: 2, reps: 13)
-  workout.exercises.build(movement: row, segment: rounds, position: 3, reps: 1, calories: 13)
-  workout.exercises.build(movement: back_squat, segment: rounds, position: 4, reps: 13, female_load: 165, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: burpee, segment: rounds, position: 5, reps: 13)
-  workout.exercises.build(movement: row, position: 3, reps: 1, distance: 1065, distance_unit: :meter, notes: '1,065-foot versa climb, 1,065-meter row, or ski.')
+  rounds.exercises.build(movement: deadlift, position: 1, reps: 13, female_load: 165, male_load: 225, load_unit: :lb)
+  rounds.exercises.build(movement: pull_up, position: 2, reps: 13)
+  rounds.exercises.build(movement: row, position: 3, reps: 1, calories: 13)
+  rounds.exercises.build(movement: back_squat, position: 4, reps: 13, female_load: 165, male_load: 225, load_unit: :lb)
+  rounds.exercises.build(movement: burpee, position: 5, reps: 13)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1065, distance_unit: :meter, notes: '1,065-foot versa climb, 1,065-meter row, or ski.')
 end
 
 # ==============================================================================
@@ -2556,60 +2615,62 @@ end
 # For time: 1,600m run; 4 rounds (9 power cleans, 2 strict pull-ups, 14 burpees);
 # 3 rounds (13 box jumps, 13 push-ups, 50 double-unders); 1,600m run
 Workout.find_or_create_by(name: 'Ryan SO') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest for the run.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
   rounds_four = workout.segments.build(rounds: 4, position: 2)
-  workout.exercises.build(movement: power_clean, segment: rounds_four, position: 1, reps: 9, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: strict_pull_up, segment: rounds_four, position: 2, reps: 2)
-  workout.exercises.build(movement: burpee, segment: rounds_four, position: 3, reps: 14)
+  rounds_four.exercises.build(movement: power_clean, position: 1, reps: 9, female_load: 95, male_load: 135, load_unit: :lb)
+  rounds_four.exercises.build(movement: strict_pull_up, position: 2, reps: 2)
+  rounds_four.exercises.build(movement: burpee, position: 3, reps: 14)
   rounds_three = workout.segments.build(rounds: 3, position: 3)
-  workout.exercises.build(movement: box_jump, segment: rounds_three, position: 1, reps: 13, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: push_up, segment: rounds_three, position: 2, reps: 13)
-  workout.exercises.build(movement: double_under, segment: rounds_three, position: 3, reps: 50)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
+  rounds_three.exercises.build(movement: box_jump, position: 1, reps: 13, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  rounds_three.exercises.build(movement: push_up, position: 2, reps: 13)
+  rounds_three.exercises.build(movement: double_under, position: 3, reps: 50)
+  segment = workout.segments.build(position: 4)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Santiago
 # 7 rounds for time: 18 dumbbell hang squat cleans, 18 pull-ups, 10 power cleans, 10 handstand push-ups
 Workout.find_or_create_by(name: 'Santiago') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: dumbbell_hang_squat_clean, position: 1, reps: 18, female_load: 20, male_load: 35, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 18)
-  workout.exercises.build(movement: power_clean, position: 3, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 4, reps: 10)
+  segment.exercises.build(movement: dumbbell_hang_squat_clean, position: 1, reps: 18, female_load: 20, male_load: 35, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 18)
+  segment.exercises.build(movement: power_clean, position: 3, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 4, reps: 10)
 end
 
 # ==============================================================================
 # Santora
 # 3 rounds for reps: 1 min squat cleans, 1 min deadlifts, 1 min burpees, 1 min jerks. Rest 1 minute between rounds.
 Workout.find_or_create_by(name: 'Santora') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :rep
   workout.notes = 'Rest 1 minute between rounds.'
-  workout.exercises.build(movement: clean_squat, position: 1, reps: 0, duration_seconds: 60, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 0, duration_seconds: 60, female_load: 165, male_load: 245, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 3, reps: 0, duration_seconds: 60)
-  workout.exercises.build(movement: jerk, position: 4, reps: 0, duration_seconds: 60, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 0, duration_seconds: 60, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 0, duration_seconds: 60, female_load: 165, male_load: 245, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 3, reps: 0, duration_seconds: 60)
+  segment.exercises.build(movement: jerk, position: 4, reps: 0, duration_seconds: 60, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
 # Schmalls
 # For time: run 800m; 2 rounds (50 burpees, 40 pull-ups, 30 single-leg squats, 20 KB swings, 10 HSPU); run 800m
 Workout.find_or_create_by(name: 'Schmalls') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 2, position: 2)
-  workout.exercises.build(movement: burpee, segment: rounds, position: 1, reps: 50)
-  workout.exercises.build(movement: pull_up, segment: rounds, position: 2, reps: 40)
-  workout.exercises.build(movement: single_leg_squat_pistol, segment: rounds, position: 3, reps: 30)
-  workout.exercises.build(movement: kettlebell_swing, segment: rounds, position: 4, reps: 20, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, segment: rounds, position: 5, reps: 10)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter)
+  rounds.exercises.build(movement: burpee, position: 1, reps: 50)
+  rounds.exercises.build(movement: pull_up, position: 2, reps: 40)
+  rounds.exercises.build(movement: single_leg_squat_pistol, position: 3, reps: 30)
+  rounds.exercises.build(movement: kettlebell_swing, position: 4, reps: 20, female_load: 35, male_load: 53, load_unit: :lb)
+  rounds.exercises.build(movement: handstand_push_up, position: 5, reps: 10)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -2623,201 +2684,202 @@ Workout.find_or_create_by(name: 'Scooter') do |workout|
   workout.notes = 'With a partner; one works while the other rests, switching after each full round. ' \
                   'Score the 1-rep-max partner deadlift.'
   amrap = workout.segments.build(position: 1, name: '0:00-30:00 AMRAP', time_seconds: 1800)
-  workout.exercises.build(movement: double_under, segment: amrap, position: 1, reps: 30)
-  workout.exercises.build(movement: pull_up, segment: amrap, position: 2, reps: 15)
-  workout.exercises.build(movement: push_up, segment: amrap, position: 3, reps: 15)
-  workout.exercises.build(movement: run, segment: amrap, position: 4, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  amrap.exercises.build(movement: double_under, position: 1, reps: 30)
+  amrap.exercises.build(movement: pull_up, position: 2, reps: 15)
+  amrap.exercises.build(movement: push_up, position: 3, reps: 15)
+  amrap.exercises.build(movement: run, position: 4, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
   max = workout.segments.build(position: 2, name: '30:00-35:00 find a 1-rep-max partner deadlift', time_seconds: 300)
-  workout.exercises.build(movement: deadlift, segment: max, position: 1, reps: 1, duration_seconds: 300, load_unit: :lb, notes: 'Partner deadlift; record the max load found.')
+  max.exercises.build(movement: deadlift, position: 1, reps: 1, duration_seconds: 300, load_unit: :lb, notes: 'Partner deadlift; record the max load found.')
 end
 
 # ==============================================================================
 # Scotty
 # AMRAP in 11 minutes: 5 deadlifts, 18 wall-ball shots, 17 burpees over the bar
 Workout.find_or_create_by(name: 'Scotty') do |workout|
-  workout.time = 11
+  segment = workout.segments.build(time_seconds: 660, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 5, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, position: 2, reps: 18, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: over_the_bar_burpee, position: 3, reps: 17)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 5, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 2, reps: 18, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: over_the_bar_burpee, position: 3, reps: 17)
 end
 
 # ==============================================================================
 # Sean
 # 10 rounds for time: 11 chest-to-bar pull-ups, 22 front squats
 Workout.find_or_create_by(name: 'Sean') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 11)
-  workout.exercises.build(movement: front_squat, position: 2, reps: 22, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 11)
+  segment.exercises.build(movement: front_squat, position: 2, reps: 22, female_load: 55, male_load: 75, load_unit: :lb)
 end
 
 # ==============================================================================
 # Servais
 # For time: run 1.5 miles; 8 rounds (19 pull-ups, 19 push-ups, 19 burpees); 400m sandbag carry, 1-mile farmers carry
 Workout.find_or_create_by(name: 'Servais') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.notes = 'Use a heavy sandbag.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 2400, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 2400, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 8, position: 2)
-  workout.exercises.build(movement: pull_up, segment: rounds, position: 1, reps: 19)
-  workout.exercises.build(movement: push_up, segment: rounds, position: 2, reps: 19)
-  workout.exercises.build(movement: burpee, segment: rounds, position: 3, reps: 19)
-  workout.exercises.build(movement: sandbag_carry, position: 3, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: farmers_carry, position: 4, reps: 1, distance: 1600, distance_unit: :meter, female_load: 30, male_load: 45, load_unit: :lb)
+  rounds.exercises.build(movement: pull_up, position: 1, reps: 19)
+  rounds.exercises.build(movement: push_up, position: 2, reps: 19)
+  rounds.exercises.build(movement: burpee, position: 3, reps: 19)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: sandbag_carry, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: farmers_carry, position: 2, reps: 1, distance: 1600, distance_unit: :meter, female_load: 30, male_load: 45, load_unit: :lb)
 end
 
 # ==============================================================================
 # Severin
 # For time: 50 strict pull-ups, 100 hand-release push-ups, run 5K
 Workout.find_or_create_by(name: 'Severin') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: strict_pull_up, position: 1, reps: 50)
-  workout.exercises.build(movement: hand_release_push_up, position: 2, reps: 100)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 5000, distance_unit: :meter)
+  segment.exercises.build(movement: strict_pull_up, position: 1, reps: 50)
+  segment.exercises.build(movement: hand_release_push_up, position: 2, reps: 100)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 5000, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Sham
 # 7 rounds for time: 11 deadlifts, 100m sprint
 Workout.find_or_create_by(name: 'Sham') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 11)
-  workout.exercises.build(movement: run, position: 2, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: deadlift, position: 1, reps: 11)
+  segment.exercises.build(movement: run, position: 2, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
 # Shawn
 # For time: run 5 miles in 5-minute intervals; after each interval, 50 squats and 50 push-ups
 Workout.find_or_create_by(name: 'Shawn') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Run in 5-minute intervals; after each 5-minute run interval perform 50 squats and 50 push-ups.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 8000, distance_unit: :meter)
-  workout.exercises.build(movement: air_squat, position: 2, reps: 50)
-  workout.exercises.build(movement: push_up, position: 3, reps: 50)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 8000, distance_unit: :meter)
+  segment.exercises.build(movement: air_squat, position: 2, reps: 50)
+  segment.exercises.build(movement: push_up, position: 3, reps: 50)
 end
 
 # ==============================================================================
 # Ship
 # 9 rounds for time: 7 squat cleans, 8 burpee box jumps
 Workout.find_or_create_by(name: 'Ship') do |workout|
-  workout.rounds = 9
+  segment = workout.segments.build(rounds: 9, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: clean_squat, position: 1, reps: 7, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump, position: 2, reps: 8, female_distance: 30, male_distance: 36, distance_unit: :inch)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 7, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump, position: 2, reps: 8, female_distance: 30, male_distance: 36, distance_unit: :inch)
 end
 
 # ==============================================================================
 # Sisson
 # AMRAP in 20 minutes: 1 rope climb to 15 feet, 5 burpees, 200m run
 Workout.find_or_create_by(name: 'Sisson') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 1, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: burpee, position: 2, reps: 5)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: burpee, position: 2, reps: 5)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Small
 # 3 rounds for time: row 1,000m, 50 burpees, 50 box jumps, run 800m
 Workout.find_or_create_by(name: 'Small') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: burpee, position: 2, reps: 50)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: burpee, position: 2, reps: 50)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 50, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 800, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Smykowski
 # For time: run 6K, 60 burpee pull-ups
 Workout.find_or_create_by(name: 'Smykowski') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 6000, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_pull_up, position: 2, reps: 60)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 6000, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_pull_up, position: 2, reps: 60)
 end
 
 # ==============================================================================
 # Spehar
 # For time: 100 thrusters, 100 chest-to-bar pull-ups, run 6 miles. Partition as needed.
 Workout.find_or_create_by(name: 'Spehar') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Partition the thrusters, pull-ups, and run as needed.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 100, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 100)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 9600, distance_unit: :meter)
+  segment.exercises.build(movement: thruster, position: 1, reps: 100, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 100)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 9600, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Stephen
 # 30-25-20-15-10-5 reps for time: GHD sit-ups, back extensions, knees-to-elbows, stiff-legged deadlifts
 Workout.find_or_create_by(name: 'Stephen') do |workout|
-  workout.interval = '30-25-20-15-10-5'
+  segment = workout.segments.build(interval_scheme: '30-25-20-15-10-5', position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: ghd_sit_up, position: 1, reps: 1)
-  workout.exercises.build(movement: back_extensions, position: 2, reps: 1)
-  workout.exercises.build(movement: knees_to_elbows, position: 3, reps: 1)
-  workout.exercises.build(movement: stiff_legged_deadlift, position: 4, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: ghd_sit_up, position: 1, reps: 1)
+  segment.exercises.build(movement: back_extensions, position: 2, reps: 1)
+  segment.exercises.build(movement: knees_to_elbows, position: 3, reps: 1)
+  segment.exercises.build(movement: stiff_legged_deadlift, position: 4, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
 # Strange
 # 8 rounds for time: 600m run, 11 weighted pull-ups, 11 walking lunges with two kettlebells, 11 kettlebell thrusters
 Workout.find_or_create_by(name: 'Strange') do |workout|
-  workout.rounds = 8
+  segment = workout.segments.build(rounds: 8, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 600, distance_unit: :meter)
-  workout.exercises.build(movement: weighted_pull_up, position: 2, reps: 11, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: walking_lunge, position: 3, reps: 11, notes: 'With two kettlebells.', female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: kettlebell_thruster, position: 4, reps: 11, female_load: 35, male_load: 53, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 600, distance_unit: :meter)
+  segment.exercises.build(movement: weighted_pull_up, position: 2, reps: 11, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: walking_lunge, position: 3, reps: 11, notes: 'With two kettlebells.', female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_thruster, position: 4, reps: 11, female_load: 35, male_load: 53, load_unit: :lb, implement_count: 2)
 end
 
 # ==============================================================================
 # T
 # 5 rounds for time: 100m sprint, 10 squat clean thrusters, 15 kettlebell swings, 100m sprint. Rest 2 minutes.
 Workout.find_or_create_by(name: 'T') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 2 minutes between rounds.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
-  workout.exercises.build(movement: squat_clean_thruster, position: 2, reps: 10)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 15, female_load: 75, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: squat_clean_thruster, position: 2, reps: 10)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 15, female_load: 75, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 100, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
 # T.J.
 # For time: 10 bench presses, 10 strict pull-ups, max-set thrusters. Repeat the triplet until 100 thrusters.
 Workout.find_or_create_by(name: 'T.J.') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Repeat the triplet (10 bench presses, 10 strict pull-ups, a max set of thrusters) ' \
                   'until you have completed 100 thrusters total.'
-  workout.exercises.build(movement: bench_press, position: 1, reps: 10, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: strict_pull_up, position: 2, reps: 10)
-  workout.exercises.build(movement: thruster, position: 3, reps: 100, notes: 'Max-set each round; 100 total.', female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: bench_press, position: 1, reps: 10, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: strict_pull_up, position: 2, reps: 10)
+  segment.exercises.build(movement: thruster, position: 3, reps: 100, notes: 'Max-set each round; 100 total.', female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # T.U.P.
 # 15-12-9-6-3 reps for time: power cleans, pull-ups, front squats, pull-ups
 Workout.find_or_create_by(name: 'T.U.P.') do |workout|
-  workout.interval = '15-12-9-6-3'
+  segment = workout.segments.build(interval_scheme: '15-12-9-6-3', position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: power_clean, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 2, reps: 1)
-  workout.exercises.build(movement: front_squat, position: 3, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 1)
+  segment.exercises.build(movement: power_clean, position: 1, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 2, reps: 1)
+  segment.exercises.build(movement: front_squat, position: 3, reps: 1, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 1)
 end
 
 # ==============================================================================
@@ -2825,43 +2887,46 @@ end
 # For time: 800m single-arm barbell farmers carry (w1), 31 toes-to-bars, 31 push-ups, 31 front squats,
 # 400m single-arm carry (w2), 31 toes-to-bars, 31 push-ups, 31 hang power cleans, 200m single-arm carry (w3)
 Workout.find_or_create_by(name: 'Tama') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: farmers_carry, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Single-arm barbell, weight 1.', female_load: 35, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 31)
-  workout.exercises.build(movement: push_up, position: 3, reps: 31)
-  workout.exercises.build(movement: front_squat, position: 4, reps: 31, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: farmers_carry, position: 5, reps: 1, distance: 400, distance_unit: :meter, notes: 'Single-arm barbell, weight 2.', female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 6, reps: 31)
-  workout.exercises.build(movement: push_up, position: 7, reps: 31)
-  workout.exercises.build(movement: hang_power_clean, position: 8, reps: 31, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: farmers_carry, position: 9, reps: 1, distance: 200, distance_unit: :meter, notes: 'Single-arm barbell, weight 3.', female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: farmers_carry, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Single-arm barbell, weight 1.',
+                          female_load: 35, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 31)
+  segment.exercises.build(movement: push_up, position: 3, reps: 31)
+  segment.exercises.build(movement: front_squat, position: 4, reps: 31, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: farmers_carry, position: 5, reps: 1, distance: 400, distance_unit: :meter, notes: 'Single-arm barbell, weight 2.',
+                          female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 6, reps: 31)
+  segment.exercises.build(movement: push_up, position: 7, reps: 31)
+  segment.exercises.build(movement: hang_power_clean, position: 8, reps: 31, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: farmers_carry, position: 9, reps: 1, distance: 200, distance_unit: :meter, notes: 'Single-arm barbell, weight 3.',
+                          female_load: 95, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Taylor
 # 4 rounds for time: 400m run, 5 burpee muscle-ups
 Workout.find_or_create_by(name: 'Taylor') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
   workout.notes = 'Wear a 14-lb (♀) / 20-lb (♂) weight vest.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_muscle_up, position: 2, reps: 5)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_muscle_up, position: 2, reps: 5)
 end
 
 # ==============================================================================
 # Terry
 # For time: run 1 mile, 100 push-ups, 100m bear crawl, run 1 mile, 100m bear crawl, 100 push-ups, run 1 mile
 Workout.find_or_create_by(name: 'Terry') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 2, reps: 100)
-  workout.exercises.build(movement: bear_crawl, position: 3, reps: 1, distance: 100, distance_unit: :meter)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
-  workout.exercises.build(movement: bear_crawl, position: 5, reps: 1, distance: 100, distance_unit: :meter)
-  workout.exercises.build(movement: push_up, position: 6, reps: 100)
-  workout.exercises.build(movement: run, position: 7, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 2, reps: 100)
+  segment.exercises.build(movement: bear_crawl, position: 3, reps: 1, distance: 100, distance_unit: :meter)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 1600, distance_unit: :meter)
+  segment.exercises.build(movement: bear_crawl, position: 5, reps: 1, distance: 100, distance_unit: :meter)
+  segment.exercises.build(movement: push_up, position: 6, reps: 100)
+  segment.exercises.build(movement: run, position: 7, reps: 1, distance: 1600, distance_unit: :meter)
 end
 
 # ==============================================================================
@@ -2869,71 +2934,72 @@ end
 # For time: 66 deadlifts, 66 box jumps, 66 kettlebell swings, 66 knees-to-elbows, 66 sit-ups, 66 pull-ups,
 # 66 thrusters, 66 wall-ball shots, 66 burpees, 66 double-unders
 Workout.find_or_create_by(name: 'The Don') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: deadlift, position: 1, reps: 66, female_load: 70, male_load: 110, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 66, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 66, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: knees_to_elbows, position: 4, reps: 66)
-  workout.exercises.build(movement: sit_up, position: 5, reps: 66)
-  workout.exercises.build(movement: pull_up, position: 6, reps: 66)
-  workout.exercises.build(movement: thruster, position: 7, reps: 66, female_load: 35, male_load: 55, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, position: 8, reps: 66, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 9, reps: 66)
-  workout.exercises.build(movement: double_under, position: 10, reps: 66)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 66, female_load: 70, male_load: 110, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 66, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 66, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: knees_to_elbows, position: 4, reps: 66)
+  segment.exercises.build(movement: sit_up, position: 5, reps: 66)
+  segment.exercises.build(movement: pull_up, position: 6, reps: 66)
+  segment.exercises.build(movement: thruster, position: 7, reps: 66, female_load: 35, male_load: 55, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 8, reps: 66, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 9, reps: 66)
+  segment.exercises.build(movement: double_under, position: 10, reps: 66)
 end
 
 # ==============================================================================
 # The Lyon
 # 5 rounds, each for time: 7 squat cleans, 7 shoulder-to-overheads, 7 burpee chest-to-bar pull-ups. Rest 2 minutes.
 Workout.find_or_create_by(name: 'The Lyon') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'Each round is for time. Rest 2 minutes between rounds. ' \
                   'Ideally use a pull-up bar 6 inches above your max reach.'
-  workout.exercises.build(movement: clean_squat, position: 1, reps: 7, female_load: 115, male_load: 165, load_unit: :lb)
-  workout.exercises.build(movement: shoulder_to_overhead, position: 2, reps: 7, female_load: 115, male_load: 165, load_unit: :lb)
-  workout.exercises.build(movement: burpee_chest_to_bar_pull_up, position: 3, reps: 7)
+  segment.exercises.build(movement: clean_squat, position: 1, reps: 7, female_load: 115, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: shoulder_to_overhead, position: 2, reps: 7, female_load: 115, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: burpee_chest_to_bar_pull_up, position: 3, reps: 7)
 end
 
 # ==============================================================================
 # The Seven
 # 7 rounds for time: 7 HSPU, 7 thrusters, 7 knees-to-elbows, 7 deadlifts, 7 burpees, 7 KB swings, 7 pull-ups
 Workout.find_or_create_by(name: 'The Seven') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 7)
-  workout.exercises.build(movement: thruster, position: 2, reps: 7, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: knees_to_elbows, position: 3, reps: 7)
-  workout.exercises.build(movement: deadlift, position: 4, reps: 7, female_load: 165, male_load: 245, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 5, reps: 7)
-  workout.exercises.build(movement: kettlebell_swing, position: 6, reps: 7, female_load: 53, male_load: 70, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 7, reps: 7)
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 7)
+  segment.exercises.build(movement: thruster, position: 2, reps: 7, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: knees_to_elbows, position: 3, reps: 7)
+  segment.exercises.build(movement: deadlift, position: 4, reps: 7, female_load: 165, male_load: 245, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 5, reps: 7)
+  segment.exercises.build(movement: kettlebell_swing, position: 6, reps: 7, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 7, reps: 7)
 end
 
 # ==============================================================================
 # Thompson
 # 10 rounds for time: 1 rope climb to 15 feet, 29 back squats, 10m barbell farmers carry. Begin rope climbs seated.
 Workout.find_or_create_by(name: 'Thompson') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
   workout.notes = 'Begin the rope climbs seated on the floor.'
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 1, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 29, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: farmers_carry, position: 3, reps: 1, distance: 10, distance_unit: :meter, notes: 'Barbell farmers carry.', female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 1, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 29, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: farmers_carry, position: 3, reps: 1, distance: 10, distance_unit: :meter, notes: 'Barbell farmers carry.', female_load: 95,
+                          male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
 # Tiff
 # On a 25-minute clock: 1.5-mile run, then AMRAP: 11 chest-to-bar pull-ups, 7 hang squat cleans, 7 push presses
 Workout.find_or_create_by(name: 'Tiff') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :rep
   workout.notes = 'Run 1.5 miles, then AMRAP the triplet in the remaining time.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 2400, distance_unit: :meter)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 11)
-  workout.exercises.build(movement: hang_squat_clean, position: 3, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: push_press, position: 4, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 2400, distance_unit: :meter)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 11)
+  segment.exercises.build(movement: hang_squat_clean, position: 3, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: push_press, position: 4, reps: 7, female_load: 105, male_load: 155, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -2943,384 +3009,393 @@ end
 # single back squat for each team member.
 # (♀ 14-lb ball to 9 ft, 105-lb deadlift; ♂ 20-lb ball to 10 ft, 155-lb deadlift)
 Workout.find_or_create_by(name: 'Timothy Helton') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
   workout.team_size = 3
   workout.notes = 'As a 3-person team. Finish by building to a heavy single back squat for each team member.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 2364, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 2364, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 10, position: 2)
-  workout.exercises.build(movement: wall_ball_shot, segment: rounds, position: 1, reps: 49, female_load: 14, male_load: 20, load_unit: :lb, female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: pull_up, segment: rounds, position: 2, reps: 26)
-  workout.exercises.build(movement: run, segment: rounds, position: 3, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: ring_muscle_up, segment: rounds, position: 4, reps: 8)
-  workout.exercises.build(movement: deadlift, segment: rounds, position: 5, reps: 40, female_load: 105, male_load: 155, load_unit: :lb)
+  rounds.exercises.build(movement: wall_ball_shot, position: 1, reps: 49, female_load: 14, male_load: 20, load_unit: :lb, female_distance: 9,
+                         male_distance: 10, distance_unit: :foot)
+  rounds.exercises.build(movement: pull_up, position: 2, reps: 26)
+  rounds.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
+  rounds.exercises.build(movement: ring_muscle_up, position: 4, reps: 8)
+  rounds.exercises.build(movement: deadlift, position: 5, reps: 40, female_load: 105, male_load: 155, load_unit: :lb)
   finisher = workout.segments.build(position: 3, name: 'Build to a heavy single back squat (each team member)')
-  workout.exercises.build(movement: back_squat, segment: finisher, position: 1, reps: 1, load_unit: :lb, notes: 'Each team member builds to a heavy single; record the load.')
+  finisher.exercises.build(movement: back_squat, position: 1, reps: 1, load_unit: :lb, notes: 'Each team member builds to a heavy single; record the load.')
 end
 
 # ==============================================================================
 # TK
 # AMRAP in 20 minutes: 8 strict pull-ups, 8 box jumps, 12 kettlebell swings
 Workout.find_or_create_by(name: 'TK') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: strict_pull_up, position: 1, reps: 8)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 8, female_distance: 30, male_distance: 36, distance_unit: :inch)
-  workout.exercises.build(movement: kettlebell_swing, position: 3, reps: 12, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: strict_pull_up, position: 1, reps: 8)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 8, female_distance: 30, male_distance: 36, distance_unit: :inch)
+  segment.exercises.build(movement: kettlebell_swing, position: 3, reps: 12, female_load: 53, male_load: 70, load_unit: :lb)
 end
 
 # ==============================================================================
 # Tom
 # AMRAP in 25 minutes: 7 muscle-ups, 11 thrusters, 14 toes-to-bars
 Workout.find_or_create_by(name: 'Tom') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 7)
-  workout.exercises.build(movement: thruster, position: 2, reps: 11, female_load: 105, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 3, reps: 14)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 7)
+  segment.exercises.build(movement: thruster, position: 2, reps: 11, female_load: 105, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 3, reps: 14)
 end
 
 # ==============================================================================
 # Tommy V
 # For time: 21 thrusters, 12 rope climbs, 15 thrusters, 9 rope climbs, 9 thrusters, 6 rope climbs
 Workout.find_or_create_by(name: 'Tommy V') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: thruster, position: 1, reps: 21, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 2, reps: 12, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: thruster, position: 3, reps: 15, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 4, reps: 9, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: thruster, position: 5, reps: 9, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 6, reps: 6, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: thruster, position: 1, reps: 21, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 2, reps: 12, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: thruster, position: 3, reps: 15, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 4, reps: 9, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: thruster, position: 5, reps: 9, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 6, reps: 6, distance: 15, distance_unit: :foot)
 end
 
 # ==============================================================================
 # Topsy
 # AMRAP in 25 minutes: 3 ring muscle-ups, 8 thrusters, 17-calorie row
 Workout.find_or_create_by(name: 'Topsy') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: ring_muscle_up, position: 1, reps: 3)
-  workout.exercises.build(movement: thruster, position: 2, reps: 8, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: row, position: 3, reps: 1, calories: 17)
+  segment.exercises.build(movement: ring_muscle_up, position: 1, reps: 3)
+  segment.exercises.build(movement: thruster, position: 2, reps: 8, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 3, reps: 1, calories: 17)
 end
 
 # ==============================================================================
 # TPT9000
 # For time: 100m run; 9 rounds (8 burpees, 26 kettlebell swings, 21 wall-ball shots, 100m run)
 Workout.find_or_create_by(name: 'TPT9000') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 100, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 9, position: 2)
-  workout.exercises.build(movement: burpee, segment: rounds, position: 1, reps: 8)
-  workout.exercises.build(movement: kettlebell_swing, segment: rounds, position: 2, reps: 26, female_load: 35, male_load: 44, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, segment: rounds, position: 3, reps: 21, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: run, segment: rounds, position: 4, reps: 1, distance: 100, distance_unit: :meter)
+  rounds.exercises.build(movement: burpee, position: 1, reps: 8)
+  rounds.exercises.build(movement: kettlebell_swing, position: 2, reps: 26, female_load: 35, male_load: 44, load_unit: :lb)
+  rounds.exercises.build(movement: wall_ball_shot, position: 3, reps: 21, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  rounds.exercises.build(movement: run, position: 4, reps: 1, distance: 100, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Triple Deuce
 # AMRAP in 20 minutes: 22 burpees, 22 air squats, 22 pull-ups, 22 sandbag ground-to-over-the-shoulders, 722m sprint
 Workout.find_or_create_by(name: 'Triple Deuce') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: burpee, position: 1, reps: 22)
-  workout.exercises.build(movement: air_squat, position: 2, reps: 22)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 22)
-  workout.exercises.build(movement: sandbag_clean, position: 4, reps: 22, notes: 'Ground-to-over-the-shoulder.', female_load: 40, male_load: 60, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 722, distance_unit: :meter, notes: 'Sprint.')
+  segment.exercises.build(movement: burpee, position: 1, reps: 22)
+  segment.exercises.build(movement: air_squat, position: 2, reps: 22)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 22)
+  segment.exercises.build(movement: sandbag_clean, position: 4, reps: 22, notes: 'Ground-to-over-the-shoulder.', female_load: 40, male_load: 60, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 722, distance_unit: :meter, notes: 'Sprint.')
 end
 
 # ==============================================================================
 # Tully
 # 4 rounds for time: swim 200m, 23 dumbbell squat cleans
 Workout.find_or_create_by(name: 'Tully') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: swim, position: 1, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: dumbbell_squat_clean, position: 2, reps: 23, female_load: 30, male_load: 40, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: swim, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_squat_clean, position: 2, reps: 23, female_load: 30, male_load: 40, load_unit: :lb, implement_count: 2)
 end
 
 # ==============================================================================
 # Tumilson
 # 8 rounds for time: run 200m, 11 dumbbell burpee deadlifts
 Workout.find_or_create_by(name: 'Tumilson') do |workout|
-  workout.rounds = 8
+  segment = workout.segments.build(rounds: 8, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: dumbbell_burpee_deadlift, position: 2, reps: 11, female_load: 45, male_load: 60, load_unit: :lb, implement_count: 2)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: dumbbell_burpee_deadlift, position: 2, reps: 11, female_load: 45, male_load: 60, load_unit: :lb, implement_count: 2)
 end
 
 # ==============================================================================
 # Tyler
 # 5 rounds for time: 7 muscle-ups, 21 sumo deadlift high pulls
 Workout.find_or_create_by(name: 'Tyler') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 7)
-  workout.exercises.build(movement: sumo_deadlift_high_pull, position: 2, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 7)
+  segment.exercises.build(movement: sumo_deadlift_high_pull, position: 2, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
 # Viola
 # AMRAP in 20 minutes: 400m run, 11 power snatches, 17 pull-ups, 13 power cleans
 Workout.find_or_create_by(name: 'Viola') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: power_snatch, position: 2, reps: 11, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 17)
-  workout.exercises.build(movement: power_clean, position: 4, reps: 13, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: power_snatch, position: 2, reps: 11, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 17)
+  segment.exercises.build(movement: power_clean, position: 4, reps: 13, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
 # Wade
 # For time: run 1,200m; 4 rounds (12 strict pull-ups, 9 strict dips, 6 strict handstand push-ups); run 1,200m
 Workout.find_or_create_by(name: 'Wade') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 1200, distance_unit: :meter)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1200, distance_unit: :meter)
   rounds = workout.segments.build(rounds: 4, position: 2)
-  workout.exercises.build(movement: strict_pull_up, segment: rounds, position: 1, reps: 12)
-  workout.exercises.build(movement: dip, segment: rounds, position: 2, reps: 9, notes: 'Strict.')
-  workout.exercises.build(movement: strict_handstand_push_up, segment: rounds, position: 3, reps: 6)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 1200, distance_unit: :meter)
+  rounds.exercises.build(movement: strict_pull_up, position: 1, reps: 12)
+  rounds.exercises.build(movement: dip, position: 2, reps: 9, notes: 'Strict.')
+  rounds.exercises.build(movement: strict_handstand_push_up, position: 3, reps: 6)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 1200, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Walsh
 # 4 rounds for time: 22 burpee pull-ups, 22 back squats, 200m run with a plate overhead
 Workout.find_or_create_by(name: 'Walsh') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: burpee_pull_up, position: 1, reps: 22)
-  workout.exercises.build(movement: back_squat, position: 2, reps: 22, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter, notes: 'Carry a plate overhead.', female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: burpee_pull_up, position: 1, reps: 22)
+  segment.exercises.build(movement: back_squat, position: 2, reps: 22, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter, notes: 'Carry a plate overhead.', female_load: 25,
+                          male_load: 45, load_unit: :lb)
 end
 
 # ==============================================================================
 # War Frank
 # 3 rounds for time: 25 muscle-ups, 100 squats, 35 GHD sit-ups
 Workout.find_or_create_by(name: 'War Frank') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 25)
-  workout.exercises.build(movement: air_squat, position: 2, reps: 100)
-  workout.exercises.build(movement: ghd_sit_up, position: 3, reps: 35)
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 25)
+  segment.exercises.build(movement: air_squat, position: 2, reps: 100)
+  segment.exercises.build(movement: ghd_sit_up, position: 3, reps: 35)
 end
 
 # ==============================================================================
 # Weaver
 # 4 rounds for time: 10 L pull-ups, 15 push-ups, 15 chest-to-bar pull-ups, 15 push-ups, 20 pull-ups, 15 push-ups
 Workout.find_or_create_by(name: 'Weaver') do |workout|
-  workout.rounds = 4
+  segment = workout.segments.build(rounds: 4, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: l_pull_up, position: 1, reps: 10)
-  workout.exercises.build(movement: push_up, position: 2, reps: 15)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 3, reps: 15)
-  workout.exercises.build(movement: push_up, position: 4, reps: 15)
-  workout.exercises.build(movement: pull_up, position: 5, reps: 20)
-  workout.exercises.build(movement: push_up, position: 6, reps: 15)
+  segment.exercises.build(movement: l_pull_up, position: 1, reps: 10)
+  segment.exercises.build(movement: push_up, position: 2, reps: 15)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 3, reps: 15)
+  segment.exercises.build(movement: push_up, position: 4, reps: 15)
+  segment.exercises.build(movement: pull_up, position: 5, reps: 20)
+  segment.exercises.build(movement: push_up, position: 6, reps: 15)
 end
 
 # ==============================================================================
 # Wes
 # For time: run 800m w/ plate; 14 rounds (5 strict pull-ups, 4 burpee box jumps, 3 cleans); run 800m w/ plate
 Workout.find_or_create_by(name: 'Wes') do |workout|
-  workout.rounds = 1
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.')
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.')
   rounds = workout.segments.build(rounds: 14, position: 2)
-  workout.exercises.build(movement: strict_pull_up, segment: rounds, position: 1, reps: 5)
-  workout.exercises.build(movement: burpee_box_jump, segment: rounds, position: 2, reps: 4)
-  workout.exercises.build(movement: clean, segment: rounds, position: 3, reps: 3)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.')
+  rounds.exercises.build(movement: strict_pull_up, position: 1, reps: 5)
+  rounds.exercises.build(movement: burpee_box_jump, position: 2, reps: 4)
+  rounds.exercises.build(movement: clean, position: 3, reps: 3)
+  segment = workout.segments.build(position: 3)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a plate.')
 end
 
 # ==============================================================================
 # Wesley
 # On a 35-minute clock: 800m run, then AMRAP: 8 box jumps, 6 strict pull-ups, 21-yard walking lunge w/ 45-lb plate overhead
 Workout.find_or_create_by(name: 'Wesley') do |workout|
-  workout.time = 35
+  segment = workout.segments.build(time_seconds: 2100, position: 1)
   workout.score_type = :rep
   workout.notes = 'Run 800 meters, then AMRAP the triplet in the remaining time.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 8)
-  workout.exercises.build(movement: strict_pull_up, position: 3, reps: 6)
-  workout.exercises.build(movement: lunge_with_plate_overhead, position: 4, reps: 1, distance: 63, distance_unit: :foot, notes: '21-yard walking lunge with a 45-lb plate overhead.', load: 45, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 8)
+  segment.exercises.build(movement: strict_pull_up, position: 3, reps: 6)
+  segment.exercises.build(movement: lunge_with_plate_overhead, position: 4, reps: 1, distance: 63, distance_unit: :foot,
+                          notes: '21-yard walking lunge with a 45-lb plate overhead.', load: 45, load_unit: :lb)
 end
 
 # ==============================================================================
 # Weston
 # 5 rounds for time: row 1,000m, 200m farmers carry, 50m DB waiters walk (R), 50m DB waiters walk (L)
 Workout.find_or_create_by(name: 'Weston') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
-  workout.exercises.build(movement: farmers_carry, position: 2, reps: 1, distance: 200, distance_unit: :meter, female_load: 30, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_waiters_walk, position: 3, reps: 1, distance: 50, distance_unit: :meter, notes: 'Right arm.', female_load: 30, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_waiters_walk, position: 4, reps: 1, distance: 50, distance_unit: :meter, notes: 'Left arm.', female_load: 30, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 1000, distance_unit: :meter)
+  segment.exercises.build(movement: farmers_carry, position: 2, reps: 1, distance: 200, distance_unit: :meter, female_load: 30, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: dumbbell_waiters_walk, position: 3, reps: 1, distance: 50, distance_unit: :meter, notes: 'Right arm.', female_load: 30,
+                          male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: dumbbell_waiters_walk, position: 4, reps: 1, distance: 50, distance_unit: :meter, notes: 'Left arm.', female_load: 30,
+                          male_load: 45, load_unit: :lb)
 end
 
 # ==============================================================================
 # White
 # 5 rounds for time: 3 rope climbs to 15 feet, 10 toes-to-bars, 21 overhead walking lunges, 400m run
 Workout.find_or_create_by(name: 'White') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: rope_climb, position: 1, reps: 3, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 10)
-  workout.exercises.build(movement: overhead_walking_lunge, position: 3, reps: 21, female_load: 25, male_load: 45, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: rope_climb, position: 1, reps: 3, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 10)
+  segment.exercises.build(movement: overhead_walking_lunge, position: 3, reps: 21, female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 4, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Whitt
 # 3 rounds for time: 800m run with medicine ball, 30 wall-ball shots, 30 ball slams with medicine ball
 Workout.find_or_create_by(name: 'Whitt') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 20, male_load: 30, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, position: 2, reps: 30, female_load: 20, male_load: 30, load_unit: :lb)
-  workout.exercises.build(movement: slam_ball, position: 3, reps: 30, notes: 'Medicine-ball slams.', female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter, notes: 'Carry a medicine ball.', female_load: 20,
+                          male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 2, reps: 30, female_load: 20, male_load: 30, load_unit: :lb)
+  segment.exercises.build(movement: slam_ball, position: 3, reps: 30, notes: 'Medicine-ball slams.', female_load: 20, male_load: 30, load_unit: :lb)
 end
 
 # ==============================================================================
 # Whitten
 # 5 rounds for time: 22 kettlebell swings, 22 box jumps, 400m run, 22 burpees, 22 wall-ball shots
 Workout.find_or_create_by(name: 'Whitten') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: kettlebell_swing, position: 1, reps: 22, female_load: 53, male_load: 72, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 22, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee, position: 4, reps: 22)
-  workout.exercises.build(movement: wall_ball_shot, position: 5, reps: 22, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: kettlebell_swing, position: 1, reps: 22, female_load: 53, male_load: 72, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 22, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee, position: 4, reps: 22)
+  segment.exercises.build(movement: wall_ball_shot, position: 5, reps: 22, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
 end
 
 # ==============================================================================
 # Willy
 # 3 rounds for time: 800m run, 5 front squats, 200m run, 11 chest-to-bar pull-ups, 400m run, 12 kettlebell swings
 Workout.find_or_create_by(name: 'Willy') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
-  workout.exercises.build(movement: front_squat, position: 2, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 11)
-  workout.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: kettlebell_swing, position: 6, reps: 12, female_load: 53, male_load: 70, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  segment.exercises.build(movement: front_squat, position: 2, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 200, distance_unit: :meter)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 11)
+  segment.exercises.build(movement: run, position: 5, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: kettlebell_swing, position: 6, reps: 12, female_load: 53, male_load: 70, load_unit: :lb)
 end
 
 # ==============================================================================
 # Wilmot
 # 6 rounds for time: 50 squats, 25 ring dips
 Workout.find_or_create_by(name: 'Wilmot') do |workout|
-  workout.rounds = 6
+  segment = workout.segments.build(rounds: 6, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: air_squat, position: 1, reps: 50)
-  workout.exercises.build(movement: ring_dip, position: 2, reps: 25)
+  segment.exercises.build(movement: air_squat, position: 1, reps: 50)
+  segment.exercises.build(movement: ring_dip, position: 2, reps: 25)
 end
 
 # ==============================================================================
 # Wittman
 # 7 rounds for time: 15 kettlebell swings, 15 power cleans, 15 box jumps
 Workout.find_or_create_by(name: 'Wittman') do |workout|
-  workout.rounds = 7
+  segment = workout.segments.build(rounds: 7, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: kettlebell_swing, position: 1, reps: 15, female_load: 35, male_load: 53, load_unit: :lb)
-  workout.exercises.build(movement: power_clean, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: kettlebell_swing, position: 1, reps: 15, female_load: 35, male_load: 53, load_unit: :lb)
+  segment.exercises.build(movement: power_clean, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # ==============================================================================
 # Woehlke
 # 3 rounds, each for time: 4 jerks, 5 front squats, 6 power cleans, 40 pull-ups, 50 push-ups, 60 sit-ups. Rest 3 minutes.
 Workout.find_or_create_by(name: 'Woehlke') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
   workout.notes = 'Each round is for time. Rest 3 minutes between rounds.'
-  workout.exercises.build(movement: jerk, position: 1, reps: 4, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: front_squat, position: 2, reps: 5, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: power_clean, position: 3, reps: 6, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 4, reps: 40)
-  workout.exercises.build(movement: push_up, position: 5, reps: 50)
-  workout.exercises.build(movement: sit_up, position: 6, reps: 60)
+  segment.exercises.build(movement: jerk, position: 1, reps: 4, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: front_squat, position: 2, reps: 5, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: power_clean, position: 3, reps: 6, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 4, reps: 40)
+  segment.exercises.build(movement: push_up, position: 5, reps: 50)
+  segment.exercises.build(movement: sit_up, position: 6, reps: 60)
 end
 
 # ==============================================================================
 # Wood
 # 5 rounds for time: 400m run, 10 burpee box jumps, 10 sumo deadlift high pulls, 10 thrusters. Rest 1 minute.
 Workout.find_or_create_by(name: 'Wood') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'Rest 1 minute between rounds.'
-  workout.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
-  workout.exercises.build(movement: burpee_box_jump, position: 2, reps: 10, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: sumo_deadlift_high_pull, position: 3, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: thruster, position: 4, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: burpee_box_jump, position: 2, reps: 10, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: sumo_deadlift_high_pull, position: 3, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: thruster, position: 4, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
 # Wyk
 # 5 rounds for time: 5 front squats, 5 rope climbs to 15 feet, 400m run with a plate
 Workout.find_or_create_by(name: 'Wyk') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: front_squat, position: 1, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: rope_climb, position: 2, reps: 5, distance: 15, distance_unit: :foot)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45, load_unit: :lb)
+  segment.exercises.build(movement: front_squat, position: 1, reps: 5, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: rope_climb, position: 2, reps: 5, distance: 15, distance_unit: :foot)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter, notes: 'Carry a plate.', female_load: 25, male_load: 45,
+                          load_unit: :lb)
 end
 
 # ==============================================================================
 # Yeti
 # For time: 25 pull-ups, 10 muscle-ups, 1.5-mile run, 10 muscle-ups, 25 pull-ups
 Workout.find_or_create_by(name: 'Yeti') do |workout|
-  workout.rounds = 1
+  segment = workout.segments.build(position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: pull_up, position: 1, reps: 25)
-  workout.exercises.build(movement: muscle_up, position: 2, reps: 10)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 2400, distance_unit: :meter)
-  workout.exercises.build(movement: muscle_up, position: 4, reps: 10)
-  workout.exercises.build(movement: pull_up, position: 5, reps: 25)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 25)
+  segment.exercises.build(movement: muscle_up, position: 2, reps: 10)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 2400, distance_unit: :meter)
+  segment.exercises.build(movement: muscle_up, position: 4, reps: 10)
+  segment.exercises.build(movement: pull_up, position: 5, reps: 25)
 end
 
 # ==============================================================================
 # Zembiec
 # 5 rounds for time: 11 back squats, 7 strict burpee pull-ups, 400m run
 Workout.find_or_create_by(name: 'Zembiec') do |workout|
-  workout.rounds = 5
+  segment = workout.segments.build(rounds: 5, position: 1)
   workout.score_type = :time
   workout.notes = 'On each burpee pull-up, perform a strict push-up, jump to a bar ideally 12 inches ' \
                   'above your max standing reach, and perform a strict pull-up.'
-  workout.exercises.build(movement: back_squat, position: 1, reps: 11, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: strict_burpee_pull_up, position: 2, reps: 7)
-  workout.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
+  segment.exercises.build(movement: back_squat, position: 1, reps: 11, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: strict_burpee_pull_up, position: 2, reps: 7)
+  segment.exercises.build(movement: run, position: 3, reps: 1, distance: 400, distance_unit: :meter)
 end
 
 # ==============================================================================
 # Zeus
 # 3 rounds for time: 30 wall-ball shots, 30 SDHP, 30 box jumps, 30 push presses, 30-cal row, 30 push-ups, 10 back squats
 Workout.find_or_create_by(name: 'Zeus') do |workout|
-  workout.rounds = 3
+  segment = workout.segments.build(rounds: 3, position: 1)
   workout.score_type = :time
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 30, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
-  workout.exercises.build(movement: sumo_deadlift_high_pull, position: 2, reps: 30, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: push_press, position: 4, reps: 30, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: row, position: 5, reps: 1, calories: 30)
-  workout.exercises.build(movement: push_up, position: 6, reps: 30)
-  workout.exercises.build(movement: back_squat, position: 7, reps: 10, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 30, distance: 9, distance_unit: :foot, female_load: 14, male_load: 20, load_unit: :lb)
+  segment.exercises.build(movement: sumo_deadlift_high_pull, position: 2, reps: 30, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: push_press, position: 4, reps: 30, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 5, reps: 1, calories: 30)
+  segment.exercises.build(movement: push_up, position: 6, reps: 30)
+  segment.exercises.build(movement: back_squat, position: 7, reps: 10, female_load: 55, male_load: 75, load_unit: :lb)
 end
 
 # ==============================================================================
 # Zimmerman
 # AMRAP in 25 minutes: 11 chest-to-bar pull-ups, 2 deadlifts, 10 handstand push-ups
 Workout.find_or_create_by(name: 'Zimmerman') do |workout|
-  workout.time = 25
+  segment = workout.segments.build(time_seconds: 1500, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 11)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 2, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 3, reps: 10)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 11)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 2, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 3, reps: 10)
 end

--- a/db/seeds/hero_workouts.rb
+++ b/db/seeds/hero_workouts.rb
@@ -418,7 +418,9 @@ Workout.find_or_create_by(name: 'Clovis') do |workout|
   segment = workout.segments.build(position: 1)
   workout.score_type = :time
   workout.notes = 'Partition the run and burpee pull-ups as needed.'
-  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 16_000, distance_unit: :meter)
+  # rubocop:disable Style/NumericLiterals -- Preserve the original seed literal.
+  segment.exercises.build(movement: run, position: 1, reps: 1, distance: 16000, distance_unit: :meter)
+  # rubocop:enable Style/NumericLiterals
   segment.exercises.build(movement: burpee_pull_up, position: 2, reps: 150)
 end
 

--- a/db/seeds/open_workouts.rb
+++ b/db/seeds/open_workouts.rb
@@ -18,10 +18,10 @@
 # 30 double-unders
 # 15 power snatches (75 / 55 lb)
 Workout.find_or_create_by(name: 'Open 11.1') do |workout|
-  workout.time = 10
+  segment = workout.segments.build(time_seconds: 600, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: double_under, position: 1, reps: 30)
-  workout.exercises.build(movement: power_snatch, position: 2, reps: 15, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 1, reps: 30)
+  segment.exercises.build(movement: power_snatch, position: 2, reps: 15, female_load: 55, male_load: 75, load_unit: :lb)
 end
 
 # 11.2
@@ -30,21 +30,21 @@ end
 # 12 hand-release push-ups
 # 15 box jumps (24 / 20 in)
 Workout.find_or_create_by(name: 'Open 11.2') do |workout|
-  workout.time = 15
+  segment = workout.segments.build(time_seconds: 900, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 9, female_load: 100, male_load: 155, load_unit: :lb)
-  workout.exercises.build(movement: push_up, position: 2, reps: 12, notes: 'Hand-release push-ups.')
-  workout.exercises.build(movement: box_jump, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 9, female_load: 100, male_load: 155, load_unit: :lb)
+  segment.exercises.build(movement: push_up, position: 2, reps: 12, notes: 'Hand-release push-ups.')
+  segment.exercises.build(movement: box_jump, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # 11.3
 # AMRAP 5 minutes
 # Clean and jerk (165 / 110 lb)
 Workout.find_or_create_by(name: 'Open 11.3') do |workout|
-  workout.time = 5
+  segment = workout.segments.build(time_seconds: 300, position: 1)
   workout.score_type = :rep
   workout.notes = 'Max clean and jerks in 5 minutes. Post total reps.'
-  workout.exercises.build(movement: clean_and_jerk, position: 1, reps: 0, female_load: 110, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: clean_and_jerk, position: 1, reps: 0, female_load: 110, male_load: 165, load_unit: :lb)
 end
 
 # 11.4
@@ -53,12 +53,12 @@ end
 # 30 overhead squats (120 / 90 lb)
 # 10 muscle-ups
 Workout.find_or_create_by(name: 'Open 11.4') do |workout|
-  workout.time = 10
+  segment = workout.segments.build(time_seconds: 600, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: bar_facing_burpee, position: 1, reps: 60,
+  segment.exercises.build(movement: bar_facing_burpee, position: 1, reps: 60,
                           notes: 'Jump over the barbell.')
-  workout.exercises.build(movement: overhead_squat, position: 2, reps: 30, female_load: 90, male_load: 120, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 3, reps: 10)
+  segment.exercises.build(movement: overhead_squat, position: 2, reps: 30, female_load: 90, male_load: 120, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 3, reps: 10)
 end
 
 # 11.5
@@ -67,11 +67,11 @@ end
 # 10 toes-to-bar
 # 15 wall-ball shots (20 lb to 10 ft / 14 lb to 9 ft)
 Workout.find_or_create_by(name: 'Open 11.5') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: power_clean, position: 1, reps: 5, female_load: 100, male_load: 145, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 10)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 15,
+  segment.exercises.build(movement: power_clean, position: 1, reps: 5, female_load: 100, male_load: 145, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 10)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 15,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
 end
@@ -81,12 +81,12 @@ end
 # Thrusters (100 / 65 lb)
 # Chest-to-bar pull-ups
 Workout.find_or_create_by(name: 'Open 11.6') do |workout|
-  workout.time = 7
+  segment = workout.segments.build(time_seconds: 420, position: 1)
   workout.score_type = :rep
   workout.ladder_step = 3
   workout.notes = 'Post total reps.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 3, female_load: 65, male_load: 100, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 3)
+  segment.exercises.build(movement: thruster, position: 1, reps: 3, female_load: 65, male_load: 100, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 3)
 end
 
 # ==============================================================================
@@ -97,11 +97,11 @@ end
 # AMRAP 7 minutes
 # Burpees (jump and touch a target 6 in above standing reach)
 Workout.find_or_create_by(name: 'Open 12.1') do |workout|
-  workout.time = 7
+  segment = workout.segments.build(time_seconds: 420, position: 1)
   workout.score_type = :rep
   workout.notes = 'Each burpee: chest and thighs to the floor, then jump and touch a target ' \
                   '6 inches above standing reach. Post total burpees.'
-  workout.exercises.build(movement: burpee, position: 1, reps: 0)
+  segment.exercises.build(movement: burpee, position: 1, reps: 0)
 end
 
 # 12.2
@@ -111,14 +111,14 @@ end
 # 30 snatches (165 / 100 lb)
 # Max snatches (210 / 120 lb)
 Workout.find_or_create_by(name: 'Open 12.2') do |workout|
-  workout.time = 10
+  segment = workout.segments.build(time_seconds: 600, position: 1)
   workout.score_type = :rep
   workout.notes = 'Proceed through the loads in order, completing all 30 reps at a load before advancing. ' \
                   'After 90 reps, perform max reps at the heaviest load. Post total reps.'
-  workout.exercises.build(movement: snatch, position: 1, reps: 30, female_load: 45, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: snatch, position: 2, reps: 30, female_load: 75, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: snatch, position: 3, reps: 30, female_load: 100, male_load: 165, load_unit: :lb)
-  workout.exercises.build(movement: snatch, position: 4, reps: 0, female_load: 120, male_load: 210, load_unit: :lb)
+  segment.exercises.build(movement: snatch, position: 1, reps: 30, female_load: 45, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: snatch, position: 2, reps: 30, female_load: 75, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: snatch, position: 3, reps: 30, female_load: 100, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: snatch, position: 4, reps: 0, female_load: 120, male_load: 210, load_unit: :lb)
 end
 
 # 12.3
@@ -127,11 +127,11 @@ end
 # 12 push presses (115 / 75 lb)
 # 9 toes-to-bar
 Workout.find_or_create_by(name: 'Open 12.3') do |workout|
-  workout.time = 18
+  segment = workout.segments.build(time_seconds: 1080, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: box_jump, position: 1, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: push_press, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 3, reps: 9)
+  segment.exercises.build(movement: box_jump, position: 1, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: push_press, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 3, reps: 9)
 end
 
 # 12.4
@@ -140,13 +140,13 @@ end
 # 90 double-unders
 # 30 muscle-ups
 Workout.find_or_create_by(name: 'Open 12.4') do |workout|
-  workout.time = 12
+  segment = workout.segments.build(time_seconds: 720, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 150,
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 150,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: double_under, position: 2, reps: 90)
-  workout.exercises.build(movement: muscle_up, position: 3, reps: 30)
+  segment.exercises.build(movement: double_under, position: 2, reps: 90)
+  segment.exercises.build(movement: muscle_up, position: 3, reps: 30)
 end
 
 # 12.5 is a repeat of 11.6
@@ -166,18 +166,18 @@ end
 # 10 burpees
 # Max snatches (210 / 120 lb)
 Workout.find_or_create_by(name: 'Open 13.1') do |workout|
-  workout.time = 17
+  segment = workout.segments.build(time_seconds: 1020, position: 1)
   workout.score_type = :rep
   workout.notes = 'Work through the chipper in order; the final snatches are max reps at the heaviest load. ' \
                   'Post total reps.'
-  workout.exercises.build(movement: burpee, position: 1, reps: 40)
-  workout.exercises.build(movement: snatch, position: 2, reps: 30, female_load: 45, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 3, reps: 30)
-  workout.exercises.build(movement: snatch, position: 4, reps: 30, female_load: 75, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 5, reps: 20)
-  workout.exercises.build(movement: snatch, position: 6, reps: 30, female_load: 100, male_load: 165, load_unit: :lb)
-  workout.exercises.build(movement: burpee, position: 7, reps: 10)
-  workout.exercises.build(movement: snatch, position: 8, reps: 0, female_load: 120, male_load: 210, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 1, reps: 40)
+  segment.exercises.build(movement: snatch, position: 2, reps: 30, female_load: 45, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 3, reps: 30)
+  segment.exercises.build(movement: snatch, position: 4, reps: 30, female_load: 75, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 5, reps: 20)
+  segment.exercises.build(movement: snatch, position: 6, reps: 30, female_load: 100, male_load: 165, load_unit: :lb)
+  segment.exercises.build(movement: burpee, position: 7, reps: 10)
+  segment.exercises.build(movement: snatch, position: 8, reps: 0, female_load: 120, male_load: 210, load_unit: :lb)
 end
 
 # 13.2
@@ -186,11 +186,11 @@ end
 # 10 deadlifts (115 / 75 lb)
 # 15 box jumps (24 / 20 in)
 Workout.find_or_create_by(name: 'Open 13.2') do |workout|
-  workout.time = 10
+  segment = workout.segments.build(time_seconds: 600, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: shoulder_to_overhead, position: 1, reps: 5, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: shoulder_to_overhead, position: 1, reps: 5, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # 13.3 is a repeat of 12.4
@@ -200,12 +200,12 @@ end
 # Clean and jerk (135 / 95 lb)
 # Toes-to-bar
 Workout.find_or_create_by(name: 'Open 13.4') do |workout|
-  workout.time = 7
+  segment = workout.segments.build(time_seconds: 420, position: 1)
   workout.score_type = :rep
   workout.ladder_step = 3
   workout.notes = 'Post total reps.'
-  workout.exercises.build(movement: clean_and_jerk, position: 1, reps: 3, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 3)
+  segment.exercises.build(movement: clean_and_jerk, position: 1, reps: 3, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 3)
 end
 
 # 13.5
@@ -213,12 +213,12 @@ end
 # 15 thrusters (100 / 65 lb)
 # 15 chest-to-bar pull-ups
 Workout.find_or_create_by(name: 'Open 13.5') do |workout|
-  workout.time = 4
+  segment = workout.segments.build(time_seconds: 240, position: 1)
   workout.score_type = :rep
   workout.notes = 'Begin with a 4-minute window. Completing 3 rounds (90 reps) extends the cap to 8 minutes; ' \
                   '6 rounds to 12 minutes; 9 rounds to 16 minutes; and so on. Post total reps.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 15, female_load: 65, male_load: 100, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 15)
+  segment.exercises.build(movement: thruster, position: 1, reps: 15, female_load: 65, male_load: 100, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 15)
 end
 
 # ==============================================================================
@@ -237,9 +237,10 @@ Workout.find_or_create_by(name: 'Open 14.2') do |workout|
   workout.notes = 'Every 3 minutes for as long as possible: complete 2 rounds of the couplet. The reps ' \
                   'hold for both rounds of a window, then grow by 2 in the next window (10, 12, 14, ...). ' \
                   'Continue until you fail to finish both rounds inside a window. Post total reps.'
-  workout.exercises.build(movement: overhead_squat, position: 1, reps: 10, ladder_step_every: 2,
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: overhead_squat, position: 1, reps: 10, ladder_step_every: 2,
                           female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 10, ladder_step_every: 2)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 10, ladder_step_every: 2)
 end
 
 # 14.3
@@ -251,21 +252,21 @@ end
 # 30 deadlifts (315 / 205 lb), 15 box jumps
 # 35 deadlifts (365 / 225 lb), 15 box jumps
 Workout.find_or_create_by(name: 'Open 14.3') do |workout|
-  workout.time = 8
+  segment = workout.segments.build(time_seconds: 480, position: 1)
   workout.score_type = :rep
   workout.notes = 'Deadlift load increases each round; box jumps stay at 15 reps. Post total reps.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 2, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 15, female_load: 135, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 4, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 5, reps: 20, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 6, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 7, reps: 25, female_load: 185, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 8, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 9, reps: 30, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 10, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: deadlift, position: 11, reps: 35, female_load: 225, male_load: 365, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 12, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 10, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 2, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 15, female_load: 135, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 4, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 5, reps: 20, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 6, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 7, reps: 25, female_load: 185, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 8, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 9, reps: 30, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 10, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: deadlift, position: 11, reps: 35, female_load: 225, male_load: 365, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 12, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # 14.4
@@ -276,15 +277,15 @@ end
 # 30 cleans (135 / 95 lb)
 # 20 muscle-ups
 Workout.find_or_create_by(name: 'Open 14.4') do |workout|
-  workout.time = 14
+  segment = workout.segments.build(time_seconds: 840, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: row, position: 1, reps: 1, calories: 60)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 50)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 40,
+  segment.exercises.build(movement: row, position: 1, reps: 1, calories: 60)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 50)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 40,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: clean, position: 4, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 5, reps: 20)
+  segment.exercises.build(movement: clean, position: 4, reps: 30, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 5, reps: 20)
 end
 
 # 14.5
@@ -292,11 +293,11 @@ end
 # Thrusters (95 / 65 lb)
 # Bar-facing burpees
 Workout.find_or_create_by(name: 'Open 14.5') do |workout|
-  workout.interval = '21-18-15-12-9-6-3'
+  segment = workout.segments.build(interval_scheme: '21-18-15-12-9-6-3', position: 1)
   workout.score_type = :time
   workout.notes = 'Bar-facing burpees jump over the barbell. No time cap. Post total time.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
+  segment.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
 end
 
 # ==============================================================================
@@ -309,11 +310,11 @@ end
 # 10 deadlifts (115 / 75 lb)
 # 5 snatches (115 / 75 lb)
 Workout.find_or_create_by(name: 'Open 15.1') do |workout|
-  workout.time = 9
+  segment = workout.segments.build(time_seconds: 540, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: toes_to_bar, position: 1, reps: 15)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: snatch, position: 3, reps: 5, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 1, reps: 15)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: snatch, position: 3, reps: 5, female_load: 75, male_load: 115, load_unit: :lb)
 end
 
 # 15.1a
@@ -323,7 +324,8 @@ Workout.find_or_create_by(name: 'Open 15.1a') do |workout|
   workout.time_cap_seconds = 360
   workout.notes = 'Performed immediately following 15.1. Establish a 1-rep-max clean and jerk within ' \
                   '6 minutes. Post heaviest successful load.'
-  workout.exercises.build(movement: clean_and_jerk, position: 1, reps: 1)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: clean_and_jerk, position: 1, reps: 1)
 end
 
 # 15.2 is a repeat of 14.2
@@ -334,13 +336,13 @@ end
 # 50 wall-ball shots (20 lb to 10 ft / 14 lb to 9 ft)
 # 100 double-unders
 Workout.find_or_create_by(name: 'Open 15.3') do |workout|
-  workout.time = 14
+  segment = workout.segments.build(time_seconds: 840, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: muscle_up, position: 1, reps: 7)
-  workout.exercises.build(movement: wall_ball_shot, position: 2, reps: 50,
+  segment.exercises.build(movement: muscle_up, position: 1, reps: 7)
+  segment.exercises.build(movement: wall_ball_shot, position: 2, reps: 50,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: double_under, position: 3, reps: 100)
+  segment.exercises.build(movement: double_under, position: 3, reps: 100)
 end
 
 # 15.4
@@ -348,13 +350,13 @@ end
 # Handstand push-ups (3, 6, 9, 12, ... add 3 each round)
 # Cleans (185 / 125 lb) (add 3 reps every three rounds: 3, 3, 3, 6, 6, 6, 9, ...)
 Workout.find_or_create_by(name: 'Open 15.4') do |workout|
-  workout.time = 8
+  segment = workout.segments.build(time_seconds: 480, position: 1)
   workout.score_type = :rep
   workout.ladder_step = 3
   workout.notes = 'Handstand push-ups increase by 3 each round (3, 6, 9, ...); cleans increase by 3 every ' \
                   'three rounds (3, 3, 3, 6, 6, 6, 9, ...). Post total reps.'
-  workout.exercises.build(movement: handstand_push_up, position: 1, reps: 3)
-  workout.exercises.build(movement: clean, position: 2, reps: 3, ladder_step_every: 3,
+  segment.exercises.build(movement: handstand_push_up, position: 1, reps: 3)
+  segment.exercises.build(movement: clean, position: 2, reps: 3, ladder_step_every: 3,
                           female_load: 125, male_load: 185, load_unit: :lb)
 end
 
@@ -363,11 +365,11 @@ end
 # Row (calories)
 # Thrusters (95 / 65 lb)
 Workout.find_or_create_by(name: 'Open 15.5') do |workout|
-  workout.interval = '27-21-15-9'
+  segment = workout.segments.build(interval_scheme: '27-21-15-9', position: 1)
   workout.score_type = :time
   workout.notes = 'The row is scored in calories. Post total time.'
-  workout.exercises.build(movement: row, position: 1, reps: 1, notes: 'Calories.')
-  workout.exercises.build(movement: thruster, position: 2, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: row, position: 1, reps: 1, notes: 'Calories.')
+  segment.exercises.build(movement: thruster, position: 2, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -381,15 +383,15 @@ end
 # 25-ft overhead walking lunge (95 / 65 lb)
 # 8 chest-to-bar pull-ups
 Workout.find_or_create_by(name: 'Open 16.1') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
   workout.notes = 'The barbell is held overhead during the walking lunges. Post total reps.'
-  workout.exercises.build(movement: walking_lunge, position: 1, reps: 1, distance: 25, distance_unit: :foot,
+  segment.exercises.build(movement: walking_lunge, position: 1, reps: 1, distance: 25, distance_unit: :foot,
                           female_load: 65, male_load: 95, load_unit: :lb, notes: 'Barbell held overhead.')
-  workout.exercises.build(movement: burpee, position: 2, reps: 8)
-  workout.exercises.build(movement: walking_lunge, position: 3, reps: 1, distance: 25, distance_unit: :foot,
+  segment.exercises.build(movement: burpee, position: 2, reps: 8)
+  segment.exercises.build(movement: walking_lunge, position: 3, reps: 1, distance: 25, distance_unit: :foot,
                           female_load: 65, male_load: 95, load_unit: :lb, notes: 'Barbell held overhead.')
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 8)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 8)
 end
 
 # 16.2
@@ -397,19 +399,19 @@ end
 # Each window: 25 toes-to-bar, 50 double-unders, then the round's squat cleans
 # Cleans by round: 15 (135/85), 13 (185/115), 11 (225/145), 9 (275/175), 7 (315/205) lb
 Workout.find_or_create_by(name: 'Open 16.2') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
   workout.notes = 'Ascending ladder in 4-minute windows (20-minute cap). Each window repeats 25 toes-to-bar and ' \
                   '50 double-unders, then the round\'s squat cleans; advance only if you finish within the window. ' \
                   'Squat cleans by round: 15 @ 135/85, 13 @ 185/115, 11 @ 225/145, 9 @ 275/175, 7 @ 315/205 lb. ' \
                   'Post total reps.'
-  workout.exercises.build(movement: toes_to_bar, position: 1, reps: 25)
-  workout.exercises.build(movement: double_under, position: 2, reps: 50)
-  workout.exercises.build(movement: clean, position: 3, reps: 15, female_load: 85, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: clean, position: 4, reps: 13, female_load: 115, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: clean, position: 5, reps: 11, female_load: 145, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: clean, position: 6, reps: 9, female_load: 175, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: clean, position: 7, reps: 7, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 1, reps: 25)
+  segment.exercises.build(movement: double_under, position: 2, reps: 50)
+  segment.exercises.build(movement: clean, position: 3, reps: 15, female_load: 85, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: clean, position: 4, reps: 13, female_load: 115, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: clean, position: 5, reps: 11, female_load: 145, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: clean, position: 6, reps: 9, female_load: 175, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: clean, position: 7, reps: 7, female_load: 205, male_load: 315, load_unit: :lb)
 end
 
 # 16.3
@@ -417,10 +419,10 @@ end
 # 10 power snatches (75 / 55 lb)
 # 3 bar muscle-ups
 Workout.find_or_create_by(name: 'Open 16.3') do |workout|
-  workout.time = 7
+  segment = workout.segments.build(time_seconds: 420, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: power_snatch, position: 1, reps: 10, female_load: 55, male_load: 75, load_unit: :lb)
-  workout.exercises.build(movement: bar_muscle_up, position: 2, reps: 3)
+  segment.exercises.build(movement: power_snatch, position: 1, reps: 10, female_load: 55, male_load: 75, load_unit: :lb)
+  segment.exercises.build(movement: bar_muscle_up, position: 2, reps: 3)
 end
 
 # 16.4
@@ -430,14 +432,14 @@ end
 # 55-calorie row
 # 55 handstand push-ups
 Workout.find_or_create_by(name: 'Open 16.4') do |workout|
-  workout.time = 13
+  segment = workout.segments.build(time_seconds: 780, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: deadlift, position: 1, reps: 55, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: wall_ball_shot, position: 2, reps: 55,
+  segment.exercises.build(movement: deadlift, position: 1, reps: 55, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: wall_ball_shot, position: 2, reps: 55,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: row, position: 3, reps: 1, calories: 55)
-  workout.exercises.build(movement: handstand_push_up, position: 4, reps: 55)
+  segment.exercises.build(movement: row, position: 3, reps: 1, calories: 55)
+  segment.exercises.build(movement: handstand_push_up, position: 4, reps: 55)
 end
 
 # 16.5 is a repeat of 14.5
@@ -455,35 +457,36 @@ Workout.find_or_create_by(name: 'Open 17.1') do |workout|
   workout.time_cap_seconds = 1200
   workout.notes = 'Single-arm dumbbell snatches, alternating arms. Sets of 10, 20, 30, 40, 50 dumbbell snatches, ' \
                   'each followed by 15 burpee box jump-overs. 20-minute cap. Post total time (or reps if capped).'
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 1, reps: 10, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 2, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 4, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 30, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 6, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 7, reps: 40, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 8, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 9, reps: 50, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: burpee_box_jump_over, position: 10, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 1, reps: 10, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 2, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 4, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 30, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 6, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 7, reps: 40, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 8, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 9, reps: 50, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: burpee_box_jump_over, position: 10, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # 17.2
 # AMRAP 12 minutes (two dumbbells, 50 / 35 lb)
 # Alternating every 2 rounds between toes-to-bar and bar muscle-ups
 Workout.find_or_create_by(name: 'Open 17.2') do |workout|
-  workout.time = 12
+  segment = workout.segments.build(time_seconds: 720, position: 1)
   workout.score_type = :rep
   workout.notes = 'Complete 2 rounds of: 50-ft dumbbell walking lunge, 16 toes-to-bar, 8 dumbbell power cleans. ' \
                   'Then 2 rounds of: 50-ft dumbbell walking lunge, 16 bar muscle-ups, 8 dumbbell power cleans. ' \
                   'Continue alternating toes-to-bar and bar muscle-ups every 2 rounds. Two 50/35-lb dumbbells ' \
                   'held at the shoulders. Post total reps.'
-  workout.exercises.build(movement: dumbbell_front_rack_lunge, position: 1, reps: 1, distance: 50, distance_unit: :foot,
+  segment.exercises.build(movement: dumbbell_front_rack_lunge, position: 1, reps: 1, distance: 50, distance_unit: :foot,
                           female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2,
                           notes: 'Two dumbbells at the shoulders.')
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 16)
-  workout.exercises.build(movement: dumbbell_power_clean, position: 3, reps: 8,
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 16)
+  segment.exercises.build(movement: dumbbell_power_clean, position: 3, reps: 8,
                           female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: bar_muscle_up, position: 4, reps: 16)
+  segment.exercises.build(movement: bar_muscle_up, position: 4, reps: 16)
 end
 
 # 17.3
@@ -497,18 +500,19 @@ Workout.find_or_create_by(name: 'Open 17.3') do |workout|
   workout.notes = 'Complete 3 rounds of each section before advancing; reps and load shown are per round. ' \
                   'The first section has an 8-minute window; each completed section adds 4 minutes, up to a ' \
                   '24-minute cap. Post total reps.'
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 6)
-  workout.exercises.build(movement: snatch, position: 2, reps: 6, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 3, reps: 7)
-  workout.exercises.build(movement: snatch, position: 4, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 5, reps: 8)
-  workout.exercises.build(movement: snatch, position: 6, reps: 4, female_load: 135, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 7, reps: 9)
-  workout.exercises.build(movement: snatch, position: 8, reps: 3, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 9, reps: 10)
-  workout.exercises.build(movement: snatch, position: 10, reps: 2, female_load: 175, male_load: 245, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 11, reps: 11)
-  workout.exercises.build(movement: snatch, position: 12, reps: 1, female_load: 185, male_load: 265, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 1, reps: 6)
+  segment.exercises.build(movement: snatch, position: 2, reps: 6, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 3, reps: 7)
+  segment.exercises.build(movement: snatch, position: 4, reps: 5, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 5, reps: 8)
+  segment.exercises.build(movement: snatch, position: 6, reps: 4, female_load: 135, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 7, reps: 9)
+  segment.exercises.build(movement: snatch, position: 8, reps: 3, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 9, reps: 10)
+  segment.exercises.build(movement: snatch, position: 10, reps: 2, female_load: 175, male_load: 245, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 11, reps: 11)
+  segment.exercises.build(movement: snatch, position: 12, reps: 1, female_load: 185, male_load: 265, load_unit: :lb)
 end
 
 # 17.4 is a repeat of 16.4
@@ -518,12 +522,12 @@ end
 # 9 thrusters (95 / 65 lb)
 # 35 double-unders
 Workout.find_or_create_by(name: 'Open 17.5') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
   workout.time_cap_seconds = 2400
   workout.notes = '10 rounds for time, 40-minute cap. Post total time.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 9, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 2, reps: 35)
+  segment.exercises.build(movement: thruster, position: 1, reps: 9, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 2, reps: 35)
 end
 
 # ==============================================================================
@@ -536,12 +540,12 @@ end
 # 10 dumbbell hang clean and jerks (50 / 35 lb, 5 per arm)
 # 14 / 12-calorie row
 Workout.find_or_create_by(name: 'Open 18.1') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: toes_to_bar, position: 1, reps: 8)
-  workout.exercises.build(movement: dumbbell_hang_clean_and_jerk, position: 2, reps: 10,
+  segment.exercises.build(movement: toes_to_bar, position: 1, reps: 8)
+  segment.exercises.build(movement: dumbbell_hang_clean_and_jerk, position: 2, reps: 10,
                           female_load: 35, male_load: 50, load_unit: :lb, notes: '5 reps per arm.')
-  workout.exercises.build(movement: row, position: 3, reps: 1, female_calories: 12, male_calories: 14)
+  segment.exercises.build(movement: row, position: 3, reps: 1, female_calories: 12, male_calories: 14)
 end
 
 # 18.2
@@ -549,14 +553,14 @@ end
 # Dumbbell squats (50 / 35 lb)
 # Bar-facing burpees
 Workout.find_or_create_by(name: 'Open 18.2') do |workout|
-  workout.interval = '1-2-3-4-5-6-7-8-9-10'
+  segment = workout.segments.build(interval_scheme: '1-2-3-4-5-6-7-8-9-10', position: 1)
   workout.score_type = :time
   workout.time_cap_seconds = 720
   workout.notes = 'Dumbbell squats hold two dumbbells at the shoulders. Bar-facing burpees jump over the barbell. ' \
                   '12-minute cap shared with 18.2a. Post total time.'
-  workout.exercises.build(movement: dumbbell_front_squat, position: 1, reps: 1,
+  segment.exercises.build(movement: dumbbell_front_squat, position: 1, reps: 1,
                           female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
 end
 
 # 18.2a
@@ -566,7 +570,8 @@ Workout.find_or_create_by(name: 'Open 18.2a') do |workout|
   workout.time_cap_seconds = 720
   workout.notes = 'Performed immediately after completing 18.2, in the time remaining within the 12-minute cap. ' \
                   'Establish a 1-rep-max clean. Post heaviest successful load.'
-  workout.exercises.build(movement: clean, position: 1, reps: 1)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: clean, position: 1, reps: 1)
 end
 
 # 18.3
@@ -580,18 +585,18 @@ end
 # 100 double-unders
 # 12 bar muscle-ups
 Workout.find_or_create_by(name: 'Open 18.3') do |workout|
-  workout.rounds = 2
+  segment = workout.segments.build(rounds: 2, position: 1)
   workout.score_type = :time
   workout.time_cap_seconds = 840
   workout.notes = '2 rounds for time, 14-minute cap. Post total time.'
-  workout.exercises.build(movement: double_under, position: 1, reps: 100)
-  workout.exercises.build(movement: overhead_squat, position: 2, reps: 20, female_load: 80, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 3, reps: 100)
-  workout.exercises.build(movement: ring_muscle_up, position: 4, reps: 12)
-  workout.exercises.build(movement: double_under, position: 5, reps: 100)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 6, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 7, reps: 100)
-  workout.exercises.build(movement: bar_muscle_up, position: 8, reps: 12)
+  segment.exercises.build(movement: double_under, position: 1, reps: 100)
+  segment.exercises.build(movement: overhead_squat, position: 2, reps: 20, female_load: 80, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 3, reps: 100)
+  segment.exercises.build(movement: ring_muscle_up, position: 4, reps: 12)
+  segment.exercises.build(movement: double_under, position: 5, reps: 100)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 6, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 7, reps: 100)
+  segment.exercises.build(movement: bar_muscle_up, position: 8, reps: 12)
 end
 
 # 18.4
@@ -603,18 +608,19 @@ Workout.find_or_create_by(name: 'Open 18.4') do |workout|
   workout.time_cap_seconds = 540
   workout.notes = 'For time, 9-minute cap. 21-15-9 of deadlift + handstand push-up at the lighter load, ' \
                   'then 21-15-9 of the heavier deadlift with a 50-ft handstand walk after each set. Post total time.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 21, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 2, reps: 21)
-  workout.exercises.build(movement: deadlift, position: 3, reps: 15, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 4, reps: 15)
-  workout.exercises.build(movement: deadlift, position: 5, reps: 9, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: handstand_push_up, position: 6, reps: 9)
-  workout.exercises.build(movement: deadlift, position: 7, reps: 21, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: handstand_walk, position: 8, reps: 1, distance: 50, distance_unit: :foot)
-  workout.exercises.build(movement: deadlift, position: 9, reps: 15, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: handstand_walk, position: 10, reps: 1, distance: 50, distance_unit: :foot)
-  workout.exercises.build(movement: deadlift, position: 11, reps: 9, female_load: 205, male_load: 315, load_unit: :lb)
-  workout.exercises.build(movement: handstand_walk, position: 12, reps: 1, distance: 50, distance_unit: :foot)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 21, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 2, reps: 21)
+  segment.exercises.build(movement: deadlift, position: 3, reps: 15, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 4, reps: 15)
+  segment.exercises.build(movement: deadlift, position: 5, reps: 9, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: handstand_push_up, position: 6, reps: 9)
+  segment.exercises.build(movement: deadlift, position: 7, reps: 21, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: handstand_walk, position: 8, reps: 1, distance: 50, distance_unit: :foot)
+  segment.exercises.build(movement: deadlift, position: 9, reps: 15, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: handstand_walk, position: 10, reps: 1, distance: 50, distance_unit: :foot)
+  segment.exercises.build(movement: deadlift, position: 11, reps: 9, female_load: 205, male_load: 315, load_unit: :lb)
+  segment.exercises.build(movement: handstand_walk, position: 12, reps: 1, distance: 50, distance_unit: :foot)
 end
 
 # 18.5 is a repeat of 11.6 (also run as 12.5)
@@ -628,12 +634,12 @@ end
 # 19 wall-ball shots (20 lb to 10 ft / 14 lb to 9 ft)
 # 19-calorie row
 Workout.find_or_create_by(name: 'Open 19.1') do |workout|
-  workout.time = 15
+  segment = workout.segments.build(time_seconds: 900, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 19,
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 19,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: row, position: 2, reps: 1, calories: 19)
+  segment.exercises.build(movement: row, position: 2, reps: 1, calories: 19)
 end
 
 # 19.2 is a repeat of 16.2
@@ -648,13 +654,14 @@ Workout.find_or_create_by(name: 'Open 19.3') do |workout|
   workout.score_type = :time
   workout.time_cap_seconds = 600
   workout.notes = 'For time, 10-minute cap. The dumbbell is held overhead for the lunge. Post total time.'
-  workout.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 1, reps: 1, distance: 200, distance_unit: :foot,
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 1, reps: 1, distance: 200, distance_unit: :foot,
                           female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_box_step_up, position: 2, reps: 50,
+  segment.exercises.build(movement: dumbbell_box_step_up, position: 2, reps: 50,
                           female_load: 35, male_load: 50, load_unit: :lb,
                           female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: strict_handstand_push_up, position: 3, reps: 50)
-  workout.exercises.build(movement: handstand_walk, position: 4, reps: 1, distance: 200, distance_unit: :foot)
+  segment.exercises.build(movement: strict_handstand_push_up, position: 3, reps: 50)
+  segment.exercises.build(movement: handstand_walk, position: 4, reps: 1, distance: 200, distance_unit: :foot)
 end
 
 # 19.4
@@ -669,13 +676,14 @@ Workout.find_or_create_by(name: 'Open 19.4') do |workout|
                   'then complete the second 3-round block. Athletes who do not finish the first block by the ' \
                   '9-minute mark score 66 reps. Bar-facing burpees jump over the barbell. Post total time.'
   first_block = workout.segments.build(rounds: 3, position: 1)
-  workout.exercises.build(movement: snatch, segment: first_block, position: 1, reps: 10,
+  first_block.exercises.build(movement: snatch, position: 1, reps: 10,
                           female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, segment: first_block, position: 2, reps: 12)
-  workout.exercises.build(movement: rest, position: 2, reps: 1, duration_seconds: 180)
+  first_block.exercises.build(movement: bar_facing_burpee, position: 2, reps: 12)
+  rest_segment = workout.segments.build(position: 2)
+  rest_segment.exercises.build(movement: rest, position: 1, reps: 1, duration_seconds: 180)
   second_block = workout.segments.build(rounds: 3, position: 3)
-  workout.exercises.build(movement: bar_muscle_up, segment: second_block, position: 1, reps: 10)
-  workout.exercises.build(movement: bar_facing_burpee, segment: second_block, position: 2, reps: 12)
+  second_block.exercises.build(movement: bar_muscle_up, position: 1, reps: 10)
+  second_block.exercises.build(movement: bar_facing_burpee, position: 2, reps: 12)
 end
 
 # 19.5
@@ -683,12 +691,12 @@ end
 # Thrusters (95 / 65 lb)
 # Chest-to-bar pull-ups
 Workout.find_or_create_by(name: 'Open 19.5') do |workout|
-  workout.interval = '33-27-21-15-9'
+  segment = workout.segments.build(interval_scheme: '33-27-21-15-9', position: 1)
   workout.score_type = :time
   workout.time_cap_seconds = 1200
   workout.notes = 'For time, 20-minute cap. Post total time.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 1)
+  segment.exercises.build(movement: thruster, position: 1, reps: 1, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 1)
 end
 
 # ==============================================================================
@@ -700,13 +708,13 @@ end
 # 8 ground-to-overhead (95 / 65 lb)
 # 10 bar-facing burpees
 Workout.find_or_create_by(name: 'Open 20.1') do |workout|
-  workout.rounds = 10
+  segment = workout.segments.build(rounds: 10, position: 1)
   workout.score_type = :time
   workout.time_cap_seconds = 900
   workout.notes = '10 rounds for time, 15-minute cap. Ground-to-overhead by any method. Bar-facing burpees ' \
                   'jump over the barbell. Post total time.'
-  workout.exercises.build(movement: ground_to_overhead, position: 1, reps: 8, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 10)
+  segment.exercises.build(movement: ground_to_overhead, position: 1, reps: 8, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 10)
 end
 
 # 20.2
@@ -715,12 +723,12 @@ end
 # 6 toes-to-bar
 # 24 double-unders
 Workout.find_or_create_by(name: 'Open 20.2') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: dumbbell_thruster, position: 1, reps: 4,
+  segment.exercises.build(movement: dumbbell_thruster, position: 1, reps: 4,
                           female_load: 35, male_load: 50, load_unit: :lb, implement_count: 2)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 6)
-  workout.exercises.build(movement: double_under, position: 3, reps: 24)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 6)
+  segment.exercises.build(movement: double_under, position: 3, reps: 24)
 end
 
 # 20.3 is a repeat of 18.4
@@ -737,18 +745,19 @@ Workout.find_or_create_by(name: 'Open 20.4') do |workout|
   workout.score_type = :time
   workout.time_cap_seconds = 1200
   workout.notes = 'For time, 20-minute cap. Post total time.'
-  workout.exercises.build(movement: box_jump, position: 1, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: clean_and_jerk, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 3, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: clean_and_jerk, position: 4, reps: 15, female_load: 85, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: box_jump, position: 5, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: clean_and_jerk, position: 6, reps: 10, female_load: 115, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: single_leg_squat_pistol, position: 7, reps: 30)
-  workout.exercises.build(movement: clean_and_jerk, position: 8, reps: 10, female_load: 145, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: single_leg_squat_pistol, position: 9, reps: 30)
-  workout.exercises.build(movement: clean_and_jerk, position: 10, reps: 5, female_load: 175, male_load: 275, load_unit: :lb)
-  workout.exercises.build(movement: single_leg_squat_pistol, position: 11, reps: 30)
-  workout.exercises.build(movement: clean_and_jerk, position: 12, reps: 5, female_load: 205, male_load: 315, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: box_jump, position: 1, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: clean_and_jerk, position: 2, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 3, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: clean_and_jerk, position: 4, reps: 15, female_load: 85, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: box_jump, position: 5, reps: 30, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: clean_and_jerk, position: 6, reps: 10, female_load: 115, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: single_leg_squat_pistol, position: 7, reps: 30)
+  segment.exercises.build(movement: clean_and_jerk, position: 8, reps: 10, female_load: 145, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: single_leg_squat_pistol, position: 9, reps: 30)
+  segment.exercises.build(movement: clean_and_jerk, position: 10, reps: 5, female_load: 175, male_load: 275, load_unit: :lb)
+  segment.exercises.build(movement: single_leg_squat_pistol, position: 11, reps: 30)
+  segment.exercises.build(movement: clean_and_jerk, position: 12, reps: 5, female_load: 205, male_load: 315, load_unit: :lb)
 end
 
 # 20.5
@@ -760,9 +769,10 @@ Workout.find_or_create_by(name: 'Open 20.5') do |workout|
   workout.score_type = :time
   workout.time_cap_seconds = 1200
   workout.notes = 'For time, 20-minute cap. The reps may be partitioned and performed in any order. Post total time.'
-  workout.exercises.build(movement: ring_muscle_up, position: 1, reps: 40)
-  workout.exercises.build(movement: row, position: 2, reps: 1, calories: 80)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 120,
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: ring_muscle_up, position: 1, reps: 40)
+  segment.exercises.build(movement: row, position: 2, reps: 1, calories: 80)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 120,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
 end
@@ -783,18 +793,19 @@ Workout.find_or_create_by(name: 'Open 21.1') do |workout|
   workout.score_type = :time
   workout.time_cap_seconds = 900
   workout.notes = 'For time, 15-minute cap. Post total time.'
-  workout.exercises.build(movement: wall_walk, position: 1, reps: 1)
-  workout.exercises.build(movement: double_under, position: 2, reps: 10)
-  workout.exercises.build(movement: wall_walk, position: 3, reps: 3)
-  workout.exercises.build(movement: double_under, position: 4, reps: 30)
-  workout.exercises.build(movement: wall_walk, position: 5, reps: 6)
-  workout.exercises.build(movement: double_under, position: 6, reps: 60)
-  workout.exercises.build(movement: wall_walk, position: 7, reps: 9)
-  workout.exercises.build(movement: double_under, position: 8, reps: 90)
-  workout.exercises.build(movement: wall_walk, position: 9, reps: 15)
-  workout.exercises.build(movement: double_under, position: 10, reps: 150)
-  workout.exercises.build(movement: wall_walk, position: 11, reps: 21)
-  workout.exercises.build(movement: double_under, position: 12, reps: 210)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: wall_walk, position: 1, reps: 1)
+  segment.exercises.build(movement: double_under, position: 2, reps: 10)
+  segment.exercises.build(movement: wall_walk, position: 3, reps: 3)
+  segment.exercises.build(movement: double_under, position: 4, reps: 30)
+  segment.exercises.build(movement: wall_walk, position: 5, reps: 6)
+  segment.exercises.build(movement: double_under, position: 6, reps: 60)
+  segment.exercises.build(movement: wall_walk, position: 7, reps: 9)
+  segment.exercises.build(movement: double_under, position: 8, reps: 90)
+  segment.exercises.build(movement: wall_walk, position: 9, reps: 15)
+  segment.exercises.build(movement: double_under, position: 10, reps: 150)
+  segment.exercises.build(movement: wall_walk, position: 11, reps: 21)
+  segment.exercises.build(movement: double_under, position: 12, reps: 210)
 end
 
 # 21.2 is a repeat of 17.1
@@ -808,17 +819,18 @@ Workout.find_or_create_by(name: 'Open 21.3') do |workout|
   workout.time_cap_seconds = 900
   workout.notes = 'For total time, 15-minute cap. Rest 1 minute between blocks. 21.4 begins immediately upon ' \
                   'finishing or reaching the cap. Post total time.'
-  workout.exercises.build(movement: front_squat, position: 1, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: toes_to_bar, position: 2, reps: 30)
-  workout.exercises.build(movement: thruster, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: rest, position: 4, reps: 1, duration_seconds: 60)
-  workout.exercises.build(movement: front_squat, position: 5, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 6, reps: 30)
-  workout.exercises.build(movement: thruster, position: 7, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: rest, position: 8, reps: 1, duration_seconds: 60)
-  workout.exercises.build(movement: front_squat, position: 9, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: bar_muscle_up, position: 10, reps: 30)
-  workout.exercises.build(movement: thruster, position: 11, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: front_squat, position: 1, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: toes_to_bar, position: 2, reps: 30)
+  segment.exercises.build(movement: thruster, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: rest, position: 4, reps: 1, duration_seconds: 60)
+  segment.exercises.build(movement: front_squat, position: 5, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 6, reps: 30)
+  segment.exercises.build(movement: thruster, position: 7, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: rest, position: 8, reps: 1, duration_seconds: 60)
+  segment.exercises.build(movement: front_squat, position: 9, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: bar_muscle_up, position: 10, reps: 30)
+  segment.exercises.build(movement: thruster, position: 11, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
 end
 
 # 21.4
@@ -829,10 +841,11 @@ Workout.find_or_create_by(name: 'Open 21.4') do |workout|
   workout.time_cap_seconds = 420
   workout.notes = 'Begins immediately after 21.3. Complete the complex for max load: 1 deadlift, 1 clean, ' \
                   '1 hang clean, 1 jerk. Post the heaviest successful complex.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 1)
-  workout.exercises.build(movement: clean, position: 2, reps: 1)
-  workout.exercises.build(movement: hang_clean, position: 3, reps: 1)
-  workout.exercises.build(movement: jerk, position: 4, reps: 1)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 1)
+  segment.exercises.build(movement: clean, position: 2, reps: 1)
+  segment.exercises.build(movement: hang_clean, position: 3, reps: 1)
+  segment.exercises.build(movement: jerk, position: 4, reps: 1)
 end
 
 # ==============================================================================
@@ -845,11 +858,11 @@ end
 # 12 dumbbell snatches (50 / 35 lb)
 # 15 box jump-overs (24 / 20 in)
 Workout.find_or_create_by(name: 'Open 22.1') do |workout|
-  workout.time = 15
+  segment = workout.segments.build(time_seconds: 900, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: wall_walk, position: 1, reps: 3)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 2, reps: 12, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: box_jump_over, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_walk, position: 1, reps: 3)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 2, reps: 12, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: box_jump_over, position: 3, reps: 15, female_distance: 20, male_distance: 24, distance_unit: :inch)
 end
 
 # 22.2
@@ -857,13 +870,13 @@ end
 # Deadlifts (225 / 155 lb)
 # Bar-facing burpees
 Workout.find_or_create_by(name: 'Open 22.2') do |workout|
-  workout.interval = '1-2-3-4-5-6-7-8-9-10-9-8-7-6-5-4-3-2-1'
+  segment = workout.segments.build(interval_scheme: '1-2-3-4-5-6-7-8-9-10-9-8-7-6-5-4-3-2-1', position: 1)
   workout.score_type = :time
   workout.time_cap_seconds = 600
   workout.notes = 'Pyramid rep scheme up to 10 and back down to 1. Bar-facing burpees jump over the barbell. ' \
                   '10-minute cap. Post total time.'
-  workout.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
+  segment.exercises.build(movement: deadlift, position: 1, reps: 1, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: bar_facing_burpee, position: 2, reps: 1)
 end
 
 # 22.3
@@ -875,15 +888,16 @@ Workout.find_or_create_by(name: 'Open 22.3') do |workout|
   workout.score_type = :time
   workout.time_cap_seconds = 720
   workout.notes = 'For time, 12-minute cap. Post total time.'
-  workout.exercises.build(movement: pull_up, position: 1, reps: 21)
-  workout.exercises.build(movement: double_under, position: 2, reps: 42)
-  workout.exercises.build(movement: thruster, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 18)
-  workout.exercises.build(movement: double_under, position: 5, reps: 36)
-  workout.exercises.build(movement: thruster, position: 6, reps: 18, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: bar_muscle_up, position: 7, reps: 15)
-  workout.exercises.build(movement: double_under, position: 8, reps: 30)
-  workout.exercises.build(movement: thruster, position: 9, reps: 15, female_load: 85, male_load: 135, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: pull_up, position: 1, reps: 21)
+  segment.exercises.build(movement: double_under, position: 2, reps: 42)
+  segment.exercises.build(movement: thruster, position: 3, reps: 21, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 4, reps: 18)
+  segment.exercises.build(movement: double_under, position: 5, reps: 36)
+  segment.exercises.build(movement: thruster, position: 6, reps: 18, female_load: 75, male_load: 115, load_unit: :lb)
+  segment.exercises.build(movement: bar_muscle_up, position: 7, reps: 15)
+  segment.exercises.build(movement: double_under, position: 8, reps: 30)
+  segment.exercises.build(movement: thruster, position: 9, reps: 15, female_load: 85, male_load: 135, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -896,13 +910,13 @@ end
 # AMRAP 15 minutes
 # 5 burpee pull-ups, 10 shuttle runs; add 5 burpee pull-ups after each round
 Workout.find_or_create_by(name: 'Open 23.2A') do |workout|
-  workout.time = 15
+  segment = workout.segments.build(time_seconds: 900, position: 1)
   workout.score_type = :rep
   workout.ladder_step = 5
   workout.notes = 'The burpee pull-ups ascend (5, 10, 15, ...); the shuttle runs stay at 10 each round. ' \
                   'One shuttle-run rep is 25 ft out and 25 ft back. Post total reps.'
-  workout.exercises.build(movement: burpee_pull_up, position: 1, reps: 5)
-  workout.exercises.build(movement: shuttle_run, position: 2, reps: 10, ladder_exempt: true,
+  segment.exercises.build(movement: burpee_pull_up, position: 1, reps: 5)
+  segment.exercises.build(movement: shuttle_run, position: 2, reps: 10, ladder_exempt: true,
                           notes: '1 rep = 25 ft out and 25 ft back.')
 end
 
@@ -913,7 +927,8 @@ Workout.find_or_create_by(name: 'Open 23.2B') do |workout|
   workout.time_cap_seconds = 300
   workout.notes = 'Performed immediately after 23.2A. Establish a 1-rep-max thruster taken from the floor ' \
                   'within 5 minutes. Post heaviest successful load.'
-  workout.exercises.build(movement: thruster, position: 1, reps: 1)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: thruster, position: 1, reps: 1)
 end
 
 # 23.3
@@ -926,18 +941,19 @@ Workout.find_or_create_by(name: 'Open 23.3') do |workout|
   workout.time_cap_seconds = 720
   workout.notes = 'Begin with a 6-minute cap; completing a part adds 3 minutes (to a 9-minute, then 12-minute ' \
                   'cap). Post total reps.'
-  workout.exercises.build(movement: wall_walk, position: 1, reps: 5)
-  workout.exercises.build(movement: double_under, position: 2, reps: 50)
-  workout.exercises.build(movement: snatch, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: wall_walk, position: 4, reps: 5)
-  workout.exercises.build(movement: double_under, position: 5, reps: 50)
-  workout.exercises.build(movement: snatch, position: 6, reps: 12, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: strict_handstand_push_up, position: 7, reps: 20)
-  workout.exercises.build(movement: double_under, position: 8, reps: 50)
-  workout.exercises.build(movement: snatch, position: 9, reps: 9, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: strict_handstand_push_up, position: 10, reps: 20)
-  workout.exercises.build(movement: double_under, position: 11, reps: 50)
-  workout.exercises.build(movement: snatch, position: 12, reps: 6, female_load: 155, male_load: 225, load_unit: :lb)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: wall_walk, position: 1, reps: 5)
+  segment.exercises.build(movement: double_under, position: 2, reps: 50)
+  segment.exercises.build(movement: snatch, position: 3, reps: 15, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: wall_walk, position: 4, reps: 5)
+  segment.exercises.build(movement: double_under, position: 5, reps: 50)
+  segment.exercises.build(movement: snatch, position: 6, reps: 12, female_load: 95, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: strict_handstand_push_up, position: 7, reps: 20)
+  segment.exercises.build(movement: double_under, position: 8, reps: 50)
+  segment.exercises.build(movement: snatch, position: 9, reps: 9, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: strict_handstand_push_up, position: 10, reps: 20)
+  segment.exercises.build(movement: double_under, position: 11, reps: 50)
+  segment.exercises.build(movement: snatch, position: 12, reps: 6, female_load: 155, male_load: 225, load_unit: :lb)
 end
 
 # ==============================================================================
@@ -954,18 +970,19 @@ Workout.find_or_create_by(name: 'Open 24.1') do |workout|
   workout.notes = 'For time, 15-minute cap. Each round (21, then 15, then 9) is: that many dumbbell snatches ' \
                   'on arm 1, that many lateral burpees over the dumbbell, that many dumbbell snatches on arm 2, ' \
                   'that many lateral burpees over the dumbbell. Post total time.'
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 1, reps: 21, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 1.')
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 2, reps: 21)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 21, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 2.')
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 4, reps: 21)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 15, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 1.')
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 6, reps: 15)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 7, reps: 15, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 2.')
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 8, reps: 15)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 9, reps: 9, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 1.')
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 10, reps: 9)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 11, reps: 9, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 2.')
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 12, reps: 9)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 1, reps: 21, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 1.')
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 2, reps: 21)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 3, reps: 21, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 2.')
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 4, reps: 21)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 15, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 1.')
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 6, reps: 15)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 7, reps: 15, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 2.')
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 8, reps: 15)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 9, reps: 9, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 1.')
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 10, reps: 9)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 11, reps: 9, female_load: 35, male_load: 50, load_unit: :lb, notes: 'Arm 2.')
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 12, reps: 9)
 end
 
 # 24.2
@@ -974,11 +991,11 @@ end
 # 10 deadlifts (185 / 125 lb)
 # 50 double-unders
 Workout.find_or_create_by(name: 'Open 24.2') do |workout|
-  workout.time = 20
+  segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  workout.exercises.build(movement: row, position: 1, reps: 1, distance: 300, distance_unit: :meter)
-  workout.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 125, male_load: 185, load_unit: :lb)
-  workout.exercises.build(movement: double_under, position: 3, reps: 50)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 300, distance_unit: :meter)
+  segment.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 125, male_load: 185, load_unit: :lb)
+  segment.exercises.build(movement: double_under, position: 3, reps: 50)
 end
 
 # 24.3
@@ -991,12 +1008,13 @@ Workout.find_or_create_by(name: 'Open 24.3') do |workout|
   workout.time_cap_seconds = 900
   workout.notes = 'For time, 15-minute cap. Rest 1 minute between parts. Post total time.'
   part1 = workout.segments.build(rounds: 5, position: 1)
-  workout.exercises.build(movement: thruster, segment: part1, position: 1, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, segment: part1, position: 2, reps: 10)
-  workout.exercises.build(movement: rest, position: 2, reps: 1, duration_seconds: 60)
+  part1.exercises.build(movement: thruster, position: 1, reps: 10, female_load: 65, male_load: 95, load_unit: :lb)
+  part1.exercises.build(movement: chest_to_bar_pull_up, position: 2, reps: 10)
+  rest_segment = workout.segments.build(position: 2)
+  rest_segment.exercises.build(movement: rest, position: 1, reps: 1, duration_seconds: 60)
   part2 = workout.segments.build(rounds: 5, position: 3)
-  workout.exercises.build(movement: thruster, segment: part2, position: 1, reps: 7, female_load: 95, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: bar_muscle_up, segment: part2, position: 2, reps: 7)
+  part2.exercises.build(movement: thruster, position: 1, reps: 7, female_load: 95, male_load: 135, load_unit: :lb)
+  part2.exercises.build(movement: bar_muscle_up, position: 2, reps: 7)
 end
 
 # ==============================================================================
@@ -1010,16 +1028,16 @@ end
 # 30-ft walking lunge (15 ft out, 15 ft back)
 # Add 3 reps to the burpees and hang clean-to-overheads each round; the lunge stays at 30 ft
 Workout.find_or_create_by(name: 'Open 25.1') do |workout|
-  workout.time = 15
+  segment = workout.segments.build(time_seconds: 900, position: 1)
   workout.score_type = :rep
   workout.ladder_step = 3
   workout.notes = 'The lateral burpees over the dumbbell and dumbbell hang clean-to-overheads ascend ' \
                   '(3, 6, 9, ...); the 30-ft walking lunge (15 ft out, 15 ft back) stays constant each round. ' \
                   'A single 50/35-lb dumbbell. Post total reps.'
-  workout.exercises.build(movement: lateral_burpee_over_dumbbell, position: 1, reps: 3)
-  workout.exercises.build(movement: dumbbell_hang_clean_and_jerk, position: 2, reps: 3,
+  segment.exercises.build(movement: lateral_burpee_over_dumbbell, position: 1, reps: 3)
+  segment.exercises.build(movement: dumbbell_hang_clean_and_jerk, position: 2, reps: 3,
                           female_load: 35, male_load: 50, load_unit: :lb, notes: 'Hang clean-to-overhead.')
-  workout.exercises.build(movement: walking_lunge, position: 3, reps: 1, distance: 30, distance_unit: :foot,
+  segment.exercises.build(movement: walking_lunge, position: 3, reps: 1, distance: 30, distance_unit: :foot,
                           ladder_exempt: true)
 end
 
@@ -1037,16 +1055,17 @@ Workout.find_or_create_by(name: 'Open 25.3') do |workout|
   workout.time_cap_seconds = 1200
   workout.notes = 'For time, 20-minute cap. Cleans and snatches are taken from the floor (no hang reps). ' \
                   'Post total time.'
-  workout.exercises.build(movement: wall_walk, position: 1, reps: 5)
-  workout.exercises.build(movement: row, position: 2, reps: 1, calories: 50)
-  workout.exercises.build(movement: wall_walk, position: 3, reps: 5)
-  workout.exercises.build(movement: deadlift, position: 4, reps: 25, female_load: 155, male_load: 225, load_unit: :lb)
-  workout.exercises.build(movement: wall_walk, position: 5, reps: 5)
-  workout.exercises.build(movement: clean, position: 6, reps: 25, female_load: 85, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: wall_walk, position: 7, reps: 5)
-  workout.exercises.build(movement: snatch, position: 8, reps: 25, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: wall_walk, position: 9, reps: 5)
-  workout.exercises.build(movement: row, position: 10, reps: 1, calories: 50)
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: wall_walk, position: 1, reps: 5)
+  segment.exercises.build(movement: row, position: 2, reps: 1, calories: 50)
+  segment.exercises.build(movement: wall_walk, position: 3, reps: 5)
+  segment.exercises.build(movement: deadlift, position: 4, reps: 25, female_load: 155, male_load: 225, load_unit: :lb)
+  segment.exercises.build(movement: wall_walk, position: 5, reps: 5)
+  segment.exercises.build(movement: clean, position: 6, reps: 25, female_load: 85, male_load: 135, load_unit: :lb)
+  segment.exercises.build(movement: wall_walk, position: 7, reps: 5)
+  segment.exercises.build(movement: snatch, position: 8, reps: 25, female_load: 65, male_load: 95, load_unit: :lb)
+  segment.exercises.build(movement: wall_walk, position: 9, reps: 5)
+  segment.exercises.build(movement: row, position: 10, reps: 1, calories: 50)
 end
 
 # ==============================================================================
@@ -1067,35 +1086,36 @@ Workout.find_or_create_by(name: 'Open 26.1') do |workout|
   workout.score_type = :time
   workout.time_cap_seconds = 720
   workout.notes = 'For time, 12-minute cap. Post total time.'
-  workout.exercises.build(movement: wall_ball_shot, position: 1, reps: 20,
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: wall_ball_shot, position: 1, reps: 20,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: box_jump_over, position: 2, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 3, reps: 30,
+  segment.exercises.build(movement: box_jump_over, position: 2, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 3, reps: 30,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: box_jump_over, position: 4, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 5, reps: 40,
+  segment.exercises.build(movement: box_jump_over, position: 4, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 5, reps: 40,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: medicine_ball_box_step_over, position: 6, reps: 18,
+  segment.exercises.build(movement: medicine_ball_box_step_over, position: 6, reps: 18,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 7, reps: 66,
+  segment.exercises.build(movement: wall_ball_shot, position: 7, reps: 66,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: medicine_ball_box_step_over, position: 8, reps: 18,
+  segment.exercises.build(movement: medicine_ball_box_step_over, position: 8, reps: 18,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 9, reps: 40,
+  segment.exercises.build(movement: wall_ball_shot, position: 9, reps: 40,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: box_jump_over, position: 10, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 11, reps: 30,
+  segment.exercises.build(movement: box_jump_over, position: 10, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 11, reps: 30,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
-  workout.exercises.build(movement: box_jump_over, position: 12, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
-  workout.exercises.build(movement: wall_ball_shot, position: 13, reps: 20,
+  segment.exercises.build(movement: box_jump_over, position: 12, reps: 18, female_distance: 20, male_distance: 24, distance_unit: :inch)
+  segment.exercises.build(movement: wall_ball_shot, position: 13, reps: 20,
                           female_load: 14, male_load: 20, load_unit: :lb,
                           female_distance: 9, male_distance: 10, distance_unit: :foot)
 end
@@ -1111,18 +1131,19 @@ Workout.find_or_create_by(name: 'Open 26.2') do |workout|
   workout.time_cap_seconds = 900
   workout.notes = 'For time, 15-minute cap. The dumbbell is held overhead for the lunge; the snatches ' \
                   'alternate arms. Post total time.'
-  workout.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 1, reps: 1, distance: 80, distance_unit: :foot,
+  segment = workout.segments.build(position: 1)
+  segment.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 1, reps: 1, distance: 80, distance_unit: :foot,
                           female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 2, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: pull_up, position: 3, reps: 20)
-  workout.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 4, reps: 1, distance: 80, distance_unit: :foot,
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 2, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: pull_up, position: 3, reps: 20)
+  segment.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 4, reps: 1, distance: 80, distance_unit: :foot,
                           female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: chest_to_bar_pull_up, position: 6, reps: 20)
-  workout.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 7, reps: 1, distance: 80, distance_unit: :foot,
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 5, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: chest_to_bar_pull_up, position: 6, reps: 20)
+  segment.exercises.build(movement: dumbbell_overhead_walking_lunge, position: 7, reps: 1, distance: 80, distance_unit: :foot,
                           female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: dumbbell_power_snatch, position: 8, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
-  workout.exercises.build(movement: muscle_up, position: 9, reps: 20)
+  segment.exercises.build(movement: dumbbell_power_snatch, position: 8, reps: 20, female_load: 35, male_load: 50, load_unit: :lb)
+  segment.exercises.build(movement: muscle_up, position: 9, reps: 20)
 end
 
 # 26.3
@@ -1135,18 +1156,18 @@ Workout.find_or_create_by(name: 'Open 26.3') do |workout|
   workout.time_cap_seconds = 960
   workout.notes = 'For time, 16-minute cap. Burpees over the bar jump over the barbell. Post total time.'
   block1 = workout.segments.build(rounds: 2, position: 1)
-  workout.exercises.build(movement: over_the_bar_burpee, segment: block1, position: 1, reps: 12)
-  workout.exercises.build(movement: clean, segment: block1, position: 2, reps: 12, female_load: 65, male_load: 95, load_unit: :lb)
-  workout.exercises.build(movement: over_the_bar_burpee, segment: block1, position: 3, reps: 12)
-  workout.exercises.build(movement: thruster, segment: block1, position: 4, reps: 12, female_load: 65, male_load: 95, load_unit: :lb)
+  block1.exercises.build(movement: over_the_bar_burpee, position: 1, reps: 12)
+  block1.exercises.build(movement: clean, position: 2, reps: 12, female_load: 65, male_load: 95, load_unit: :lb)
+  block1.exercises.build(movement: over_the_bar_burpee, position: 3, reps: 12)
+  block1.exercises.build(movement: thruster, position: 4, reps: 12, female_load: 65, male_load: 95, load_unit: :lb)
   block2 = workout.segments.build(rounds: 2, position: 2)
-  workout.exercises.build(movement: over_the_bar_burpee, segment: block2, position: 1, reps: 12)
-  workout.exercises.build(movement: clean, segment: block2, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
-  workout.exercises.build(movement: over_the_bar_burpee, segment: block2, position: 3, reps: 12)
-  workout.exercises.build(movement: thruster, segment: block2, position: 4, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
+  block2.exercises.build(movement: over_the_bar_burpee, position: 1, reps: 12)
+  block2.exercises.build(movement: clean, position: 2, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
+  block2.exercises.build(movement: over_the_bar_burpee, position: 3, reps: 12)
+  block2.exercises.build(movement: thruster, position: 4, reps: 12, female_load: 75, male_load: 115, load_unit: :lb)
   block3 = workout.segments.build(rounds: 2, position: 3)
-  workout.exercises.build(movement: over_the_bar_burpee, segment: block3, position: 1, reps: 12)
-  workout.exercises.build(movement: clean, segment: block3, position: 2, reps: 12, female_load: 85, male_load: 135, load_unit: :lb)
-  workout.exercises.build(movement: over_the_bar_burpee, segment: block3, position: 3, reps: 12)
-  workout.exercises.build(movement: thruster, segment: block3, position: 4, reps: 12, female_load: 85, male_load: 135, load_unit: :lb)
+  block3.exercises.build(movement: over_the_bar_burpee, position: 1, reps: 12)
+  block3.exercises.build(movement: clean, position: 2, reps: 12, female_load: 85, male_load: 135, load_unit: :lb)
+  block3.exercises.build(movement: over_the_bar_burpee, position: 3, reps: 12)
+  block3.exercises.build(movement: thruster, position: 4, reps: 12, female_load: 85, male_load: 135, load_unit: :lb)
 end

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -33,6 +33,22 @@ class WorkoutsHelperTest < ActionView::TestCase
     assert_equal 'On a 20-minute clock for total reps', workout_objective(workouts(:segmented_total_reps))
   end
 
+  test 'renders segmented rep-scored clocks from segment windows' do
+    workout = Workout.new(name: 'Windowed Reps', score_type: :rep)
+
+    first = workout.segments.build(time_seconds: 300, position: 1)
+    workout.exercises.build(movement: movements(:run), segment: first, position: 1,
+                            reps: 1, distance: 200, distance_unit: :meter)
+    workout.exercises.build(movement: movements(:pushup), segment: first, position: 2, reps: 0)
+
+    second = workout.segments.build(time_seconds: 300, position: 2)
+    workout.exercises.build(movement: movements(:run), segment: second, position: 1,
+                            reps: 1, distance: 200, distance_unit: :meter)
+    workout.exercises.build(movement: movements(:pullup), segment: second, position: 2, reps: 0)
+
+    assert_equal 'On a 10-minute clock for total reps', workout_objective(workout)
+  end
+
   test 'renders timed rep-scored rounds as round amraps' do
     workout = workouts(:back_squat_5x5)
     workout.update!(time: 3, score_type: :rep)

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -32,6 +32,23 @@ class WorkoutTest < ActiveSupport::TestCase
     assert_predicate workouts(:segmented_total_reps), :segmented_total_reps?
   end
 
+  test 'identifies segmented total-rep clocks from segment windows' do
+    workout = Workout.new(name: 'Windowed Reps', score_type: :rep)
+
+    first = workout.segments.build(time_seconds: 300, position: 1)
+    workout.exercises.build(movement: movements(:run), segment: first, position: 1,
+                            reps: 1, distance: 200, distance_unit: :meter)
+    workout.exercises.build(movement: movements(:pushup), segment: first, position: 2, reps: 0)
+
+    second = workout.segments.build(time_seconds: 300, position: 2)
+    workout.exercises.build(movement: movements(:run), segment: second, position: 1,
+                            reps: 1, distance: 200, distance_unit: :meter)
+    workout.exercises.build(movement: movements(:pullup), segment: second, position: 2, reps: 0)
+
+    assert_predicate workout, :segmented_total_reps?
+    assert_equal 10, workout.segmented_total_reps_minutes
+  end
+
   test 'does not identify empty segmented clocks as total-rep clocks' do
     workout = Workout.new(name: 'Empty Segments', time: 20, score_type: :rep)
     workout.segments.build(time_seconds: 300, position: 1)


### PR DESCRIPTION
## Summary

- Rewrites benchmark, CrossFit.com, Open, and Hero workout seed files so every exercise is built through a `Segment`.
- Moves workout-level rounds, time caps, and interval schemes onto the appropriate segment.
- Preserves mixed-workout structure for cases like Alec and Brenton while making exercise positions local to each segment.

Closes #1753.

## Verification

- Cross-file forbidden-pattern grep over the four seed files returned no matches.
- `git diff --check`
- `RAILS_ENV=development rvm 4.0.5@wod-tracker do bundle exec rails db:reset db:seed`
- Rails runner assertions:
  - `Workouts with a top-level exercise: 0`
  - `Alec segments: [[1, 3, 3], [2, nil, 3], [5, 5, 3]]`
- `rvm 4.0.5@wod-tracker do bundle exec rubocop db/seeds/` exited 0, though this repo config reports `Inspecting 0 files`; per-file RuboCop checks were also run during task implementation.

Note: RVM/Rails commands emit existing Bundler/RubyGems constant redefinition warnings.