### PR TITLE
Tighten mobile workout form layout

### DIFF
--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -104,6 +104,20 @@
   margin-top: 2rem;
 }
 
+.exercise-editor__optional-groups {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.exercise-editor__optional-groups > .btn-group {
+  justify-content: flex-start;
+}
+
+.exercise-editor__optional-panel {
+  padding-top: 0.5rem;
+}
+
 @media (max-width: 575.98px) {
   .workout-form .form-label {
     font-size: 0.875rem;

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -105,6 +105,40 @@
 }
 
 @media (max-width: 575.98px) {
+  .workout-form .form-label {
+    font-size: 0.875rem;
+    line-height: 1.2;
+    margin-bottom: 0.25rem;
+  }
+
+  .workout-form .form-text {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    margin-top: 0.25rem;
+  }
+
+  .workout-form .form-control,
+  .workout-form .form-select,
+  .workout-form .ts-control {
+    min-height: 2.5rem;
+    padding-block: 0.375rem;
+  }
+
+  .workout-form trix-toolbar {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .workout-form trix-toolbar .trix-button-row {
+    flex-wrap: nowrap;
+  }
+
+  .workout-form trix-editor {
+    min-height: 7rem;
+  }
+
   .workout-card-toolbar .btn {
     flex: 1 1 8rem;
   }

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -91,6 +91,42 @@
   min-width: 0;
 }
 
+.exercise-editor.card {
+  background: var(--bs-body-bg);
+  border-color: var(--bs-border-color);
+  margin-top: 0.5rem;
+  overflow: hidden;
+}
+
+.exercise-editor__header,
+.exercise-editor__footer {
+  align-items: center;
+  background: var(--bs-tertiary-bg);
+  display: flex;
+  justify-content: space-between;
+}
+
+.exercise-editor__header {
+  border-bottom: 1px solid var(--bs-border-color);
+  min-height: 3rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.exercise-editor__footer {
+  border-top: 1px solid var(--bs-border-color);
+  gap: 0.5rem;
+  justify-content: flex-end;
+  padding: 0.5rem 0.75rem;
+}
+
+.exercise-editor__eyebrow {
+  color: var(--bs-secondary-color);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .exercise-editor__delete {
   align-items: center;
   display: inline-flex;
@@ -100,16 +136,8 @@
   min-width: 2.25rem;
 }
 
-.exercise-editor__delete {
-  margin-top: 2rem;
-}
-
-.exercise-editor.card {
-  border: 0;
-}
-
 .exercise-editor.card > .card-body {
-  padding-inline: 0;
+  padding: 0.75rem;
 }
 
 .exercise-editor__help {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -104,6 +104,39 @@
   margin-top: 2rem;
 }
 
+.exercise-editor.card {
+  border: 0;
+}
+
+.exercise-editor.card > .card-body {
+  padding-inline: 0;
+}
+
+.exercise-editor__help {
+  align-items: center;
+  background: var(--bs-secondary-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 50%;
+  color: var(--bs-secondary-color);
+  display: inline-flex;
+  font-size: 0.625rem;
+  font-weight: 700;
+  height: 1rem;
+  justify-content: center;
+  line-height: 1;
+  margin-left: 0.25rem;
+  padding: 0;
+  vertical-align: 0.125rem;
+  width: 1rem;
+}
+
+.exercise-editor__help:focus,
+.exercise-editor__help:hover {
+  background: var(--bs-primary-bg-subtle);
+  border-color: var(--bs-primary-border-subtle);
+  color: var(--bs-primary-text-emphasis);
+}
+
 .exercise-editor__optional-groups {
   display: grid;
   gap: 0.375rem;
@@ -129,9 +162,6 @@
   align-items: center;
   color: var(--bs-secondary-color);
   display: inline-flex;
-  font-size: 0.75rem;
-  font-weight: 500;
-  gap: 0.5rem;
   line-height: 1;
 }
 
@@ -145,11 +175,6 @@
   transition: transform 0.15s ease-in-out;
 }
 
-.exercise-editor__optional-toggle:not(.collapsed) .exercise-editor__optional-state--closed,
-.exercise-editor__optional-toggle.collapsed .exercise-editor__optional-state--open {
-  display: none;
-}
-
 .exercise-editor__optional-toggle:not(.collapsed) .exercise-editor__optional-toggle-meta {
   color: inherit;
 }
@@ -159,9 +184,8 @@
 }
 
 .exercise-editor__optional-panel {
-  border-left: 2px solid var(--bs-primary-border-subtle);
-  margin: 0 0 0.25rem 0.5rem;
-  padding: 0.5rem 0 0.25rem 0.75rem;
+  margin: 0 0 0.375rem;
+  padding: 0.625rem 0 0.375rem;
 }
 
 @media (max-width: 575.98px) {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -106,16 +106,62 @@
 
 .exercise-editor__optional-groups {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.375rem;
   margin-top: 0.5rem;
 }
 
-.exercise-editor__optional-groups > .btn-group {
-  justify-content: flex-start;
+.exercise-editor__optional-toggle {
+  align-items: center;
+  display: flex;
+  font-weight: 600;
+  justify-content: space-between;
+  text-align: left;
+  width: 100%;
+}
+
+.exercise-editor__optional-toggle:not(.collapsed) {
+  background: var(--bs-primary-bg-subtle);
+  border-color: var(--bs-primary-border-subtle);
+  color: var(--bs-primary-text-emphasis);
+}
+
+.exercise-editor__optional-toggle-meta {
+  align-items: center;
+  color: var(--bs-secondary-color);
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 500;
+  gap: 0.5rem;
+  line-height: 1;
+}
+
+.exercise-editor__optional-toggle-meta::after {
+  border-bottom: 0;
+  border-left: 0.3em solid transparent;
+  border-right: 0.3em solid transparent;
+  border-top: 0.3em solid currentcolor;
+  content: "";
+  display: inline-block;
+  transition: transform 0.15s ease-in-out;
+}
+
+.exercise-editor__optional-toggle:not(.collapsed) .exercise-editor__optional-state--closed,
+.exercise-editor__optional-toggle.collapsed .exercise-editor__optional-state--open {
+  display: none;
+}
+
+.exercise-editor__optional-toggle:not(.collapsed) .exercise-editor__optional-toggle-meta {
+  color: inherit;
+}
+
+.exercise-editor__optional-toggle:not(.collapsed) .exercise-editor__optional-toggle-meta::after {
+  transform: rotate(180deg);
 }
 
 .exercise-editor__optional-panel {
-  padding-top: 0.5rem;
+  border-left: 2px solid var(--bs-primary-border-subtle);
+  margin: 0 0 0.25rem 0.5rem;
+  padding: 0.5rem 0 0.25rem 0.75rem;
 }
 
 @media (max-width: 575.98px) {

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -144,7 +144,7 @@
   align-items: center;
   display: flex;
   gap: 0.25rem;
-  min-height: 1.5rem;
+  min-height: 1.75rem;
 }
 
 .exercise-editor__help {
@@ -154,13 +154,14 @@
   border-radius: 50%;
   color: var(--bs-secondary-color);
   display: inline-flex;
+  flex: 0 0 1.75rem;
   font-size: 0.625rem;
   font-weight: 700;
-  height: 1.5rem;
+  height: 1.75rem;
   justify-content: center;
   line-height: 1;
   padding: 0;
-  width: 1.5rem;
+  width: 1.75rem;
 }
 
 .exercise-editor__help:focus,

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -140,6 +140,13 @@
   padding: 0.75rem;
 }
 
+.exercise-editor__field-label {
+  align-items: center;
+  display: flex;
+  gap: 0.25rem;
+  min-height: 1.5rem;
+}
+
 .exercise-editor__help {
   align-items: center;
   background: var(--bs-secondary-bg);
@@ -149,13 +156,11 @@
   display: inline-flex;
   font-size: 0.625rem;
   font-weight: 700;
-  height: 1rem;
+  height: 1.5rem;
   justify-content: center;
   line-height: 1;
-  margin-left: 0.25rem;
   padding: 0;
-  vertical-align: 0.125rem;
-  width: 1rem;
+  width: 1.5rem;
 }
 
 .exercise-editor__help:focus,

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -140,34 +140,32 @@
   padding: 0.75rem;
 }
 
-.exercise-editor__field-label {
+.workout-form__field-label {
   align-items: center;
   display: flex;
-  gap: 0.25rem;
-  min-height: 1.75rem;
+  gap: 0.125rem;
+  min-height: 1.5rem;
 }
 
-.exercise-editor__help {
+.workout-form__help {
   align-items: center;
-  background: var(--bs-secondary-bg);
-  border: 1px solid var(--bs-border-color);
+  background: transparent;
+  border: 0;
   border-radius: 50%;
   color: var(--bs-secondary-color);
   display: inline-flex;
-  flex: 0 0 1.75rem;
-  font-size: 0.625rem;
-  font-weight: 700;
-  height: 1.75rem;
+  flex: 0 0 1.5rem;
+  font-size: 0.875rem;
+  height: 1.5rem;
   justify-content: center;
   line-height: 1;
   padding: 0;
-  width: 1.75rem;
+  width: 1.5rem;
 }
 
-.exercise-editor__help:focus,
-.exercise-editor__help:hover {
-  background: var(--bs-primary-bg-subtle);
-  border-color: var(--bs-primary-border-subtle);
+.workout-form__help:focus,
+.workout-form__help:hover {
+  background: transparent;
   color: var(--bs-primary-text-emphasis);
 }
 

--- a/app/assets/stylesheets/workouts.scss
+++ b/app/assets/stylesheets/workouts.scss
@@ -151,11 +151,11 @@
   align-items: center;
   background: transparent;
   border: 0;
-  border-radius: 50%;
   color: var(--bs-secondary-color);
   display: inline-flex;
   flex: 0 0 1.5rem;
   font-size: 0.875rem;
+  font-weight: 700;
   height: 1.5rem;
   justify-content: center;
   line-height: 1;
@@ -172,6 +172,7 @@
 .exercise-editor__optional-groups {
   display: grid;
   gap: 0.375rem;
+  margin-bottom: 0.75rem;
   margin-top: 0.5rem;
 }
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,6 +7,7 @@ import "./controllers"
 import * as bootstrap from "bootstrap"
 import LocalTime from "local-time"
 import { dom, library } from "@fortawesome/fontawesome-svg-core"
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons/faCircleInfo"
 import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import { faDumbbell } from "@fortawesome/free-solid-svg-icons/faDumbbell"
@@ -22,6 +23,7 @@ import { faCheckSquare } from "@fortawesome/free-regular-svg-icons/faCheckSquare
 LocalTime.start()
 library.add(
   faCheckSquare,
+  faCircleInfo,
   faDumbbell,
   faEdit,
   faExternalLinkAlt,

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -321,7 +321,7 @@ export default class extends Controller {
   }
 
   durationText(value) {
-    const totalSeconds = parseInt(value, 10)
+    const totalSeconds = this.durationInSeconds(value)
     if (Number.isNaN(totalSeconds)) return value.trim()
 
     const hours = Math.floor(totalSeconds / 3600)
@@ -331,6 +331,17 @@ export default class extends Controller {
     if (hours > 0) return `${hours}:${this.pad(minutes)}:${this.pad(seconds)}`
 
     return `${minutes}:${this.pad(seconds)}`
+  }
+
+  durationInSeconds(value) {
+    const cleanValue = value.trim()
+    if (!cleanValue.includes(":")) return parseInt(cleanValue, 10)
+
+    return cleanValue
+      .split(":")
+      .map((part) => parseInt(part, 10))
+      .reverse()
+      .reduce((total, part, index) => total + (part * (60 ** index)), 0)
   }
 
   loadUnit() {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import WorkoutSearchController from "./workout_search_controller.js"
 application.register("workout-search", WorkoutSearchController)
 
+import TooltipController from "./tooltip_controller.js"
+application.register("tooltip", TooltipController)
+
 import MovementSelectController from "./movement_select_controller.js"
 application.register("movement-select", MovementSelectController)
 

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+import { Tooltip } from "bootstrap"
+
+export default class extends Controller {
+  connect() {
+    this.tooltip = new Tooltip(this.element)
+  }
+
+  disconnect() {
+    this.tooltip?.dispose()
+  }
+}

--- a/app/models/concerns/exercise_duration.rb
+++ b/app/models/concerns/exercise_duration.rb
@@ -1,0 +1,28 @@
+module ExerciseDuration
+  extend ActiveSupport::Concern
+
+  # Duration is stored as seconds, but forms accept "M:SS" or "H:MM:SS" for faster entry.
+  def duration_seconds=(value)
+    if value.is_a?(String) && value.include?(':')
+      super(duration_string_to_seconds(value))
+    else
+      super
+    end
+  end
+
+  def duration
+    return if duration_seconds.blank?
+
+    hours, remainder = duration_seconds.divmod(3600)
+    minutes, seconds = remainder.divmod(60)
+    return format('%<hours>d:%<minutes>02d:%<seconds>02d', hours:, minutes:, seconds:) if hours.positive?
+
+    format('%<minutes>d:%<seconds>02d', minutes:, seconds:)
+  end
+
+  private
+
+  def duration_string_to_seconds(value)
+    value.split(':').map(&:to_i).reverse.each_with_index.sum { |part, index| part * (60**index) }
+  end
+end

--- a/app/models/concerns/exercise_prescription.rb
+++ b/app/models/concerns/exercise_prescription.rb
@@ -1,6 +1,8 @@
 module ExercisePrescription
   extend ActiveSupport::Concern
 
+  SEX_PAIRED_DIMENSIONS = %i[load distance calories].freeze
+
   included do
     enum :distance_unit, { meter: 0, foot: 1, inch: 2 }, prefix: :distance_unit
 
@@ -66,6 +68,20 @@ module ExercisePrescription
     %i[load female_load male_load].each do |attribute|
       value = self[attribute]
       self[attribute] = LoadEquivalence.to_lb(value, @load_unit) if value.present?
+    end
+  end
+
+  def prescription_values_are_unambiguous
+    SEX_PAIRED_DIMENSIONS.each do |dimension|
+      value = self[dimension]
+      female = self[:"female_#{dimension}"]
+      male = self[:"male_#{dimension}"]
+
+      if value.present? && (female.present? || male.present?)
+        errors.add(dimension, 'cannot be set with sex-specific values')
+      elsif female.blank? != male.blank?
+        errors.add(:base, "#{dimension} requires both female and male values")
+      end
     end
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,9 +1,8 @@
 class Exercise < ApplicationRecord
+  include ExerciseDuration
   include ExercisePositionValidation
   include ExercisePrescription
   include RefreshesWorkoutContentKey
-
-  SEX_PAIRED_DIMENSIONS = %i[load distance calories].freeze
 
   belongs_to :movement
   belongs_to :segment
@@ -105,20 +104,6 @@ class Exercise < ApplicationRecord
 
   def scorable_metric?(metric)
     metric&.value.present? && metric.value.positive?
-  end
-
-  def prescription_values_are_unambiguous
-    SEX_PAIRED_DIMENSIONS.each do |dimension|
-      value = self[dimension]
-      female = self[:"female_#{dimension}"]
-      male = self[:"male_#{dimension}"]
-
-      if value.present? && (female.present? || male.present?)
-        errors.add(dimension, 'cannot be set with sex-specific values')
-      elsif female.blank? != male.blank?
-        errors.add(:base, "#{dimension} requires both female and male values")
-      end
-    end
   end
 
   def implement_count_requires_load

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -10,7 +10,7 @@
 - calories_collapse_id = "exercise-#{exercise_key}-calories"
 - tooltip_button = ->(title) do
   - content_tag(:button, type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) do
-    - content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true })
+    span aria-hidden="true" !
 - field_label = ->(attribute, label, title) do
   - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
 - editor_title = f.object.persisted? ? 'Editing Exercise' : 'New exercise'

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -10,10 +10,9 @@
 - calories_collapse_id = "exercise-#{exercise_key}-calories"
 - tooltip_button = ->(title) do
   - content_tag(:button, '?', type: 'button', class: 'exercise-editor__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title })
-- reps_label = safe_join(['Reps ', tooltip_button.call('0 = max reps; for a ladder, the round-1 reps')])
-- load_label = safe_join(["Load (#{load_display_unit}) ", tooltip_button.call('0 = find-a-max (no fixed load)')])
-- calories_label = safe_join(['Calories ', tooltip_button.call('0 = max calories')])
-- implements_label = safe_join(['Implements ', tooltip_button.call('e.g. 2 = double dumbbell')])
+- field_label = ->(attribute, label, title) do
+  - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
+- editor_title = f.object.persisted? ? 'Editing Exercise' : 'New exercise'
 
 .exercise.nested-fields.mb-3.segment-exercise data-controller="exercise-form exercise-card implement-count ladder-step" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError change->implement-count#toggle ladder-fields:change@document->ladder-step#toggle" data-exercise-card-expanded-value=expanded data-exercise-card-load-unit-value=load_display_unit data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
   = f.hidden_field :_destroy
@@ -29,7 +28,7 @@
           i.fas.fa-trash-alt aria-hidden="true"
       .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
         .exercise-editor__header
-          span.exercise-editor__eyebrow Editing Exercise
+          span.exercise-editor__eyebrow = editor_title
           = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
             i.fas.fa-trash-alt aria-hidden="true"
         .card-body
@@ -37,8 +36,12 @@
             .exercise-editor__movement
               = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect', 'implement-count-target': 'movementSelect' } }
           .row.g-2
-            .col-6.col-md-3 = f.input :reps, label: reps_label, input_html: { data: { 'exercise-card-target': 'repsInput' } }
-            .col-6.col-md-3 = f.input :duration_seconds, as: :string, label: 'Duration', placeholder: 'MM:SS', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
+            .col-6.col-md-3
+              .exercise-editor__field-label = field_label.call(:reps, 'Reps', '0 = max reps; for a ladder, the round-1 reps')
+              = f.input :reps, label: false, input_html: { data: { 'exercise-card-target': 'repsInput' } }
+            .col-6.col-md-3
+              .exercise-editor__field-label = f.label :duration_seconds, 'Duration', class: 'form-label mb-0'
+              = f.input :duration_seconds, as: :string, label: false, placeholder: 'MM:SS', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
             .col-6.col-md-3 data-ladder-step-target="exemptField" hidden=(!@workout&.ascending_ladder?)
               = f.input :ladder_exempt, as: :boolean, label: 'Constant (no ladder)', input_html: { data: { 'ladder-step-target': 'exempt', action: 'change->ladder-step#toggle' } }
             .col-6.col-md-3 data-ladder-step-target="stepEveryField" hidden=(!(@workout&.ascending_ladder? && !f.object.ladder_exempt))
@@ -50,11 +53,14 @@
             .collapse class=('show' if has_load) id=load_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
-                  .col-6.col-md-3 = f.input :load, label: load_label, input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
+                  .col-6.col-md-3
+                    .exercise-editor__field-label = field_label.call(:load, "Load (#{load_display_unit})", '0 = find-a-max (no fixed load)')
+                    = f.input :load, label: false, input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
                   .col-6.col-md-3 = f.input :female_load, label: "Female load (#{load_display_unit})", input_html: { value: load_input_value(f.object.female_load), data: { 'exercise-card-target': 'femaleLoadInput' } }
                   .col-6.col-md-3 = f.input :male_load, label: "Male load (#{load_display_unit})", input_html: { value: load_input_value(f.object.male_load), data: { 'exercise-card-target': 'maleLoadInput' } }
                   .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
-                    = f.input :implement_count, label: implements_label
+                    .exercise-editor__field-label = field_label.call(:implement_count, 'Implements', 'e.g. 2 = double dumbbell')
+                    = f.input :implement_count, label: false
             button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_distance) type="button" data-bs-toggle="collapse" data-bs-target="##{distance_collapse_id}" aria-expanded=has_distance.to_s aria-controls=distance_collapse_id
               span Distance
               span.exercise-editor__optional-toggle-meta aria-hidden="true"
@@ -73,7 +79,9 @@
             .collapse class=('show' if has_calories) id=calories_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
-                  .col-4.col-md-3 = f.input :calories, label: calories_label, input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
+                  .col-4.col-md-3
+                    .exercise-editor__field-label = field_label.call(:calories, 'Calories', '0 = max calories')
+                    = f.input :calories, label: false, input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
                   .col-4.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
                   .col-4.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
           .row.g-2

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -30,16 +30,17 @@
               i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
             .col-6.col-md-3 = f.input :reps, hint: '0 = max reps; for a ladder, the round-1 reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
-            .col-6.col-md-3 = f.input :duration_seconds, as: :string, label: 'Duration', placeholder: '1:30', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
+            .col-6.col-md-3 = f.input :duration_seconds, as: :string, label: 'Duration', placeholder: 'MM:SS', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
             .col-6.col-md-3 data-ladder-step-target="exemptField" hidden=(!@workout&.ascending_ladder?)
               = f.input :ladder_exempt, as: :boolean, label: 'Constant (no ladder)', input_html: { data: { 'ladder-step-target': 'exempt', action: 'change->ladder-step#toggle' } }
             .col-6.col-md-3 data-ladder-step-target="stepEveryField" hidden=(!(@workout&.ascending_ladder? && !f.object.ladder_exempt))
               = f.input :ladder_step_every, label: 'Ladder step every', hint: 'rounds between increments (blank = each round)'
           .exercise-editor__optional-groups
-            .btn-group.btn-group-sm role="group" aria-label="Optional exercise fields"
-              button.btn.btn-outline-secondary class=('collapsed' unless has_load) type="button" data-bs-toggle="collapse" data-bs-target="##{load_collapse_id}" aria-expanded=has_load aria-controls=load_collapse_id Load
-              button.btn.btn-outline-secondary class=('collapsed' unless has_distance) type="button" data-bs-toggle="collapse" data-bs-target="##{distance_collapse_id}" aria-expanded=has_distance aria-controls=distance_collapse_id Distance
-              button.btn.btn-outline-secondary class=('collapsed' unless has_calories) type="button" data-bs-toggle="collapse" data-bs-target="##{calories_collapse_id}" aria-expanded=has_calories aria-controls=calories_collapse_id Calories
+            button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_load) type="button" data-bs-toggle="collapse" data-bs-target="##{load_collapse_id}" aria-expanded=has_load.to_s aria-controls=load_collapse_id
+              span Load
+              span.exercise-editor__optional-toggle-meta
+                span.exercise-editor__optional-state.exercise-editor__optional-state--open Shown
+                span.exercise-editor__optional-state.exercise-editor__optional-state--closed Hidden
             .collapse class=('show' if has_load) id=load_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
@@ -48,6 +49,11 @@
                   .col-6.col-md-3 = f.input :male_load, label: "Male load (#{load_display_unit})", input_html: { value: load_input_value(f.object.male_load), data: { 'exercise-card-target': 'maleLoadInput' } }
                   .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
                     = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
+            button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_distance) type="button" data-bs-toggle="collapse" data-bs-target="##{distance_collapse_id}" aria-expanded=has_distance.to_s aria-controls=distance_collapse_id
+              span Distance
+              span.exercise-editor__optional-toggle-meta
+                span.exercise-editor__optional-state.exercise-editor__optional-state--open Shown
+                span.exercise-editor__optional-state.exercise-editor__optional-state--closed Hidden
             .collapse class=('show' if has_distance) id=distance_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
@@ -57,6 +63,11 @@
                   .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect', 'exercise-card-target': 'distanceUnitSelect' } }
                   .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
                     = f.input :distance_units_per_rep, label: 'Distance units per rep'
+            button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_calories) type="button" data-bs-toggle="collapse" data-bs-target="##{calories_collapse_id}" aria-expanded=has_calories.to_s aria-controls=calories_collapse_id
+              span Calories
+              span.exercise-editor__optional-toggle-meta
+                span.exercise-editor__optional-state.exercise-editor__optional-state--open Shown
+                span.exercise-editor__optional-state.exercise-editor__optional-state--closed Hidden
             .collapse class=('show' if has_calories) id=calories_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -28,12 +28,14 @@
         = link_to '#', class: 'exercise-summary__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
           i.fas.fa-trash-alt aria-hidden="true"
       .exercise-editor.card data-exercise-card-target="editor" hidden=(!expanded)
+        .exercise-editor__header
+          span.exercise-editor__eyebrow Editing Exercise
+          = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
+            i.fas.fa-trash-alt aria-hidden="true"
         .card-body
           .exercise-editor__movement-row
             .exercise-editor__movement
               = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect', 'implement-count-target': 'movementSelect' } }
-            = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
-              i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
             .col-6.col-md-3 = f.input :reps, label: reps_label, input_html: { data: { 'exercise-card-target': 'repsInput' } }
             .col-6.col-md-3 = f.input :duration_seconds, as: :string, label: 'Duration', placeholder: 'MM:SS', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
@@ -76,5 +78,5 @@
                   .col-4.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
           .row.g-2
             .col = f.input :notes
-          .workout-card-toolbar.mt-2
-            button.btn.btn-sm.btn-primary type="button" data-action="click->exercise-card#save" Done
+        .exercise-editor__footer
+          button.btn.btn-sm.btn-primary type="button" data-action="click->exercise-card#save" Done

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -1,7 +1,13 @@
 - has_distance = f.object.distance.present? || f.object.female_distance.present? || f.object.male_distance.present? || f.object.distance_unit.present?
+- has_load = f.object.load.present? || f.object.female_load.present? || f.object.male_load.present? || f.object.implement_count.present?
+- has_calories = f.object.calories.present? || f.object.female_calories.present? || f.object.male_calories.present?
 - distance_units_hidden = f.object.distance_units_per_rep.blank? && !has_distance
 - expanded = f.object.new_record?
 - summary = f.object.persisted? ? measurable_message(f.object) : 'New exercise'
+- exercise_key = f.object_name.gsub(/\W+/, '_')
+- load_collapse_id = "exercise-#{exercise_key}-load"
+- distance_collapse_id = "exercise-#{exercise_key}-distance"
+- calories_collapse_id = "exercise-#{exercise_key}-calories"
 
 .exercise.nested-fields.mb-3.segment-exercise data-controller="exercise-form exercise-card implement-count ladder-step" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError change->implement-count#toggle ladder-fields:change@document->ladder-step#toggle" data-exercise-card-expanded-value=expanded data-exercise-card-load-unit-value=load_display_unit data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
   = f.hidden_field :_destroy
@@ -23,29 +29,40 @@
             = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
               i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
-            .col-4.col-md-3 = f.input :reps, hint: '0 = max reps; for a ladder, the round-1 reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
-            .col-4.col-md-3 = f.input :duration_seconds, label: 'Duration (s)', input_html: { data: { 'exercise-card-target': 'durationInput' } }
-            .col-4.col-md-3 = f.input :calories, hint: '0 = max calories', input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
+            .col-6.col-md-3 = f.input :reps, hint: '0 = max reps; for a ladder, the round-1 reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
+            .col-6.col-md-3 = f.input :duration_seconds, as: :string, label: 'Duration', placeholder: '1:30', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
             .col-6.col-md-3 data-ladder-step-target="exemptField" hidden=(!@workout&.ascending_ladder?)
               = f.input :ladder_exempt, as: :boolean, label: 'Constant (no ladder)', input_html: { data: { 'ladder-step-target': 'exempt', action: 'change->ladder-step#toggle' } }
             .col-6.col-md-3 data-ladder-step-target="stepEveryField" hidden=(!(@workout&.ascending_ladder? && !f.object.ladder_exempt))
               = f.input :ladder_step_every, label: 'Ladder step every', hint: 'rounds between increments (blank = each round)'
-          .row.g-2
-            .col-6.col-md-3 = f.input :load, label: "Load (#{load_display_unit})", hint: '0 = find-a-max (no fixed load)', input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
-            .col-6.col-md-3 = f.input :female_load, label: "Female load (#{load_display_unit})", input_html: { value: load_input_value(f.object.female_load), data: { 'exercise-card-target': 'femaleLoadInput' } }
-            .col-6.col-md-3 = f.input :male_load, label: "Male load (#{load_display_unit})", input_html: { value: load_input_value(f.object.male_load), data: { 'exercise-card-target': 'maleLoadInput' } }
-            .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
-              = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
-          .row.g-2
-            .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'distanceInput' } }
-            .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'femaleDistanceInput' } }
-            .col-6.col-md-3 = f.input :male_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'maleDistanceInput' } }
-            .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect', 'exercise-card-target': 'distanceUnitSelect' } }
-          .row.g-2
-            .col-6.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
-            .col-6.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
-            .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
-              = f.input :distance_units_per_rep, label: 'Distance units per rep'
+          .exercise-editor__optional-groups
+            .btn-group.btn-group-sm role="group" aria-label="Optional exercise fields"
+              button.btn.btn-outline-secondary class=('collapsed' unless has_load) type="button" data-bs-toggle="collapse" data-bs-target="##{load_collapse_id}" aria-expanded=has_load aria-controls=load_collapse_id Load
+              button.btn.btn-outline-secondary class=('collapsed' unless has_distance) type="button" data-bs-toggle="collapse" data-bs-target="##{distance_collapse_id}" aria-expanded=has_distance aria-controls=distance_collapse_id Distance
+              button.btn.btn-outline-secondary class=('collapsed' unless has_calories) type="button" data-bs-toggle="collapse" data-bs-target="##{calories_collapse_id}" aria-expanded=has_calories aria-controls=calories_collapse_id Calories
+            .collapse class=('show' if has_load) id=load_collapse_id
+              .exercise-editor__optional-panel
+                .row.g-2
+                  .col-6.col-md-3 = f.input :load, label: "Load (#{load_display_unit})", hint: '0 = find-a-max (no fixed load)', input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
+                  .col-6.col-md-3 = f.input :female_load, label: "Female load (#{load_display_unit})", input_html: { value: load_input_value(f.object.female_load), data: { 'exercise-card-target': 'femaleLoadInput' } }
+                  .col-6.col-md-3 = f.input :male_load, label: "Male load (#{load_display_unit})", input_html: { value: load_input_value(f.object.male_load), data: { 'exercise-card-target': 'maleLoadInput' } }
+                  .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
+                    = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
+            .collapse class=('show' if has_distance) id=distance_collapse_id
+              .exercise-editor__optional-panel
+                .row.g-2
+                  .col-6.col-md-3 = f.input :distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'distanceInput' } }
+                  .col-6.col-md-3 = f.input :female_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'femaleDistanceInput' } }
+                  .col-6.col-md-3 = f.input :male_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'maleDistanceInput' } }
+                  .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect', 'exercise-card-target': 'distanceUnitSelect' } }
+                  .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden
+                    = f.input :distance_units_per_rep, label: 'Distance units per rep'
+            .collapse class=('show' if has_calories) id=calories_collapse_id
+              .exercise-editor__optional-panel
+                .row.g-2
+                  .col-4.col-md-3 = f.input :calories, hint: '0 = max calories', input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
+                  .col-4.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
+                  .col-4.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
           .row.g-2
             .col = f.input :notes
           .workout-card-toolbar.mt-2

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -8,7 +8,7 @@
 - load_collapse_id = "exercise-#{exercise_key}-load"
 - distance_collapse_id = "exercise-#{exercise_key}-distance"
 - calories_collapse_id = "exercise-#{exercise_key}-calories"
