### PR TITLE
fix: point mailer default_url_options at the real production domain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,12 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: 'cf.mattyanchek.com', protocol: 'https' }
+  # RAILWAY_PUBLIC_DOMAIN is set per-environment by Railway (production, staging, and
+  # each PR environment all get their own correct value), so this needs no per-environment override.
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('RAILWAY_PUBLIC_DOMAIN', 'cf.mattyanchek.com'),
+    protocol: 'https'
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: 'example.com' }
+  config.action_mailer.default_url_options = { host: 'cf.mattyanchek.com', protocol: 'https' }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Found while wiring up DNS for the Heroku→Railway migration (#1781): `config/environments/production.rb` hardcoded `action_mailer.default_url_options` to `example.com`. Since `User` has Devise's `:recoverable` module enabled, password-reset emails have been generating links to a domain that isn't ours — pre-existing on Heroku too, not introduced by the migration.

**Updated after review feedback:** an earlier version of this PR hardcoded `cf.mattyanchek.com` directly, but that config file applies to every Railway environment — production, staging, and every PR-preview environment all boot `RAILS_ENV=production` — so staging/PR environments would have generated mailer links pointing at production's domain. Now uses `ENV.fetch('RAILWAY_PUBLIC_DOMAIN', 'cf.mattyanchek.com')`, which Railway sets correctly per-environment automatically (confirmed: staging's copy already reflects its own subdomain, not production's), so no per-environment configuration is needed, including for future PR environments.