### PR TITLE
fix: send transactional email via Resend instead of raw SMTP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'sassc-rails' # Requred by rails_admin
 gem 'cancancan'
 gem 'devise'
 
+# ActionMailer delivery method for transactional email (password resets, etc.)
+gem 'resend'
+
 gem 'kaminari' # Pagination
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,10 @@ GEM
     globalid (1.4.0)
       activesupport (>= 6.1)
     hashdiff (1.2.1)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -185,6 +189,8 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.1)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
     nested_form (0.3.2)
     net-imap (0.6.4.1)
       date
@@ -275,6 +281,9 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.6.0)
+      base64
+      httparty (>= 0.22.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -402,6 +411,7 @@ DEPENDENCIES
   puma (~> 8.0)
   rails (~> 8.1.3)
   rails_admin (~> 3.3)
+  resend
   rubocop
   rubocop-capybara
   rubocop-performance

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@cf.mattyanchek.com'
   layout 'mailer'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,15 @@ Rails.application.configure do
   # Raw SMTP isn't usable here: the hosting platform blocks outbound SMTP on this plan tier.
   config.action_mailer.delivery_method = :resend
 
+  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
+  # config.action_mailer.smtp_settings = {
+  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
+  #   password: Rails.application.credentials.dig(:smtp, :password),
+  #   address: "smtp.example.com",
+  #   port: 587,
+  #   authentication: :plain
+  # }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,14 +64,9 @@ Rails.application.configure do
     protocol: 'https'
   }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # Deliver via Resend's HTTPS API (see config/initializers/resend.rb for the API key).
+  # Raw SMTP isn't usable here: the hosting platform blocks outbound SMTP on this plan tier.
+  config.action_mailer.delivery_method = :resend
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,1 @@
+Resend.api_key = ENV.fetch('RESEND_API_KEY', nil)


### PR DESCRIPTION
Found while verifying the Heroku→Railway migration (#1781): password-reset emails (Devise `:recoverable`) crash with `Errno::ECONNREFUSED` trying to reach `localhost:25` — no SMTP delivery method was ever configured, on Heroku either.

Raw SMTP isn't a viable fix here regardless: the hosting platform blocks outbound SMTP on the current plan tier, so even real SMTP credentials from a provider would fail at the network level. Switched to Resend, which delivers over HTTPS and works regardless of plan (free tier: 3,000 emails/month, more than enough for this app's scale).

Requires `RESEND_API_KEY` set on `web` (and `worker`, for safety — no current code path sends mail from there, but nothing should assume that never changes) in every environment. Will be set post-merge before this is verified end-to-end.