-- tooltip_button = ->(title) { content_tag(:button, content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true }), type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) }
+- tooltip_button = ->(title) { content_tag(:button, content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true }), type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-animation': false, 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) }
 - field_label = ->(attribute, label, title) do
   - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
 - editor_title = f.object.persisted? ? 'Editing Exercise' : 'New exercise'

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -23,8 +23,9 @@
             = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
               i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
-            .col-6.col-md-3 = f.input :reps, hint: '0 = max reps; for a ladder, the round-1 reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
-            .col-6.col-md-3 = f.input :duration_seconds, label: 'Duration (s)', input_html: { data: { 'exercise-card-target': 'durationInput' } }
+            .col-4.col-md-3 = f.input :reps, hint: '0 = max reps; for a ladder, the round-1 reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
+            .col-4.col-md-3 = f.input :duration_seconds, label: 'Duration (s)', input_html: { data: { 'exercise-card-target': 'durationInput' } }
+            .col-4.col-md-3 = f.input :calories, hint: '0 = max calories', input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
             .col-6.col-md-3 data-ladder-step-target="exemptField" hidden=(!@workout&.ascending_ladder?)
               = f.input :ladder_exempt, as: :boolean, label: 'Constant (no ladder)', input_html: { data: { 'ladder-step-target': 'exempt', action: 'change->ladder-step#toggle' } }
             .col-6.col-md-3 data-ladder-step-target="stepEveryField" hidden=(!(@workout&.ascending_ladder? && !f.object.ladder_exempt))
