### PR TITLE
Hide admin link from regular users

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,7 +28,7 @@ html lang="en"
                 = link_to '#', class: 'nav-link dropdown-toggle', id: "navbarDropdownMenuLink", "data-bs-toggle": "dropdown", role: "button", aria: { expanded: "false" }
                   i.fas.fa-user
                 .dropdown-menu.dropdown-menu-end aria-labelledby="navbarDropdownMenuLink"
-                  = link_to 'Admin', rails_admin_path, class: 'dropdown-item'
+                  = link_to 'Admin', rails_admin_path, class: 'dropdown-item' if Current.user.admin?
                   = link_to 'Edit Profile', edit_user_registration_path, class: 'dropdown-item'
                   = link_to 'Logout', destroy_user_session_path, data: { turbo_method: :delete }, class: 'dropdown-item'
     = render partial: 'flash', flash: flash

--- a/test/controllers/application_layout_visibility_test.rb
+++ b/test/controllers/application_layout_visibility_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ApplicationLayoutVisibilityTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'does not render admin link for regular users' do
+    users(:mathew).update!(role: :user)
+
+    sign_in users(:mathew)
+    get workouts_url
+
+    assert_response :success
+    assert_select 'a[href=?]', rails_admin_path, count: 0
+  end
+
+  test 'renders admin link for admin users' do
+    users(:brooke).update!(role: :admin)
+
+    sign_in users(:brooke)
+    get workouts_url
+
+    assert_response :success
+    assert_select 'a[href=?]', rails_admin_path, text: 'Admin'
+  end
+end


### PR DESCRIPTION
## Summary

- Hide the Admin dropdown link unless the signed-in user has the admin role.
- Add layout regression coverage for regular and admin users.

## Root Cause

The shared application layout rendered the RailsAdmin link unconditionally for every signed-in user, even though admin authorization already exists elsewhere in the app.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/application_layout_visibility_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/workouts_controller_test.rb`