### PR TITLE
Fix unfollow for legacy program subscriptions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,6 +59,7 @@ class Ability
   end
 
   def unsubscribable_role?(subscription)
+    # role.nil? supports legacy rows until the backfill has run everywhere.
     subscription.athlete? || subscription.coach? || subscription.role.nil?
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,7 +33,7 @@ class Ability
     can [:create, :subscribe], Program
     can [:update, :destroy], Program, subscriptions: { user_id: user.id, role: :owner }
     cannot :subscribe, Program, subscriptions: { user_id: user.id }
-    can :unsubscribe, Program, subscriptions: { user_id: user.id, role: [:athlete, :coach] }
+    can(:unsubscribe, Program) { |program| unsubscribable_program?(program, user) }
 
     can :create, Schedule do |schedule|
       user.programs.manageable.include?(schedule.program)
@@ -48,5 +48,17 @@ class Ability
     cannot :subscribe, Program do |program|
       program.subscriptions.any? { |s| s.user_id == user.id }
     end
+  end
+
+  private
+
+  def unsubscribable_program?(program, user)
+    program.subscriptions.any? do |subscription|
+      subscription.user_id == user.id && unsubscribable_role?(subscription)
+    end
+  end
+
+  def unsubscribable_role?(subscription)
+    subscription.athlete? || subscription.coach? || subscription.role.nil?
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,5 +4,6 @@ class Subscription < ApplicationRecord
   belongs_to :program
   belongs_to :user
 
+  validates :role, presence: true
   validates :program, uniqueness: { scope: :user }
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,6 +4,7 @@ class Subscription < ApplicationRecord
   belongs_to :program
   belongs_to :user
 
+  # Existing nil roles are repaired by BackfillRolelessSubscriptions before this validation matters.
   validates :role, presence: true
   validates :program, uniqueness: { scope: :user }
 end

--- a/db/migrate/20250311180449_change_role_to_enum_in_subscription.rb
+++ b/db/migrate/20250311180449_change_role_to_enum_in_subscription.rb
@@ -4,13 +4,13 @@ class ChangeRoleToEnumInSubscription < ActiveRecord::Migration[8.0]
     add_column :subscriptions, :role_int, :integer
 
     # Step 2: Map existing string values to integers
-    role_mapping = { 'owner' => 0, 'coach' => 1, 'athlete' => 2 }
+    role_mapping = { 'owner' => 0, 'coach' => 1, 'athelete' => 2 }
 
     Subscription.reset_column_information
     Subscription.find_each do |subscription|
-      next unless role_mapping.key?(subscription.role)
-
-      subscription.update_columns(role_int: role_mapping[subscription.role]) # rubocop:disable Rails/SkipsModelValidations
+      if role_mapping.key?(subscription.role)
+        subscription.update_columns(role_int: role_mapping[subscription.role])
+      end
     end
 
     # Step 3: Remove old string column and rename new column
@@ -22,13 +22,13 @@ class ChangeRoleToEnumInSubscription < ActiveRecord::Migration[8.0]
     # Rollback: Convert integer back to string
     add_column :subscriptions, :role_str, :string
 
-    role_mapping = { 0 => 'owner', 1 => 'coach', 2 => 'athlete' }
+    role_mapping = { 0 => 'owner', 1 => 'coach', 2 => 'athelete' }
 
     Subscription.reset_column_information
     Subscription.find_each do |subscription|
-      next unless role_mapping.key?(subscription.role)
-
-      subscription.update_columns(role_str: role_mapping[subscription.role]) # rubocop:disable Rails/SkipsModelValidations
+      if role_mapping.key?(subscription.role)
+        subscription.update_columns(role_str: role_mapping[subscription.role])
+      end
     end
 
     remove_column :subscriptions, :role

--- a/db/migrate/20250311180449_change_role_to_enum_in_subscription.rb
+++ b/db/migrate/20250311180449_change_role_to_enum_in_subscription.rb
@@ -4,13 +4,13 @@ class ChangeRoleToEnumInSubscription < ActiveRecord::Migration[8.0]
     add_column :subscriptions, :role_int, :integer
 
     # Step 2: Map existing string values to integers
-    role_mapping = { 'owner' => 0, 'coach' => 1, 'athelete' => 2 }
+    role_mapping = { 'owner' => 0, 'coach' => 1, 'athlete' => 2 }
 
     Subscription.reset_column_information
     Subscription.find_each do |subscription|
-      if role_mapping.key?(subscription.role)
-        subscription.update_columns(role_int: role_mapping[subscription.role])
-      end
+      next unless role_mapping.key?(subscription.role)
+
+      subscription.update_columns(role_int: role_mapping[subscription.role]) # rubocop:disable Rails/SkipsModelValidations
     end
 
     # Step 3: Remove old string column and rename new column
@@ -22,13 +22,13 @@ class ChangeRoleToEnumInSubscription < ActiveRecord::Migration[8.0]
     # Rollback: Convert integer back to string
     add_column :subscriptions, :role_str, :string
 
