### PR TITLE
Fix mobile log recording field alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ yarn-debug.log*
 
 # AI
 /.claude
+/.worktrees/

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -24,6 +24,8 @@
     - exercise = exercises[ml_form.index]
     - relevant = exercise && @log.metrics_for_movement_log(exercise).map(&:measurement)
     - load_hidden = relevant && (relevant & %w[lb kg weight]).empty?
+    - distance_unit = ml.distance_unit || 'meter'
+    - distance_unit_label = { 'meter' => 'm', 'foot' => 'ft', 'inch' => 'in' }.fetch(distance_unit, distance_unit)
     .card.mb-3 data-controller="implement-count log-exercise" data-action="change->implement-count#toggle" data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
       .card-body
         = ml_form.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', action: 'change->log-exercise#reveal', 'implement-count-target': 'movementSelect' } }, label: false
@@ -31,14 +33,14 @@
           .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[rep]).empty?)
             = ml_form.input :reps, label: 'Reps', input_html: { class: 'recording-value' }
           .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[seconds time]).empty?)
-            = ml_form.input :duration_seconds, label: 'Duration (s)', input_html: { class: 'recording-value' }
+            = ml_form.input :duration_seconds, as: :group, label: 'Duration', append: 's', input_html: { class: 'recording-value' }
           .col data-log-exercise-target="field" data-implement-count-target="loadField" hidden=load_hidden
-            = ml_form.input :load, label: "Load (#{load_display_unit})", input_html: { class: 'recording-value', value: load_input_value(ml.load) }
+            = ml_form.input :load, as: :group, label: 'Load', append: load_display_unit, input_html: { class: 'recording-value', value: load_input_value(ml.load) }
           .col data-implement-count-target="field" hidden=(!ml.movement&.supports_implement_count? || load_hidden)
             = ml_form.input :implement_count, label: 'Implements'
           .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[distance foot inch meter]).empty?)
-            = ml_form.input :distance, label: "Distance (#{ml.distance_unit || 'meter'})", input_html: { class: 'recording-value' }
-            = ml_form.hidden_field :distance_unit, value: ml.distance_unit || 'meter'
+            = ml_form.input :distance, as: :group, label: 'Distance', append: distance_unit_label, input_html: { class: 'recording-value' }
+            = ml_form.hidden_field :distance_unit, value: distance_unit
           .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[calorie]).empty?)
             = ml_form.input :calories, label: 'Calories', input_html: { class: 'recording-value' }
         .workout-card-toolbar.mt-2

--- a/test/system/log_recording_form_test.rb
+++ b/test/system/log_recording_form_test.rb
@@ -38,4 +38,34 @@ class LogRecordingFormTest < ApplicationSystemTestCase
 
     assert_selector "input[name$='[duration_seconds]']", visible: true
   end
+
+  test 'mobile recording inputs stay aligned when all metrics are visible' do
+    page.driver.browser.manage.window.resize_to(390, 900)
+    visit workout_url(workouts(:fran))
+    click_on 'Log'
+
+    pullup_card = all('.card.mb-3')[1] # Pullups: reps only -- see test/fixtures/exercises.yml
+    within pullup_card do
+      click_on 'Edit'
+    end
+
+    layout = page.evaluate_script(<<~JS)
+      (() => {
+      const card = document.querySelectorAll('.card.mb-3')[1]
+      const inputs = Array.from(card.querySelectorAll('.recording-value')).filter((input) => input.offsetParent !== null)
+      return inputs.map((input) => ({
+        columnTop: Math.round(input.closest('.col').getBoundingClientRect().top),
+        inputTop: Math.round(input.getBoundingClientRect().top)
+      }))
+      })()
+    JS
+
+    layout.group_by { |field| field['columnTop'] }.each_value do |row|
+      input_tops = row.map { |field| field['inputTop'] }
+
+      assert_equal 1, input_tops.uniq.size, "expected mobile recording inputs in each row to align, got: #{layout.inspect}"
+    end
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
 end


### PR DESCRIPTION
## Summary

- Move duration, load, and distance units out of mobile recording labels and into Bootstrap input-group add-ons.
- Add a system test that verifies visible mobile recording inputs align when all metric fields are shown.
- Ignore project-local `.worktrees/` directories so branch worktrees do not pollute status.

## Root Cause

The log recording row used equal-width Bootstrap columns, but unit text lived inside labels. On mobile, labels such as `Duration (s)` and `Distance (meter)` wrapped to two lines, pushing those inputs lower than neighboring fields.

## Validation

- `yarn install`
- `yarn build:css`
- `yarn build`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/log_recording_form_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/lifting_workouts_test.rb`
- `git diff --check`

Note: the Sass build emits existing deprecation warnings from Bootstrap/Sass imports.