### PR TITLE
Render exercise notes in workout prescriptions

### DIFF
--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -1,6 +1,6 @@
 module MeasurableHelper
   def measurable_message(measurable)
-    [measurable_movement_msg(measurable), measurable_additional_metrics(measurable)].compact.join(' ')
+    [measurable_movement_msg(measurable), measurable_additional_metrics(measurable), measurable_notes(measurable)].compact.join(' ')
   end
 
   def measurable_movement_msg(measurable)
@@ -48,6 +48,12 @@ module MeasurableHelper
     return "(#{sex_specific_metrics_msg(metrics)})" if grouped_sex_specific_metrics?(metrics)
 
     "(#{metrics.map { |metric| metric_unit_msg(metric) }.join(' / ')})"
+  end
+
+  def measurable_notes(measurable)
+    return unless measurable.respond_to?(:notes) && measurable.notes.present?
+
+    "(#{measurable.notes})"
   end
 
   def additional_metrics(measurable)

--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -53,7 +53,7 @@ module MeasurableHelper
   def measurable_notes(measurable)
     return unless measurable.respond_to?(:notes) && measurable.notes.present?
 
-    "(#{measurable.notes})"
+    "** #{measurable.notes}"
   end
 
   def additional_metrics(measurable)

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -9,18 +9,9 @@ class MeasurableHelperTest < ActionView::TestCase
 
   test 'renders sex-specific additional exercise metrics' do
     exercise = exercises(:fran_pullup)
-    exercise.update!(load_unit: :lb, female_load: 65, male_load: 95)
+    exercise.update!(load_unit: :lb, female_load: 65, male_load: 95, notes: 'Carry a plate.')
 
-    assert_equal 'Pull Up (♀65lb / ♂95lb)', measurable_message(exercise)
-  end
-
-  test 'renders exercise notes after the prescription' do
-    exercise = workouts(:murph).segments.first.exercises.create!(movement: movements(:run), position: 6, reps: 1,
-                                                                 distance: 400, distance_unit: :meter,
-                                                                 load_unit: :lb, female_load: 25, male_load: 45,
-                                                                 notes: 'Carry a plate.')
-
-    assert_equal '400 meter Run (♀25lb / ♂45lb) ** Carry a plate.', measurable_message(exercise)
+    assert_equal 'Pull Up (♀65lb / ♂95lb) ** Carry a plate.', measurable_message(exercise)
   end
 
   test 'renders multi-implement dumbbell load with a count prefix' do

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -14,6 +14,15 @@ class MeasurableHelperTest < ActionView::TestCase
     assert_equal 'Pull Up (♀65lb / ♂95lb)', measurable_message(exercise)
   end
 
+  test 'renders exercise notes after the prescription' do
+    exercise = workouts(:murph).segments.first.exercises.create!(movement: movements(:run), position: 6, reps: 1,
+                                                                 distance: 400, distance_unit: :meter,
+                                                                 load_unit: :lb, female_load: 25, male_load: 45,
+                                                                 notes: 'Carry a plate.')
+
+    assert_equal '400 meter Run (♀25lb / ♂45lb) (Carry a plate.)', measurable_message(exercise)
+  end
+
   test 'renders multi-implement dumbbell load with a count prefix' do
     thruster = Movement.create!(name: 'Dumbbell Thruster')
     exercise = workouts(:fran).segments.first.exercises.create!(movement: thruster, position: 3, reps: 10,

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -20,7 +20,7 @@ class MeasurableHelperTest < ActionView::TestCase
                                                                  load_unit: :lb, female_load: 25, male_load: 45,
                                                                  notes: 'Carry a plate.')
 
-    assert_equal '400 meter Run (♀25lb / ♂45lb) (Carry a plate.)', measurable_message(exercise)
+    assert_equal '400 meter Run (♀25lb / ♂45lb) ** Carry a plate.', measurable_message(exercise)
   end
 
   test 'renders multi-implement dumbbell load with a count prefix' do


### PR DESCRIPTION
## Summary

- Append exercise-level notes to rendered workout prescription lines.
- Cover the Hero workout plate-carry case with a helper regression test.

## Root Cause

Workout show pages render each exercise through `measurable_message`, but that formatter only included movement text and prescription metrics. Exercise notes such as `Carry a plate.` were stored in the seed data but dropped from display.

## Validation

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/helpers/measurable_prescribed_work_helper_test.rb test/helpers/measurable_helper_test.rb`
- Result: 32 runs, 42 assertions, 0 failures, 0 errors