@@ -41,7 +42,6 @@
             .col-6.col-md-3 = f.input :male_distance, input_html: { class: 'distance-value', data: { 'exercise-form-target': 'distanceValue', 'exercise-card-target': 'maleDistanceInput' } }
             .col-6.col-md-3 = f.input :distance_unit, collection: Exercise.distance_units.keys, prompt: 'Distance unit', input_html: { data: { 'exercise-form-target': 'distanceUnitSelect', 'exercise-card-target': 'distanceUnitSelect' } }
           .row.g-2
-            .col-6.col-md-3 = f.input :calories, hint: '0 = max calories', input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
             .col-6.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
             .col-6.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
             .col-12.col-md-4 data-exercise-form-target="distanceUnits" hidden=distance_units_hidden

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -9,7 +9,8 @@
 - distance_collapse_id = "exercise-#{exercise_key}-distance"
 - calories_collapse_id = "exercise-#{exercise_key}-calories"
 - tooltip_button = ->(title) do
-  - content_tag(:button, '?', type: 'button', class: 'exercise-editor__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title })
+  - content_tag(:button, type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) do
+    - content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true })
 - field_label = ->(attribute, label, title) do
   - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
 - editor_title = f.object.persisted? ? 'Editing Exercise' : 'New exercise'
@@ -37,10 +38,10 @@
               = f.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', 'exercise-card-target': 'movementSelect', 'implement-count-target': 'movementSelect' } }
           .row.g-2
             .col-6.col-md-3
