### PR TITLE
Fix CFJ-181202 workout rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ yarn-debug.log*
 
 # AI
 /.claude
-/.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ yarn-debug.log*
 
 # AI
 /.claude
+/.worktrees

--- a/app/models/concerns/workout_governing_segment.rb
+++ b/app/models/concerns/workout_governing_segment.rb
@@ -1,0 +1,22 @@
+module WorkoutGoverningSegment
+  extend ActiveSupport::Concern
+
+  # The segment that determines the workout's overall scheme: the sole segment, or the sole schemed
+  # segment when every sibling is named context. Unnamed siblings are real prescribed work, so they
+  # keep the workout from hiding them behind an inner segment's scheme.
+  #
+  # Segments are loaded into an Array before checking one?/many? here: CollectionProxy#one?/
+  # #many?/#count run a SQL query rather than counting the in-memory target, which returns 0 for
+  # an unsaved workout with only just-built (unpersisted) segments -- e.g. CfWod::WorkoutParser's
+  # freshly parsed, not-yet-saved Workout. Array#one?/#many? don't have that problem.
+  def governing_segment
+    parts = segments.to_a
+    return parts.sole if parts.one?
+
+    schemed = parts.select(&:schemed?)
+    return unless schemed.one?
+
+    governing = schemed.sole
+    governing if parts.all? { |part| part == governing || part.name.present? }
+  end
+end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -31,12 +31,7 @@ class Workout < ApplicationRecord
     where(query)
   end
 
-  # The one segment that determines the workout's overall scheme: the sole segment when there's
-  # exactly one, or the sole schemed one when the remaining parts are named context/penalty
-  # segments. nil when no single segment dominates (a genuine multi-part chipper).
-  #
-  # Segments are loaded into an Array before checking one?/many? here: CollectionProxy#one?/
-  # #many?/#count run a SQL query rather than counting the in-memory target, which returns 0 for
+  # Segments are loaded into an Array before checking one?/many?: CollectionProxy#count returns 0 for
   # an unsaved workout with only just-built (unpersisted) segments -- e.g. CfWod::WorkoutParser's
   # freshly parsed, not-yet-saved Workout. Array#one?/#many? don't have that problem.
   def governing_segment
@@ -46,8 +41,7 @@ class Workout < ApplicationRecord
     schemed = parts.select(&:schemed?)
     return unless schemed.one?
 
-    candidate = schemed.sole
-    candidate if parts.all? { |part| part == candidate || part.name.present? }
+    schemed.sole if parts.all? { |part| part == schemed.sole || part.name.present? }
   end
 
   def rounds_for_time?

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -32,8 +32,8 @@ class Workout < ApplicationRecord
   end
 
   # The one segment that determines the workout's overall scheme: the sole segment when there's
-  # exactly one, or the sole schemed one when there are several but only one carries an actual
-  # scheme. nil when no single segment dominates (a genuine multi-part chipper).
+  # exactly one, or the sole schemed one when the remaining parts are named context/penalty
+  # segments. nil when no single segment dominates (a genuine multi-part chipper).
   #
   # Segments are loaded into an Array before checking one?/many? here: CollectionProxy#one?/
   # #many?/#count run a SQL query rather than counting the in-memory target, which returns 0 for
@@ -44,7 +44,10 @@ class Workout < ApplicationRecord
     return parts.sole if parts.one?
 
     schemed = parts.select(&:schemed?)
-    schemed.sole if schemed.one?
+    return unless schemed.one?
+
+    candidate = schemed.sole
+    candidate if parts.all? { |part| part == candidate || part.name.present? }
   end
 
   def rounds_for_time?

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,5 +1,6 @@
 class Workout < ApplicationRecord
   include WorkoutFingerprint
+  include WorkoutGoverningSegment
   include WorkoutPositionReservation
   include WorkoutScoring
 
@@ -29,19 +30,6 @@ class Workout < ApplicationRecord
       q.nil? ? arel_table[:name].matches("%#{word}%") : q.and(arel_table[:name].matches("%#{word}%"))
     end
     where(query)
-  end
-
-  # Segments are loaded into an Array before checking one?/many?: CollectionProxy#count returns 0 for
-  # an unsaved workout with only just-built (unpersisted) segments -- e.g. CfWod::WorkoutParser's
-  # freshly parsed, not-yet-saved Workout. Array#one?/#many? don't have that problem.
-  def governing_segment
-    parts = segments.to_a
-    return parts.sole if parts.one?
-
-    schemed = parts.select(&:schemed?)
-    return unless schemed.one?
-
-    schemed.sole if parts.all? { |part| part == schemed.sole || part.name.present? }
   end
 
   def rounds_for_time?

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -5,6 +5,18 @@ class WorkoutsHelperTest < ActionView::TestCase
   include MeasurableHelper
   include MetricsHelper
 
