### PR TITLE
chore: drop unused Redis Action Cable adapter (Railway migration)

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,4 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: wod_tracker_production
+  adapter: async


### PR DESCRIPTION
Switches production Action Cable adapter to `async`; Redis is unused (no channels/broadcasts). Part of the Heroku→Railway migration, see #1781.

Verified: cable.yml's production block parses to `{"adapter"=>"async"}` with no ENV dependency; no test file references ActionCable/cable, so no test suite change needed for this config-only edit.