-              .exercise-editor__field-label = field_label.call(:reps, 'Reps', '0 = max reps; for a ladder, the round-1 reps')
+              .workout-form__field-label = field_label.call(:reps, 'Reps', '0 = max reps; for a ladder, the round-1 reps')
               = f.input :reps, label: false, input_html: { data: { 'exercise-card-target': 'repsInput' } }
             .col-6.col-md-3
-              .exercise-editor__field-label = f.label :duration_seconds, 'Duration', class: 'form-label mb-0'
+              .workout-form__field-label = f.label :duration_seconds, 'Duration', class: 'form-label mb-0'
               = f.input :duration_seconds, as: :string, label: false, placeholder: 'MM:SS', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
             .col-6.col-md-3 data-ladder-step-target="exemptField" hidden=(!@workout&.ascending_ladder?)
               = f.input :ladder_exempt, as: :boolean, label: 'Constant (no ladder)', input_html: { data: { 'ladder-step-target': 'exempt', action: 'change->ladder-step#toggle' } }
@@ -54,12 +55,12 @@
               .exercise-editor__optional-panel
                 .row.g-2
                   .col-6.col-md-3
-                    .exercise-editor__field-label = field_label.call(:load, "Load (#{load_display_unit})", '0 = find-a-max (no fixed load)')
+                    .workout-form__field-label = field_label.call(:load, "Load (#{load_display_unit})", '0 = find-a-max (no fixed load)')
                     = f.input :load, label: false, input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
                   .col-6.col-md-3 = f.input :female_load, label: "Female load (#{load_display_unit})", input_html: { value: load_input_value(f.object.female_load), data: { 'exercise-card-target': 'femaleLoadInput' } }
                   .col-6.col-md-3 = f.input :male_load, label: "Male load (#{load_display_unit})", input_html: { value: load_input_value(f.object.male_load), data: { 'exercise-card-target': 'maleLoadInput' } }
                   .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
-                    .exercise-editor__field-label = field_label.call(:implement_count, 'Implements', 'e.g. 2 = double dumbbell')
+                    .workout-form__field-label = field_label.call(:implement_count, 'Implements', 'e.g. 2 = double dumbbell')
                     = f.input :implement_count, label: false
             button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_distance) type="button" data-bs-toggle="collapse" data-bs-target="##{distance_collapse_id}" aria-expanded=has_distance.to_s aria-controls=distance_collapse_id
               span Distance
@@ -80,7 +81,7 @@
               .exercise-editor__optional-panel
                 .row.g-2
                   .col-4.col-md-3
-                    .exercise-editor__field-label = field_label.call(:calories, 'Calories', '0 = max calories')
+                    .workout-form__field-label = field_label.call(:calories, 'Calories', '0 = max calories')
                     = f.input :calories, label: false, input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
                   .col-4.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
                   .col-4.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -8,6 +8,12 @@
 - load_collapse_id = "exercise-#{exercise_key}-load"
 - distance_collapse_id = "exercise-#{exercise_key}-distance"
 - calories_collapse_id = "exercise-#{exercise_key}-calories"
+- tooltip_button = ->(title) do
+  - content_tag(:button, '?', type: 'button', class: 'exercise-editor__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title })
+- reps_label = safe_join(['Reps ', tooltip_button.call('0 = max reps; for a ladder, the round-1 reps')])
+- load_label = safe_join(["Load (#{load_display_unit}) ", tooltip_button.call('0 = find-a-max (no fixed load)')])
+- calories_label = safe_join(['Calories ', tooltip_button.call('0 = max calories')])
+- implements_label = safe_join(['Implements ', tooltip_button.call('e.g. 2 = double dumbbell')])
 
 .exercise.nested-fields.mb-3.segment-exercise data-controller="exercise-form exercise-card implement-count ladder-step" data-action="input->exercise-form#toggleDistanceUnits change->exercise-form#toggleDistanceUnits change->exercise-card#clearMovementError change->implement-count#toggle ladder-fields:change@document->ladder-step#toggle" data-exercise-card-expanded-value=expanded data-exercise-card-load-unit-value=load_display_unit data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
   = f.hidden_field :_destroy
@@ -29,7 +35,7 @@
             = link_to '#', class: 'exercise-editor__delete btn btn-sm btn-outline-danger', data: { action: 'click->nested-form#remove' }, aria: { label: 'Delete exercise' } do
               i.fas.fa-trash-alt aria-hidden="true"
           .row.g-2
-            .col-6.col-md-3 = f.input :reps, hint: '0 = max reps; for a ladder, the round-1 reps', input_html: { data: { 'exercise-card-target': 'repsInput' } }
+            .col-6.col-md-3 = f.input :reps, label: reps_label, input_html: { data: { 'exercise-card-target': 'repsInput' } }
             .col-6.col-md-3 = f.input :duration_seconds, as: :string, label: 'Duration', placeholder: 'MM:SS', input_html: { value: f.object.duration, data: { 'exercise-card-target': 'durationInput' } }
             .col-6.col-md-3 data-ladder-step-target="exemptField" hidden=(!@workout&.ascending_ladder?)
               = f.input :ladder_exempt, as: :boolean, label: 'Constant (no ladder)', input_html: { data: { 'ladder-step-target': 'exempt', action: 'change->ladder-step#toggle' } }
@@ -38,22 +44,18 @@
           .exercise-editor__optional-groups
             button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_load) type="button" data-bs-toggle="collapse" data-bs-target="##{load_collapse_id}" aria-expanded=has_load.to_s aria-controls=load_collapse_id
               span Load
-              span.exercise-editor__optional-toggle-meta
-                span.exercise-editor__optional-state.exercise-editor__optional-state--open Shown
-                span.exercise-editor__optional-state.exercise-editor__optional-state--closed Hidden
+              span.exercise-editor__optional-toggle-meta aria-hidden="true"
             .collapse class=('show' if has_load) id=load_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
-                  .col-6.col-md-3 = f.input :load, label: "Load (#{load_display_unit})", hint: '0 = find-a-max (no fixed load)', input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
+                  .col-6.col-md-3 = f.input :load, label: load_label, input_html: { value: load_input_value(f.object.load), data: { 'exercise-card-target': 'loadInput' } }
                   .col-6.col-md-3 = f.input :female_load, label: "Female load (#{load_display_unit})", input_html: { value: load_input_value(f.object.female_load), data: { 'exercise-card-target': 'femaleLoadInput' } }
                   .col-6.col-md-3 = f.input :male_load, label: "Male load (#{load_display_unit})", input_html: { value: load_input_value(f.object.male_load), data: { 'exercise-card-target': 'maleLoadInput' } }
                   .col-6.col-md-3 data-implement-count-target="field" hidden=(!f.object.movement&.supports_implement_count?)