+  def cfj_181202_workout
+    Workout.new(name: 'CFJ-181202', score_type: :time).tap do |workout|
+      before = workout.segments.build(position: 1)
+      before.exercises.build(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+      couplet = workout.segments.build(rounds: 10, position: 2)
+      couplet.exercises.build(movement: movements(:handstand_push_up), position: 1, reps: 10)
+      couplet.exercises.build(movement: movements(:single_leg_squat), position: 2, reps: 10)
+      after = workout.segments.build(position: 3)
+      after.exercises.build(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+    end
+  end
+
   test 'renders one round for time workouts as for time' do
     workout = Workout.new(name: 'Murph', score_type: :time)
     workout.segments.build(position: 1)
@@ -92,6 +104,10 @@ class WorkoutsHelperTest < ActionView::TestCase
     assert_equal 'On a 10-minute clock for total reps', workout_objective(workout)
   end
 
+  test 'renders a sequential workout with one inner rounds segment as for time' do
+    assert_equal 'For Time', workout_objective(cfj_181202_workout)
+  end
+
   test 'renders timed rep-scored rounds as round amraps' do
     workout = Workout.new(name: 'Back Squat 5x5', score_type: :rep)
     segment = workout.segments.build(rounds: 5, time_seconds: 180, position: 1)
@@ -133,6 +149,12 @@ class WorkoutsHelperTest < ActionView::TestCase
     segment.exercises.build(movement: movements(:pullup), position: 2, reps: 1)
 
     assert_equal "Fran\n21-15-9 for time\nThruster (95 lbs)\nPull Up", workout_as_text(workout)
+  end
+
+  test 'renders sequential workout text without lifting an inner rounds segment to the objective' do
+    assert_equal "CFJ-181202\nFor Time\n800 meter Run\nThen, 10 rounds of\n10 Handstand Push-ups\n" \
+                 "10 Single-leg Squats\n800 meter Run",
+                 workout_as_text(cfj_181202_workout)
   end
 
   test 'includes time cap and notes in the paste-text-box text' do

--- a/test/helpers/workouts_helper_test.rb
+++ b/test/helpers/workouts_helper_test.rb
@@ -7,14 +7,21 @@ class WorkoutsHelperTest < ActionView::TestCase
 
   def cfj_181202_workout
     Workout.new(name: 'CFJ-181202', score_type: :time).tap do |workout|
-      before = workout.segments.build(position: 1)
-      before.exercises.build(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
-      couplet = workout.segments.build(rounds: 10, position: 2)
-      couplet.exercises.build(movement: movements(:handstand_push_up), position: 1, reps: 10)
-      couplet.exercises.build(movement: movements(:single_leg_squat), position: 2, reps: 10)
-      after = workout.segments.build(position: 3)
-      after.exercises.build(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+      build_run_segment(workout, position: 1)
+      build_cfj_181202_couplet(workout)
+      build_run_segment(workout, position: 3)
     end
+  end
+
+  def build_run_segment(workout, position:)
+    segment = workout.segments.build(position: position)
+    segment.exercises.build(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+  end
+
+  def build_cfj_181202_couplet(workout)
+    segment = workout.segments.build(rounds: 10, position: 2)
+    segment.exercises.build(movement: movements(:handstand_push_up), position: 1, reps: 10)
+    segment.exercises.build(movement: movements(:single_leg_squat), position: 2, reps: 10)
   end
 
   test 'renders one round for time workouts as for time' do

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -47,6 +47,20 @@ class WorkoutTest < ActiveSupport::TestCase
     assert_predicate workout, :rounds_for_time?
   end
 
+  test 'a lone schemed segment between unnamed top-level work does not govern the whole workout' do
+    workout = Workout.create!(name: 'CFJ-181202', score_type: :time)
+    before = workout.segments.create!(position: 1)
+    before.exercises.create!(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+    couplet = workout.segments.create!(rounds: 10, position: 2)
+    couplet.exercises.create!(movement: movements(:handstand_push_up), position: 1, reps: 10)
+    couplet.exercises.create!(movement: movements(:single_leg_squat), position: 2, reps: 10)
+    after = workout.segments.create!(position: 3)
+    after.exercises.create!(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+
+    assert_nil workout.governing_segment
+    assert_predicate workout, :rounds_for_time?
+  end
+
   test 'multiple schemed segments have no governing segment (Alec)' do
     workout = Workout.create!(name: 'Alec', score_type: :time)
     triplet = workout.segments.create!(rounds: 3, position: 1)

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -61,6 +61,18 @@ class WorkoutTest < ActiveSupport::TestCase
     assert_predicate workout, :rounds_for_time?
   end
 
+  test 'a lone schemed segment after unnamed top-level work does not govern the whole workout' do
+    workout = Workout.create!(name: 'Buy-in Then Couplet', score_type: :time)
+    buy_in = workout.segments.create!(position: 1)
+    buy_in.exercises.create!(movement: movements(:run), position: 1, reps: 1, distance: 800, distance_unit: :meter)
+    couplet = workout.segments.create!(interval_scheme: '21-15-9', position: 2)
+    couplet.exercises.create!(movement: movements(:thruster), position: 1, reps: 1)
+    couplet.exercises.create!(movement: movements(:pullup), position: 2, reps: 1)
+
+    assert_nil workout.governing_segment
+    assert_predicate workout, :rounds_for_time?
+  end
+
   test 'multiple schemed segments have no governing segment (Alec)' do
     workout = Workout.create!(name: 'Alec', score_type: :time)
     triplet = workout.segments.create!(rounds: 3, position: 1)


### PR DESCRIPTION
## Summary
- prevent an inner rounds segment from being promoted to the whole-workout objective when unnamed work appears before and after it
- add regression coverage for the CFJ-181202 run-couplet-run structure in model and helper tests

## Root Cause
`Workout#governing_segment` treated the lone schemed segment in a multi-part workout as the governing segment even when the surrounding unnamed segments were real prescribed work. For CFJ-181202, that lifted the middle `10 rounds` couplet into the page objective and suppressed the segment label.

## Validation
- `git diff --check`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/models/workout_test.rb test/helpers/workouts_helper_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test`