### PR TITLE
Hide flat sequence segment labels

### DIFF
--- a/app/views/workouts/_segment_fields.html.slim
+++ b/app/views/workouts/_segment_fields.html.slim
@@ -1,5 +1,5 @@
 - expanded = f.object.new_record?
-- summary = f.object.persisted? ? (segment_objective(f.object) || 'Flat sequence') : 'New segment'
+- summary = f.object.persisted? ? (segment_objective(f.object) || '') : 'New segment'
 - exercise_summaries = f.object.exercises.reject(&:marked_for_destruction?).sort_by { |exercise| exercise.position || 0 }.map { |exercise| measurable_message(exercise) }
 
 .nested-fields.card.mb-3.workout-part data-controller="segment-card" data-segment-card-expanded-value=expanded hidden=f.object.marked_for_destruction?

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -165,6 +165,14 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', edit_unstructured_workout_path(@workout)
   end
 
+  test 'does not label collapsed nameless segments as flat sequences' do
+    get edit_workout_url(workouts(:murph))
+
+    assert_response :success
+    assert_select '.segment-summary__text', text: 'Flat sequence', count: 0
+    assert_select '.segment-summary__text', text: '', count: 1
+  end
+
   test 'should update workout' do
     patch workout_url(@workout), params: { workout: {
       name: @workout.name,


### PR DESCRIPTION
## Summary

- Stop showing `Flat sequence` for collapsed persisted segments that do not have an objective label.
- Keep `New segment` for newly added unsaved segment cards.
- Add a regression test for editing a workout with a nameless segment.

## Root Cause

The segment form partial used `Flat sequence` as the server-rendered fallback when `segment_objective` returned nil for an existing segment. Nameless unschemed segments therefore displayed that fallback while collapsed.

## Validation

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/workouts_controller_test.rb`