-                    = f.input :implement_count, label: 'Implements', hint: 'e.g. 2 = double dumbbell'
+                    = f.input :implement_count, label: implements_label
             button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_distance) type="button" data-bs-toggle="collapse" data-bs-target="##{distance_collapse_id}" aria-expanded=has_distance.to_s aria-controls=distance_collapse_id
               span Distance
-              span.exercise-editor__optional-toggle-meta
-                span.exercise-editor__optional-state.exercise-editor__optional-state--open Shown
-                span.exercise-editor__optional-state.exercise-editor__optional-state--closed Hidden
+              span.exercise-editor__optional-toggle-meta aria-hidden="true"
             .collapse class=('show' if has_distance) id=distance_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
@@ -65,13 +67,11 @@
                     = f.input :distance_units_per_rep, label: 'Distance units per rep'
             button.btn.btn-outline-secondary.exercise-editor__optional-toggle class=('collapsed' unless has_calories) type="button" data-bs-toggle="collapse" data-bs-target="##{calories_collapse_id}" aria-expanded=has_calories.to_s aria-controls=calories_collapse_id
               span Calories
-              span.exercise-editor__optional-toggle-meta
-                span.exercise-editor__optional-state.exercise-editor__optional-state--open Shown
-                span.exercise-editor__optional-state.exercise-editor__optional-state--closed Hidden
+              span.exercise-editor__optional-toggle-meta aria-hidden="true"
             .collapse class=('show' if has_calories) id=calories_collapse_id
               .exercise-editor__optional-panel
                 .row.g-2
-                  .col-4.col-md-3 = f.input :calories, hint: '0 = max calories', input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
+                  .col-4.col-md-3 = f.input :calories, label: calories_label, input_html: { data: { 'exercise-card-target': 'caloriesInput' } }
                   .col-4.col-md-3 = f.input :female_calories, input_html: { data: { 'exercise-card-target': 'femaleCaloriesInput' } }
                   .col-4.col-md-3 = f.input :male_calories, input_html: { data: { 'exercise-card-target': 'maleCaloriesInput' } }
           .row.g-2

--- a/app/views/workouts/_exercise_fields.html.slim
+++ b/app/views/workouts/_exercise_fields.html.slim
@@ -8,9 +8,7 @@
 - load_collapse_id = "exercise-#{exercise_key}-load"
 - distance_collapse_id = "exercise-#{exercise_key}-distance"
 - calories_collapse_id = "exercise-#{exercise_key}-calories"
-- tooltip_button = ->(title) do
-  - content_tag(:button, type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) do
-    span aria-hidden="true" !
+- tooltip_button = ->(title) { content_tag(:button, content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true }), type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) }
 - field_label = ->(attribute, label, title) do
   - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
 - editor_title = f.object.persisted? ? 'Editing Exercise' : 'New exercise'

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -4,9 +4,7 @@
 - ladder_hidden = ladder_segment.blank? || ladder_segment.time_seconds.blank? || ladder_segment.rounds.present? || ladder_segment.interval_scheme.present?
 
 = simple_form_for @workout, wrapper: :vertical_form, html: { class: 'workout-form', data: { controller: 'ladder-fields' } } do |f|
-  - tooltip_button = ->(title) do
-    - content_tag(:button, type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) do
-      span aria-hidden="true" !
+  - tooltip_button = ->(title) { content_tag(:button, content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true }), type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) }
   - field_label = ->(attribute, label, title) do
     - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
   = f.error_notification

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -9,7 +9,7 @@
     .col-4.col-md-3 data-ladder-fields-target="row" hidden=ladder_hidden
       = f.input :ladder_step, label: 'Ascending ladder step', hint: "reps added each round (start is each exercise's reps)", input_html: { data: { 'ladder-fields-target': 'step input', action: 'input->ladder-fields#toggle' } }
     .col-4.col-md-3 = f.input :score_type, collection: Metric.workout_measurements, label: 'For'
-    .col-4.col-md-3 = f.input :team_size, label: 'Athletes', hint: 'team size'
+    .col-4.col-md-3 = f.input :team_size, label: 'Athletes', hint: 'blank = individual'
     .col-4.col-md-3 = f.input :time_cap
     .col-12
       = f.label :notes, class: 'form-label'

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -6,11 +6,11 @@
   = f.error_notification
   .form-inputs.row.g-2
     .col-12 = f.input :name, input_html: { value: f.object.name || generate_workout_name }
-    .col-sm-4 data-ladder-fields-target="row" hidden=ladder_hidden
+    .col-4.col-md-3 data-ladder-fields-target="row" hidden=ladder_hidden
       = f.input :ladder_step, label: 'Ascending ladder step', hint: "reps added each round (start is each exercise's reps)", input_html: { data: { 'ladder-fields-target': 'step input', action: 'input->ladder-fields#toggle' } }
-    .col-12 = f.input :score_type, collection: Metric.workout_measurements, label: 'For'
-    .col-sm-4 = f.input :team_size, label: 'Athletes (team size)', hint: 'leave blank for an individual workout'
-    .col-12 = f.input :time_cap
+    .col-4.col-md-3 = f.input :score_type, collection: Metric.workout_measurements, label: 'For'
+    .col-4.col-md-3 = f.input :team_size, label: 'Athletes', hint: 'team size'
+    .col-4.col-md-3 = f.input :time_cap
     .col-12
       = f.label :notes, class: 'form-label'
       = f.rich_text_area :notes

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -3,14 +3,25 @@
 - ladder_hidden = ladder_segment.blank? || ladder_segment.time_seconds.blank? || ladder_segment.rounds.present? || ladder_segment.interval_scheme.present?
 
 = simple_form_for @workout, wrapper: :vertical_form, html: { class: 'workout-form', data: { controller: 'ladder-fields' } } do |f|
+  - tooltip_button = ->(title) do
+    - content_tag(:button, type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) do
+      - content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true })
+  - field_label = ->(attribute, label, title) do
+    - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
   = f.error_notification
   .form-inputs.row.g-2
     .col-12 = f.input :name, input_html: { value: f.object.name || generate_workout_name }
     .col-4.col-md-3 data-ladder-fields-target="row" hidden=ladder_hidden
       = f.input :ladder_step, label: 'Ascending ladder step', hint: "reps added each round (start is each exercise's reps)", input_html: { data: { 'ladder-fields-target': 'step input', action: 'input->ladder-fields#toggle' } }
-    .col-4.col-md-3 = f.input :score_type, collection: Metric.workout_measurements, label: 'For'
-    .col-4.col-md-3 = f.input :team_size, label: 'Athletes', hint: 'blank = individual'
-    .col-4.col-md-3 = f.input :time_cap
+    .col-4.col-md-3
+      .workout-form__field-label = f.label :score_type, 'For', class: 'form-label mb-0'
+      = f.input :score_type, collection: Metric.workout_measurements, label: false
+    .col-4.col-md-3
+      .workout-form__field-label = field_label.call(:team_size, 'Athletes', 'blank = individual')
+      = f.input :team_size, label: false, hint: false
+    .col-4.col-md-3
+      .workout-form__field-label = f.label :time_cap, 'Time cap', class: 'form-label mb-0'
+      = f.input :time_cap, label: false
     .col-12
       = f.label :notes, class: 'form-label'
       = f.rich_text_area :notes

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -5,7 +5,7 @@
 = simple_form_for @workout, wrapper: :vertical_form, html: { class: 'workout-form', data: { controller: 'ladder-fields' } } do |f|
   - tooltip_button = ->(title) do
     - content_tag(:button, type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) do
-      - content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true })
+      span aria-hidden="true" !
   - field_label = ->(attribute, label, title) do
     - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
   = f.error_notification

--- a/app/views/workouts/_form.html.slim
+++ b/app/views/workouts/_form.html.slim
@@ -4,7 +4,7 @@
 - ladder_hidden = ladder_segment.blank? || ladder_segment.time_seconds.blank? || ladder_segment.rounds.present? || ladder_segment.interval_scheme.present?
 
 = simple_form_for @workout, wrapper: :vertical_form, html: { class: 'workout-form', data: { controller: 'ladder-fields' } } do |f|
-  - tooltip_button = ->(title) { content_tag(:button, content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true }), type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) }
+  - tooltip_button = ->(title) { content_tag(:button, content_tag(:i, '', class: 'fa-solid fa-circle-info', aria: { hidden: true }), type: 'button', class: 'workout-form__help', data: { controller: 'tooltip', 'bs-animation': false, 'bs-toggle': 'tooltip', 'bs-title': title }, aria: { label: title }) }
   - field_label = ->(attribute, label, title) do
     - safe_join([f.label(attribute, label, class: 'form-label mb-0'), tooltip_button.call(title)], ' ')
   = f.error_notification

--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -21,12 +21,12 @@
       .workout-sortable-item__body
         .row.g-2
           .col-12.col-lg-4 = f.input :name, input_html: { data: { 'segment-card-target': 'nameInput' } }
-          .col-6.col-md-3.col-lg-2 = f.input :rounds, input_html: { data: { 'segment-card-target': 'roundsInput', 'ladder-fields-target': 'rounds', action: 'input->ladder-fields#toggle' } }
-          .col-6.col-md-3.col-lg-2 = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200', input_html: { data: { 'segment-card-target': 'timeInput', 'ladder-fields-target': 'time', action: 'input->ladder-fields#toggle' } }
-          .col-12.col-md-6.col-lg-4 = f.input :interval_scheme, placeholder: '21-15-9...', input_html: { data: { 'segment-card-target': 'intervalInput', 'ladder-fields-target': 'interval', action: 'input->ladder-fields#toggle' } }
+          .col-4.col-md-3.col-lg-2 = f.input :rounds, input_html: { data: { 'segment-card-target': 'roundsInput', 'ladder-fields-target': 'rounds', action: 'input->ladder-fields#toggle' } }
+          .col-4.col-md-3.col-lg-2 = f.input :time_seconds, as: :string, placeholder: '20:00 or 1200', input_html: { data: { 'segment-card-target': 'timeInput', 'ladder-fields-target': 'time', action: 'input->ladder-fields#toggle' } }
+          .col-4.col-md-3.col-lg-2 = f.input :rest_seconds, input_html: { data: { 'segment-card-target': 'restInput' } }
+          .col-12.col-md-9.col-lg-4 = f.input :interval_scheme, placeholder: '21-15-9...', input_html: { data: { 'segment-card-target': 'intervalInput', 'ladder-fields-target': 'interval', action: 'input->ladder-fields#toggle' } }
         .row.g-2
