### PR TITLE
Fix mobile log recording layout

### DIFF
--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -30,18 +30,18 @@
       .card-body
         = ml_form.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', action: 'change->log-exercise#reveal', 'implement-count-target': 'movementSelect' } }, label: false
         .row.g-2
-          .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[rep]).empty?)
+          .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[rep]).empty?)
             = ml_form.input :reps, label: 'Reps', input_html: { class: 'recording-value' }
-          .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[seconds time]).empty?)
+          .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[seconds time]).empty?)
             = ml_form.input :duration_seconds, as: :group, label: 'Duration', append: 's', input_html: { class: 'recording-value' }
-          .col data-log-exercise-target="field" data-implement-count-target="loadField" hidden=load_hidden
+          .col-6.col-md data-log-exercise-target="field" data-implement-count-target="loadField" hidden=load_hidden
             = ml_form.input :load, as: :group, label: 'Load', append: load_display_unit, input_html: { class: 'recording-value', value: load_input_value(ml.load) }
-          .col data-implement-count-target="field" hidden=(!ml.movement&.supports_implement_count? || load_hidden)
+          .col-6.col-md data-implement-count-target="field" hidden=(!ml.movement&.supports_implement_count? || load_hidden)
             = ml_form.input :implement_count, label: 'Implements'
-          .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[distance foot inch meter]).empty?)
+          .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[distance foot inch meter]).empty?)
             = ml_form.input :distance, as: :group, label: 'Distance', append: distance_unit_label, input_html: { class: 'recording-value' }
             = ml_form.hidden_field :distance_unit, value: distance_unit
-          .col data-log-exercise-target="field" hidden=(relevant && (relevant & %w[calorie]).empty?)
+          .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[calorie]).empty?)
             = ml_form.input :calories, label: 'Calories', input_html: { class: 'recording-value' }
         .workout-card-toolbar.mt-2
           button.btn.btn-sm.btn-outline-secondary type="button" data-log-exercise-target="editButton" data-action="click->log-exercise#reveal click->implement-count#toggle" Edit

--- a/test/system/log_recording_form_test.rb
+++ b/test/system/log_recording_form_test.rb
@@ -49,23 +49,38 @@ class LogRecordingFormTest < ApplicationSystemTestCase
       click_on 'Edit'
     end
 
-    layout = page.evaluate_script(<<~JS)
-      (() => {
-      const card = document.querySelectorAll('.card.mb-3')[1]
-      const inputs = Array.from(card.querySelectorAll('.recording-value')).filter((input) => input.offsetParent !== null)
-      return inputs.map((input) => ({
-        columnTop: Math.round(input.closest('.col').getBoundingClientRect().top),
-        inputTop: Math.round(input.getBoundingClientRect().top)
-      }))
-      })()
-    JS
+    layout = recording_field_layout(pullup_card)
 
-    layout.group_by { |field| field['columnTop'] }.each_value do |row|
+    assert layout.all? { |field| field['fieldWidth'] >= 130 }, layout.inspect
+    assert layout.none? { |field| field['inputOverflows'] || field['overflowsViewport'] }, layout.inspect
+    assert_recording_inputs_align_by_row(layout)
+  ensure
+    page.driver.browser.manage.window.resize_to(1400, 1400)
+  end
+
+  private
+
+  def recording_field_layout(card)
+    card.evaluate_script(<<~JS)
+      Array.from(this.querySelectorAll('[data-log-exercise-target~="field"]:not([hidden])')).map((field) => {
+        const rect = field.getBoundingClientRect()
+        const input = field.querySelector('.recording-value')
+        return {
+          fieldWidth: rect.width,
+          fieldTop: Math.round(rect.top),
+          inputTop: Math.round(input.getBoundingClientRect().top),
+          inputOverflows: input.scrollWidth > input.clientWidth,
+          overflowsViewport: rect.left < 0 || rect.right > window.innerWidth
+        }
+      })
+    JS
+  end
+
+  def assert_recording_inputs_align_by_row(layout)
+    layout.group_by { |field| field['fieldTop'] }.each_value do |row|
       input_tops = row.map { |field| field['inputTop'] }
 
       assert_equal 1, input_tops.uniq.size, "expected mobile recording inputs in each row to align, got: #{layout.inspect}"
     end
-  ensure
-    page.driver.browser.manage.window.resize_to(1400, 1400)
   end
 end


### PR DESCRIPTION
## Summary
- make revealed log recording metric fields use two-across mobile columns before returning to flexible desktop columns
- strengthen the mobile system test to catch compressed fields, input overflow, viewport overflow, and row alignment

## Root Cause
The log recording form used equal Bootstrap `.col` fields for every revealed metric. On a narrow viewport, revealing all metrics forced five controls into one row at roughly 85px each.

## Validation
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/log_recording_form_test.rb`
- `git diff --check HEAD~1..HEAD`