### PR TITLE
Redirect after program membership changes

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -40,12 +40,12 @@ class ProgramsController < ApplicationController
 
   def subscribe
     @program.subscriptions.create(user: current_user, role: :athlete).save
-    render :show
+    redirect_to @program, status: :see_other
   end
 
   def unsubscribe
     @program.subscriptions.find_by(user: current_user).destroy
-    render :show
+    redirect_to @program, status: :see_other
   end
 
   private

--- a/test/controllers/turbo_conventions_test.rb
+++ b/test/controllers/turbo_conventions_test.rb
@@ -55,6 +55,18 @@ class TurboConventionsTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?][data-turbo-method="delete"]', unsubscribe_program_path(programs(:crossfit))
   end
 
+  test 'program unsubscribe redirects to reload action buttons' do
+    delete unsubscribe_program_url(programs(:crossfit))
+
+    assert_response :see_other
+    assert_redirected_to program_url(programs(:crossfit))
+
+    follow_redirect!
+
+    assert_select 'a[href=?][data-turbo-method="delete"]', unsubscribe_program_path(programs(:crossfit)), false
+    assert_select 'a[href=?][data-turbo-method="post"]', subscribe_program_path(programs(:crossfit))
+  end
+
   test 'log deletion uses turbo method' do
     get log_url(logs(:matt_murph))
 


### PR DESCRIPTION
## Summary
- Redirect program subscribe/unsubscribe actions with `303 See Other` instead of rendering `show` directly.
- Add a regression test proving unsubscribe reloads the program action buttons and removes the stale unfollow link.

## Root Cause
`load_and_authorize_resource` can load and cache `@program.subscriptions` while authorizing the request. The unsubscribe action then destroyed the subscription but rendered `show` with the same in-memory `@program`, so the stale subscription could still make the Unfollow button render. Clicking it again then hit a missing subscription path and could error.

## Verification
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/turbo_conventions_test.rb -n "test_program_unsubscribe_redirects_to_reload_action_buttons"`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/turbo_conventions_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rubocop app/controllers/programs_controller.rb test/controllers/turbo_conventions_test.rb`
- `git diff --check`