-          .col-12.col-md-4 = f.input :rest_seconds, input_html: { data: { 'segment-card-target': 'restInput' } }
-          .col-12.col-md-8 = f.input :notes, input_html: { data: { 'segment-card-target': 'notesInput' } }
+          .col-12 = f.input :notes, input_html: { data: { 'segment-card-target': 'notesInput' } }
         .row
           .col#segmented_exercises data-controller="nested-form sortable-list" data-action="nested-form:add->sortable-list#refresh nested-form:remove->sortable-list#refresh" data-nested-form-placeholder-value="CHILD_EXERCISE" data-nested-form-position-exercises-value="true" data-sortable-list-draggable-selector-value=".segment-exercise:not([hidden])"
             .fields data-nested-form-target="container" data-sortable-list-target="container"

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -119,6 +119,18 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_includes exercise.errors[:distance_units_per_rep], 'must divide the prescribed distance evenly'
   end
 
+  test 'parses duration strings into duration seconds' do
+    assert_equal 90, fran_segment.exercises.build(movement: movements(:pullup), duration_seconds: '1:30').duration_seconds
+    assert_equal 3630, fran_segment.exercises.build(movement: movements(:pullup), duration_seconds: '1:00:30').duration_seconds
+    assert_equal 90, fran_segment.exercises.build(movement: movements(:pullup), duration_seconds: '90').duration_seconds
+  end
+
+  test 'formats duration seconds for form input' do
+    assert_equal '1:30', fran_segment.exercises.build(movement: movements(:pullup), duration_seconds: 90).duration
+    assert_equal '1:00:30', fran_segment.exercises.build(movement: movements(:pullup), duration_seconds: 3630).duration
+    assert_nil fran_segment.exercises.build(movement: movements(:pullup)).duration
+  end
+
   private
 
   # An unsaved segment for exercising Exercise validations/prescriptions in isolation,

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -44,6 +44,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
         assert_equal '1', find('input[name$="[position]"]', visible: false).value
         find('.ts-control input').set('Run')
         find('.ts-dropdown .option', text: 'Run').click
+        click_on 'Distance'
         fill_in 'Distance', with: '400', exact: true
         select 'meter', from: 'Distance unit'
         click_on 'Done'
@@ -89,6 +90,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
 
     within first('.exercise') do
       assert_no_field 'Implements'
+      click_on 'Load'
 
       find('.ts-control input').set('Pull')
       find('.ts-dropdown .option', text: 'Pull Up').click

--- a/test/system/exercise_card_metric_display_test.rb
+++ b/test/system/exercise_card_metric_display_test.rb
@@ -19,6 +19,7 @@ class ExerciseCardMetricDisplayTest < ApplicationSystemTestCase
     within '.exercise' do
       select_movement 'Thruster'
       fill_in 'Reps', with: '21'
+      click_on 'Load'
       fill_in 'Load (kg)', with: '43'
       click_on 'Done'
 

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -1,16 +1,23 @@
 require 'application_system_test_case'
 
-class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
-  include Warden::Test::Helpers
-
-  setup do
+module ExerciseCardSummaryFormattingSystemHelpers
+  def setup_summary_formatting_test
     login_as users(:mathew), scope: :user
     Movement.find_or_create_by!(name: 'Dumbbell Overhead Walking Lunge')
   end
 
-  teardown do
-    Warden.test_reset!
+  def open_optional_group(name)
+    click_on name
   end
+end
+
+class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
+  include ExerciseCardSummaryFormattingSystemHelpers
+  include Warden::Test::Helpers
+
+  setup { setup_summary_formatting_test }
+
+  teardown { Warden.test_reset! }
 
   test 'renders distance before movement with load after local save' do
     visit new_workout_url
@@ -19,8 +26,10 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
     within '.exercise' do
       select_movement 'Run'
       fill_in 'Reps', with: '1'
+      open_optional_group 'Distance'
       fill_in 'Distance', with: '10', exact: true
       select 'meter', from: 'Distance unit'
+      open_optional_group 'Load'
       fill_in 'Load (lb)', with: '95'
       click_on 'Done'
 
@@ -35,8 +44,10 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
     within '.exercise' do
       select_movement 'Run'
       fill_in 'Reps', with: '1'
+      open_optional_group 'Load'
       fill_in 'Female load (lb)', with: '65'
       fill_in 'Male load (lb)', with: '95'
+      open_optional_group 'Distance'
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
@@ -53,6 +64,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
     within '.exercise' do
       select_movement 'Run'
       fill_in 'Reps', with: '1'
+      open_optional_group 'Distance'
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
@@ -69,8 +81,10 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
     within '.exercise' do
       select_movement 'Dumbbell Overhead Walking Lunge'
       fill_in 'Reps', with: '1'
+      open_optional_group 'Distance'
       fill_in 'Distance', with: '80', exact: true
       select 'foot', from: 'Distance unit'
+      open_optional_group 'Load'
       fill_in 'Female load (lb)', with: '35'
       fill_in 'Male load (lb)', with: '50'
       click_on 'Done'
@@ -86,6 +100,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
     within '.exercise' do
       select_movement 'Dumbbell Overhead Walking Lunge'
       fill_in 'Reps', with: '1'
+      open_optional_group 'Distance'
       fill_in 'Female distance', with: '30'
 
       # Typing into Female distance is what flips exercise-form#toggleDistanceUnits' hasDistance
@@ -99,6 +114,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
 
       fill_in 'Male distance', with: '40'
       select 'foot', from: 'Distance unit'
+      open_optional_group 'Load'
       fill_in 'Female load (lb)', with: '35'
       fill_in 'Male load (lb)', with: '50'
 
@@ -114,6 +130,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
 
     within '.exercise' do
       select_movement 'Row'
+      open_optional_group 'Calories'
       fill_in 'Calories', with: '0'
       click_on 'Done'
 

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -10,6 +10,11 @@ module ExerciseCardSummaryFormattingSystemHelpers
     execute_script("document.querySelectorAll('select.movement').forEach((select) => select.tomselect?.close())")
     toggle = find('button.exercise-editor__optional-toggle', text: name)
 
+    click_optional_group_toggle(toggle) if toggle['aria-expanded'] == 'false'
+    assert_selector 'button.exercise-editor__optional-toggle[aria-expanded="true"]', text: name
+  end
+
+  def click_optional_group_toggle(toggle)
     toggle.click
   rescue Selenium::WebDriver::Error::ElementClickInterceptedError
     execute_script('arguments[0].click()', toggle)

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -7,7 +7,12 @@ module ExerciseCardSummaryFormattingSystemHelpers
   end
 
   def open_optional_group(name)
-    click_on name
+    execute_script("document.querySelectorAll('select.movement').forEach((select) => select.tomselect?.close())")
+    toggle = find('button.exercise-editor__optional-toggle', text: name)
+
+    toggle.click
+  rescue Selenium::WebDriver::Error::ElementClickInterceptedError
+    execute_script('arguments[0].click()', toggle)
   end
 end
 

--- a/test/system/sex_specific_workout_values_test.rb
+++ b/test/system/sex_specific_workout_values_test.rb
@@ -26,6 +26,7 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
       find('.ts-dropdown .option', text: 'Thruster').click
 
       fill_in 'Reps', with: '1'
+      click_on 'Load'
       fill_in 'Female load (lb)', with: '65'
       fill_in 'Male load (lb)', with: '95'
       click_on 'Done'

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -42,68 +42,6 @@ class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
     page.driver.browser.manage.window.resize_to(1400, 1400)
   end
 
-  test 'lays out workout form fields densely on mobile' do
-    page.driver.browser.manage.window.resize_to(390, 900)
-    visit new_workout_url
-
-    layout = evaluate_script(<<~JS)
-      (() => {
-        const rowTop = (selector) => {
-          const control = document.querySelector(selector)
-          const field = control.closest('.mb-3, [class*="col-"]')
-
-          return Math.round(field.getBoundingClientRect().top)
-        }
-        const overflowingControls = Array.from(
-          document.querySelectorAll('.workout-form input, .workout-form select, .workout-form textarea, .workout-form trix-toolbar, .workout-form trix-editor')
-        ).filter((control) => {
-          const rect = control.getBoundingClientRect()
-          return rect.left < 0 || rect.right > document.documentElement.clientWidth
-        }).length
-
-        return {
-          scoreTypeTop: rowTop('#workout_score_type'),
-          teamSizeTop: rowTop('#workout_team_size'),
-          timeCapTop: rowTop('#workout_time_cap'),
-          segmentRoundsTop: rowTop('input[name$="[rounds]"]'),
-          segmentTimeTop: rowTop('input[name$="[time_seconds]"]'),
-          segmentRestTop: rowTop('input[name$="[rest_seconds]"]'),
-          overflowingControls
-        }
-      })()
-    JS
-
-    assert_equal layout['scoreTypeTop'], layout['teamSizeTop']
-    assert_equal layout['scoreTypeTop'], layout['timeCapTop']
-    assert_equal layout['segmentRoundsTop'], layout['segmentTimeTop']
-    assert_equal layout['segmentRoundsTop'], layout['segmentRestTop']
-    assert_equal 0, layout['overflowingControls']
-
-    click_on 'Add Exercise', match: :first
-
-    exercise_layout = evaluate_script(<<~JS)
-      (() => {
-        const rowTop = (selector) => {
-          const control = document.querySelector(selector)
-          const field = control.closest('.mb-3, [class*="col-"]')
-
-          return Math.round(field.getBoundingClientRect().top)
-        }
-
-        return {
-          repsTop: rowTop('input[name$="[reps]"]'),
-          durationTop: rowTop('input[name$="[duration_seconds]"]'),
-          caloriesTop: rowTop('input[name$="[calories]"]')
-        }
-      })()
-    JS
-
-    assert_equal exercise_layout['repsTop'], exercise_layout['durationTop']
-    assert_equal exercise_layout['repsTop'], exercise_layout['caloriesTop']
-  ensure
-    page.driver.browser.manage.window.resize_to(1400, 1400)
-  end
-
   test 'uses a full-width toolbar bar with container-width actions' do
     page.driver.browser.manage.window.resize_to(1400, 900)
     visit new_workout_url