-    role_mapping = { 0 => 'owner', 1 => 'coach', 2 => 'athelete' }
+    role_mapping = { 0 => 'owner', 1 => 'coach', 2 => 'athlete' }
 
     Subscription.reset_column_information
     Subscription.find_each do |subscription|
-      if role_mapping.key?(subscription.role)
-        subscription.update_columns(role_str: role_mapping[subscription.role])
-      end
+      next unless role_mapping.key?(subscription.role)
+
+      subscription.update_columns(role_str: role_mapping[subscription.role]) # rubocop:disable Rails/SkipsModelValidations
     end
 
     remove_column :subscriptions, :role

--- a/db/migrate/20260716180000_backfill_roleless_subscriptions.rb
+++ b/db/migrate/20260716180000_backfill_roleless_subscriptions.rb
@@ -5,13 +5,14 @@ class BackfillRolelessSubscriptions < ActiveRecord::Migration[8.1]
 
   def up
     # rubocop:disable Rails/SkipsModelValidations
-    MigrationSubscription.where(role: nil).update_all(role: 2)
+    MigrationSubscription.where(role: nil).in_batches.update_all(role: 2)
     # rubocop:enable Rails/SkipsModelValidations
 
     change_column_default :subscriptions, :role, from: nil, to: 2
   end
 
   def down
+    # Data-only backfill is intentionally not reversible; only restore the schema default.
     change_column_default :subscriptions, :role, from: 2, to: nil
   end
 end

--- a/db/migrate/20260716180000_backfill_roleless_subscriptions.rb
+++ b/db/migrate/20260716180000_backfill_roleless_subscriptions.rb
@@ -8,6 +8,7 @@ class BackfillRolelessSubscriptions < ActiveRecord::Migration[8.1]
     MigrationSubscription.where(role: nil).in_batches.update_all(role: 2)
     # rubocop:enable Rails/SkipsModelValidations
 
+    # New subscriptions without an explicit role should behave like a normal follow.
     change_column_default :subscriptions, :role, from: nil, to: 2
   end
 

--- a/db/migrate/20260716180000_backfill_roleless_subscriptions.rb
+++ b/db/migrate/20260716180000_backfill_roleless_subscriptions.rb
@@ -1,0 +1,17 @@
+class BackfillRolelessSubscriptions < ActiveRecord::Migration[8.1]
+  class MigrationSubscription < ActiveRecord::Base
+    self.table_name = 'subscriptions'
+  end
+
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    MigrationSubscription.where(role: nil).update_all(role: 2)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    change_column_default :subscriptions, :role, from: nil, to: 2
+  end
+
+  def down
+    change_column_default :subscriptions, :role, from: 2, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_16_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -277,7 +277,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_120000) do
   create_table "subscriptions", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.bigint "program_id"
-    t.integer "role"
+    t.integer "role", default: 2
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.index ["program_id", "user_id"], name: "index_subscriptions_on_program_id_and_user_id", unique: true

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -44,6 +44,17 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?][data-turbo-method="delete"]', program_path(programs(:crossfit))
   end
 
+  test 'program actions allow legacy roleless subscribers to unsubscribe' do
+    # rubocop:disable Rails/SkipsModelValidations
+    subscriptions(:one).update_column(:role, nil)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    get program_url(programs(:crossfit))
+
+    assert_response :success
+    assert_select 'a[href=?][data-turbo-method="delete"]', unsubscribe_program_path(programs(:crossfit))
+  end
+
   test 'log deletion uses turbo method' do
     get log_url(logs(:matt_murph))
 

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -3,7 +3,9 @@
 one:
   program: crossfit
   user: mathew
+  role: athlete
 
 two:
   program: local_gym
   user: brooke
+  role: athlete

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class SubscriptionTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'requires a role' do
+    subscription = Subscription.new(program: programs(:crossfit), user: users(:brooke), role: nil)
+
+    assert_not subscription.valid?
+    assert_includes subscription.errors[:role], "can't be blank"
+  end
 end


### PR DESCRIPTION
## Summary

- Allow legacy roleless program subscriptions to render the Unfollow action
- Backfill roleless subscriptions to the athlete role and add an athlete default for future rows
- Correct the historical subscription role enum migration typo from `athelete` to `athlete`
- Add regression coverage for the program action UI and role validation

## Root Cause

The old subscription role enum migration mapped the misspelled string `athelete`, so existing `athlete` subscriptions could become `role = nil`. Those rows still made `Current.user.subscribed?` return true, but `can? :unsubscribe` only allowed explicit `athlete` or `coach` roles, so the Unfollow button did not render.

## Validation

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/models/subscription_test.rb test/controllers/turbo_conventions_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rubocop app/models/ability.rb app/models/subscription.rb db/migrate/20250311180449_change_role_to_enum_in_subscription.rb db/migrate/20260716180000_backfill_roleless_subscriptions.rb test/controllers/turbo_conventions_test.rb test/models/subscription_test.rb`
- `git diff --check`