--- a/test/system/workout_builder_toolbar_test.rb
+++ b/test/system/workout_builder_toolbar_test.rb
@@ -42,6 +42,68 @@ class WorkoutBuilderToolbarTest < ApplicationSystemTestCase
     page.driver.browser.manage.window.resize_to(1400, 1400)
   end
 
+  test 'lays out workout form fields densely on mobile' do
+    page.driver.browser.manage.window.resize_to(390, 900)
+    visit new_workout_url
+
+    layout = evaluate_script(<<~JS)
+      (() => {
+        const rowTop = (selector) => {
+          const control = document.querySelector(selector)
+          const field = control.closest('.mb-3, [class*="col-"]')
+
+          return Math.round(field.getBoundingClientRect().top)
+        }
+        const overflowingControls = Array.from(
+          document.querySelectorAll('.workout-form input, .workout-form select, .workout-form textarea, .workout-form trix-toolbar, .workout-form trix-editor')
+        ).filter((control) => {
+          const rect = control.getBoundingClientRect()
+          return rect.left < 0 || rect.right > document.documentElement.clientWidth
+        }).length
+
+        return {
+          scoreTypeTop: rowTop('#workout_score_type'),
+          teamSizeTop: rowTop('#workout_team_size'),
+          timeCapTop: rowTop('#workout_time_cap'),
+          segmentRoundsTop: rowTop('input[name$="[rounds]"]'),
+          segmentTimeTop: rowTop('input[name$="[time_seconds]"]'),
+          segmentRestTop: rowTop('input[name$="[rest_seconds]"]'),
+          overflowingControls
+        }
+      })()
+    JS
+
+    assert_equal layout['scoreTypeTop'], layout['teamSizeTop']
+    assert_equal layout['scoreTypeTop'], layout['timeCapTop']
+    assert_equal layout['segmentRoundsTop'], layout['segmentTimeTop']
+    assert_equal layout['segmentRoundsTop'], layout['segmentRestTop']
+    assert_equal 0, layout['overflowingControls']
+
+    click_on 'Add Exercise', match: :first
+
+    exercise_layout = evaluate_script(<<~JS)
+      (() => {
+        const rowTop = (selector) => {
+          const control = document.querySelector(selector)
+          const field = control.closest('.mb-3, [class*="col-"]')
+
+          return Math.round(field.getBoundingClientRect().top)
+        }
+
+        return {
+          repsTop: rowTop('input[name$="[reps]"]'),
+          durationTop: rowTop('input[name$="[duration_seconds]"]'),
+          caloriesTop: rowTop('input[name$="[calories]"]')
+        }
+      })()
+    JS
+
+    assert_equal exercise_layout['repsTop'], exercise_layout['durationTop']
+    assert_equal exercise_layout['repsTop'], exercise_layout['caloriesTop']
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+
   test 'uses a full-width toolbar bar with container-width actions' do
     page.driver.browser.manage.window.resize_to(1400, 900)
     visit new_workout_url

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -22,7 +22,7 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
     click_on 'Add Exercise'
 
     within all('.exercise').last do
-      within '.workout-card-toolbar' do
+      within '.exercise-editor__footer' do
         assert_button 'Done'
         assert_no_link 'Delete Exercise'
       end
@@ -44,7 +44,7 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
     end
   end
 
-  test 'renders expanded exercise movement row actions inline' do
+  test 'renders expanded exercise editor actions in header and footer' do
     visit new_workout_url
 
     fill_in 'Name *', with: 'Inline Exercise Movement Row'
@@ -55,10 +55,19 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
     click_on 'Add Exercise'
 
     within all('.exercise').last do
+      within '.exercise-editor__header' do
+        assert_text 'EDITING EXERCISE'
+        assert_selector '[aria-label="Delete exercise"]'
+      end
+
       within '.exercise-editor__movement-row' do
         assert_no_selector '[aria-label="Drag exercise"]'
         assert_field 'Movement'
-        assert_selector '[aria-label="Delete exercise"]'
+        assert_no_selector '[aria-label="Delete exercise"]'
+      end
+
+      within '.exercise-editor__footer' do
+        assert_button 'Done'
       end
     end
   end

--- a/test/system/workout_card_toolbar_test.rb
+++ b/test/system/workout_card_toolbar_test.rb
@@ -56,7 +56,7 @@ class WorkoutCardToolbarTest < ApplicationSystemTestCase
 
     within all('.exercise').last do
       within '.exercise-editor__header' do
-        assert_text 'EDITING EXERCISE'
+        assert_text 'NEW EXERCISE'
         assert_selector '[aria-label="Delete exercise"]'
       end
 

--- a/test/system/workout_drag_ordering_test.rb
+++ b/test/system/workout_drag_ordering_test.rb
@@ -37,8 +37,11 @@ module WorkoutDragOrderingSystemHelpers
       find('.ts-control input').set(movement)
       find('.ts-dropdown .option', exact_text: movement).click
       fill_in 'Reps', with: reps if reps.present?
-      fill_in 'Distance', with: distance, exact: true if distance.present?
-      select 'meter', from: 'Distance unit' if distance.present?
+      if distance.present?
+        click_on 'Distance'
+        fill_in 'Distance', with: distance, exact: true
+        select 'meter', from: 'Distance unit'
+      end
       done_button = find_button('Done')
       scroll_to done_button, align: :center
       done_button.click

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -71,12 +71,12 @@ module WorkoutFormLayoutSystemHelpers
 
   def assert_help_text_is_tooltipped
     assert_no_text '0 = max reps'
-    assert_equal 0, evaluate_script("document.querySelectorAll('label .exercise-editor__help').length")
+    assert_equal 0, evaluate_script("document.querySelectorAll('label .workout-form__help').length")
   end
 
   def assert_help_targets_are_large_enough
     sizes = evaluate_script(<<~JS)
-      Array.from(document.querySelectorAll('.exercise-editor__help')).map((button) => {
+      Array.from(document.querySelectorAll('.workout-form__help')).map((button) => {
         const rect = button.getBoundingClientRect()
 
         return { width: Math.round(rect.width), height: Math.round(rect.height) }
@@ -119,6 +119,9 @@ class WorkoutFormLayoutTest < ApplicationSystemTestCase
     assert_equal layout['segmentRoundsTop'], layout['segmentTimeTop']
     assert_equal layout['segmentRoundsTop'], layout['segmentRestTop']
     assert_equal 0, layout['overflowingControls']
+    assert_no_text 'blank = individual'
+    assert_selector '#workout_team_size'
+    assert_selector '.workout-form__help[aria-label="blank = individual"]'
 
     click_on 'Add Exercise', match: :first
 

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -72,6 +72,7 @@ module WorkoutFormLayoutSystemHelpers
   def assert_help_text_is_tooltipped
     assert_no_text '0 = max reps'
     assert_equal 0, evaluate_script("document.querySelectorAll('label .workout-form__help').length")
+    assert_selector '.workout-form__help[data-bs-animation="false"]'
     assert(page.all('.workout-form__help', visible: :visible).all? { |button| button.text.blank? })
   end
 

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -72,8 +72,7 @@ module WorkoutFormLayoutSystemHelpers
   def assert_help_text_is_tooltipped
     assert_no_text '0 = max reps'
     assert_equal 0, evaluate_script("document.querySelectorAll('label .workout-form__help').length")
-    assert_equal [], evaluate_script("Array.from(document.querySelectorAll('.workout-form__help i')).map((icon) => icon.className)")
-    assert(page.all('.workout-form__help', visible: :visible).all? { |button| button.text == '!' })
+    assert(page.all('.workout-form__help', visible: :visible).all? { |button| button.text.blank? })
   end
 
   def assert_help_targets_are_large_enough

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -72,6 +72,8 @@ module WorkoutFormLayoutSystemHelpers
   def assert_help_text_is_tooltipped
     assert_no_text '0 = max reps'
     assert_equal 0, evaluate_script("document.querySelectorAll('label .workout-form__help').length")
+    assert_equal [], evaluate_script("Array.from(document.querySelectorAll('.workout-form__help i')).map((icon) => icon.className)")
+    assert(page.all('.workout-form__help', visible: :visible).all? { |button| button.text == '!' })
   end
 
   def assert_help_targets_are_large_enough

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -71,8 +71,21 @@ module WorkoutFormLayoutSystemHelpers
 
   def assert_help_text_is_tooltipped
     assert_no_text '0 = max reps'
-    assert_no_text 'Shown'
-    assert_no_text 'Hidden'
+    assert_equal 0, evaluate_script("document.querySelectorAll('label .exercise-editor__help').length")
+  end
+
+  def assert_help_targets_are_large_enough
+    sizes = evaluate_script(<<~JS)
+      Array.from(document.querySelectorAll('.exercise-editor__help')).map((button) => {
+        const rect = button.getBoundingClientRect()
+
+        return { width: Math.round(rect.width), height: Math.round(rect.height) }
+      }).filter((size) => size.width > 0 && size.height > 0)
+    JS
+
+    assert_not_empty sizes, 'Expected at least one visible help target'
+    assert sizes.all? { |size| size['width'] >= 24 && size['height'] >= 24 },
+           "Expected help targets to be at least 24x24px, got #{sizes.inspect}"
   end
 
   def assert_optional_group_reveals_fields(name, fields)
@@ -125,6 +138,7 @@ class WorkoutFormLayoutTest < ApplicationSystemTestCase
     within '.exercise' do
       assert_field 'Duration', placeholder: 'MM:SS'
       assert_help_text_is_tooltipped
+      assert_help_targets_are_large_enough
       assert_optional_groups_hidden
       assert_no_field 'Load (lb)'
       assert_no_field 'Female load (lb)'
@@ -135,6 +149,8 @@ class WorkoutFormLayoutTest < ApplicationSystemTestCase
       assert_no_text '0 = find-a-max'
       assert_optional_group_reveals_fields 'Distance', ['Distance', 'Female distance']
       assert_optional_group_reveals_fields 'Calories', ['Calories', 'Female calories']
+      assert_help_text_is_tooltipped
+      assert_help_targets_are_large_enough
     end
   ensure
     page.driver.browser.manage.window.resize_to(1400, 1400)

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -1,0 +1,152 @@
+require 'application_system_test_case'
+
+module WorkoutFormLayoutSystemHelpers
+  WORKOUT_FORM_LAYOUT_SCRIPT = <<~JS.freeze
+    (() => {
+      return {
+        scoreTypeTop: rowTop('#workout_score_type'),
+        teamSizeTop: rowTop('#workout_team_size'),
+        timeCapTop: rowTop('#workout_time_cap'),
+        segmentRoundsTop: rowTop('input[name$="[rounds]"]'),
+        segmentTimeTop: rowTop('input[name$="[time_seconds]"]'),
+        segmentRestTop: rowTop('input[name$="[rest_seconds]"]'),
+        overflowingControls: overflowingControls()
+      }
+
+      function rowTop(selector) {
+        const control = document.querySelector(selector)
+        const field = control.closest('.mb-3, [class*="col-"]')
+
+        return Math.round(field.getBoundingClientRect().top)
+      }
+
+      function overflowingControls() {
+        return Array.from(
+          document.querySelectorAll('.workout-form input, .workout-form select, .workout-form textarea, .workout-form trix-toolbar, .workout-form trix-editor')
+        ).filter((control) => {
+          const rect = control.getBoundingClientRect()
+          return rect.left < 0 || rect.right > document.documentElement.clientWidth
+        }).length
+      }
+    })()
+  JS
+
+  EXERCISE_FORM_LAYOUT_SCRIPT = <<~JS.freeze
+    (() => {
+      return {
+        repsTop: rowTop('input[name$="[reps]"]'),
+        durationTop: rowTop('input[name$="[duration_seconds]"]')
+      }
+
+      function rowTop(selector) {
+        const control = document.querySelector(selector)
+        const field = control.closest('.mb-3, [class*="col-"]')
+
+        return Math.round(field.getBoundingClientRect().top)
+      }
+    })()
+  JS
+
+  def workout_form_layout
+    evaluate_script(WORKOUT_FORM_LAYOUT_SCRIPT)
+  end
+
+  def exercise_form_layout
+    evaluate_script(EXERCISE_FORM_LAYOUT_SCRIPT)
+  end
+end
+
+class WorkoutFormLayoutTest < ApplicationSystemTestCase
+  include WorkoutFormLayoutSystemHelpers
+  include Warden::Test::Helpers
+
+  setup do
+    login_as users(:mathew), scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test 'lays out workout form fields densely on mobile' do
+    page.driver.browser.manage.window.resize_to(390, 900)
+    visit new_workout_url
+
+    layout = workout_form_layout
+
+    assert_equal layout['scoreTypeTop'], layout['teamSizeTop']
+    assert_equal layout['scoreTypeTop'], layout['timeCapTop']
+    assert_equal layout['segmentRoundsTop'], layout['segmentTimeTop']
+    assert_equal layout['segmentRoundsTop'], layout['segmentRestTop']
+    assert_equal 0, layout['overflowingControls']
+
+    click_on 'Add Exercise', match: :first
+
+    exercise_layout = exercise_form_layout
+
+    assert_equal exercise_layout['repsTop'], exercise_layout['durationTop']
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+
+  test 'collapses optional exercise prescription groups on mobile' do
+    page.driver.browser.manage.window.resize_to(390, 900)
+    visit new_workout_url
+
+    click_on 'Add Exercise', match: :first
+
+    within '.exercise' do
+      assert_field 'Duration', placeholder: '1:30'
+      assert_no_field 'Load (lb)'
+      assert_no_field 'Female load (lb)'
+      assert_no_field 'Distance'
+      assert_no_field 'Calories'
+
+      click_on 'Load'
+      assert_field 'Load (lb)'
+      assert_field 'Female load (lb)'
+
+      click_on 'Distance'
+      assert_field 'Distance'
+      assert_field 'Female distance'
+
+      click_on 'Calories'
+      assert_field 'Calories'
+      assert_field 'Female calories'
+    end
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+
+  test 'opens optional exercise prescription groups when existing values are present' do
+    page.driver.browser.manage.window.resize_to(390, 900)
+    visit edit_workout_url(workouts(:fran))
+
+    find('.segment-summary__button').click
+    exercise = first('.exercise', text: 'Thruster')
+    within exercise do
+      find('.exercise-summary__button').click
+
+      assert_field 'Load (lb)', with: '95'
+      assert_no_field 'Distance'
+      assert_no_field 'Calories'
+    end
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+
+  test 'uses duration strings for exercise duration inputs' do
+    visit new_workout_url
+
+    click_on 'Add Exercise', match: :first
+
+    within '.exercise' do
+      find('.ts-control input').set('Run')
+      find('.ts-dropdown .option', text: 'Run').click
+      fill_in 'Duration', with: '1:30'
+      click_on 'Done'
+
+      assert_text '1:30 Run'
+    end
+  end
+end

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -54,6 +54,21 @@ module WorkoutFormLayoutSystemHelpers
   def exercise_form_layout
     evaluate_script(EXERCISE_FORM_LAYOUT_SCRIPT)
   end
+
+  def assert_optional_group_state(name, state)
+    expanded = state == :shown
+    label = expanded ? 'Shown' : 'Hidden'
+
+    assert_selector format('.exercise-editor__optional-toggle[aria-expanded="%<expanded>s"]',
+                           expanded: expanded),
+                    text: /#{Regexp.escape(name)}\s+#{label}/
+  end
+
+  def assert_optional_groups_hidden
+    assert_optional_group_state 'Load', :hidden
+    assert_optional_group_state 'Distance', :hidden
+    assert_optional_group_state 'Calories', :hidden
+  end
 end
 
 class WorkoutFormLayoutTest < ApplicationSystemTestCase
@@ -96,21 +111,25 @@ class WorkoutFormLayoutTest < ApplicationSystemTestCase
     click_on 'Add Exercise', match: :first
 
     within '.exercise' do
-      assert_field 'Duration', placeholder: '1:30'
+      assert_field 'Duration', placeholder: 'MM:SS'
+      assert_optional_groups_hidden
       assert_no_field 'Load (lb)'
       assert_no_field 'Female load (lb)'
       assert_no_field 'Distance'
       assert_no_field 'Calories'
 
       click_on 'Load'
+      assert_optional_group_state 'Load', :shown
       assert_field 'Load (lb)'
       assert_field 'Female load (lb)'
 
       click_on 'Distance'
+      assert_optional_group_state 'Distance', :shown
       assert_field 'Distance'
       assert_field 'Female distance'
 
       click_on 'Calories'
+      assert_optional_group_state 'Calories', :shown
       assert_field 'Calories'
       assert_field 'Female calories'
     end
@@ -127,6 +146,9 @@ class WorkoutFormLayoutTest < ApplicationSystemTestCase
     within exercise do
       find('.exercise-summary__button').click
 
+      assert_optional_group_state 'Load', :shown
+      assert_optional_group_state 'Distance', :hidden
+      assert_optional_group_state 'Calories', :hidden
       assert_field 'Load (lb)', with: '95'
       assert_no_field 'Distance'
       assert_no_field 'Calories'

--- a/test/system/workout_form_layout_test.rb
+++ b/test/system/workout_form_layout_test.rb
@@ -57,17 +57,29 @@ module WorkoutFormLayoutSystemHelpers
 
   def assert_optional_group_state(name, state)
     expanded = state == :shown
-    label = expanded ? 'Shown' : 'Hidden'
 
     assert_selector format('.exercise-editor__optional-toggle[aria-expanded="%<expanded>s"]',
                            expanded: expanded),
-                    text: /#{Regexp.escape(name)}\s+#{label}/
+                    text: /\A#{Regexp.escape(name)}\z/
   end
 
   def assert_optional_groups_hidden
     assert_optional_group_state 'Load', :hidden
     assert_optional_group_state 'Distance', :hidden
     assert_optional_group_state 'Calories', :hidden
+  end
+
+  def assert_help_text_is_tooltipped
+    assert_no_text '0 = max reps'
+    assert_no_text 'Shown'
+    assert_no_text 'Hidden'
+  end
+
+  def assert_optional_group_reveals_fields(name, fields)
+    click_on name
+    assert_optional_group_state name, :shown
+
+    fields.each { |field| assert_field field }
   end
 end
 
@@ -112,26 +124,17 @@ class WorkoutFormLayoutTest < ApplicationSystemTestCase
 
     within '.exercise' do
       assert_field 'Duration', placeholder: 'MM:SS'
+      assert_help_text_is_tooltipped
       assert_optional_groups_hidden
       assert_no_field 'Load (lb)'
       assert_no_field 'Female load (lb)'
       assert_no_field 'Distance'
       assert_no_field 'Calories'
 
-      click_on 'Load'
-      assert_optional_group_state 'Load', :shown
-      assert_field 'Load (lb)'
-      assert_field 'Female load (lb)'
-
-      click_on 'Distance'
-      assert_optional_group_state 'Distance', :shown
-      assert_field 'Distance'
-      assert_field 'Female distance'
-
-      click_on 'Calories'
-      assert_optional_group_state 'Calories', :shown
-      assert_field 'Calories'
-      assert_field 'Female calories'
+      assert_optional_group_reveals_fields 'Load', ['Load (lb)', 'Female load (lb)']
+      assert_no_text '0 = find-a-max'
+      assert_optional_group_reveals_fields 'Distance', ['Distance', 'Female distance']
+      assert_optional_group_reveals_fields 'Calories', ['Calories', 'Female calories']
     end
   ensure
     page.driver.browser.manage.window.resize_to(1400, 1400)

--- a/test/system/workout_workflows_test.rb
+++ b/test/system/workout_workflows_test.rb
@@ -57,6 +57,7 @@ class WorkoutWorkflowsTest < ApplicationSystemTestCase
     within '.exercise' do
       assert_no_field 'Distance units per rep'
 
+      click_on 'Distance'
       fill_in 'Distance', with: '400', exact: true
 
       assert_field 'Distance units per rep'


### PR DESCRIPTION
## Summary
- tighten the new/edit workout metadata grid on mobile so short fields share a row
- group segment timing fields and common exercise quantity fields into denser mobile rows
- add mobile safeguards for compact labels, hints, controls, and the Trix toolbar

## Validation
- `yarn build:css`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/workout_builder_toolbar_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/workout_workflows_test.rb -n test_creates_a_workout_with_an_exercise`
- `git diff --check`