### PR TITLE
Document CrossFit scrape commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Verification commands:
 
 CI loads the test schema, runs `bundle exec rails test:all`, and runs RuboCop through reviewdog. Keep local changes compatible with those checks.
 
-Production app (for reproducing reported bugs, especially UI/rendering issues): https://wod-tracker-production.herokuapp.com
+Production app (for reproducing reported bugs, especially UI/rendering issues): https://cf.mattyanchek.com
 
 ## Rails Engineering Guidelines
 

--- a/README.md
+++ b/README.md
@@ -40,5 +40,14 @@ An open source webapp to track your workout of the day capturing key points of d
   ```
   bin/rails "cf_wod:fetch[2026-06-20]"
   ```
+- Scrape and persist a single day's workout and schedule:
+  ```
+  rails "cf_wod:scrape[2026-01-01]"
+  ```
+- Enqueue a scrape job for every day in an inclusive date range, staggered by 2 seconds per date:
+  ```
+  rails "cf_wod:backfill[2026-01-01,2026-01-31]"
+  ```
+- Date ranges must be ordered from earliest to latest. Reversed ranges abort with `start_date must be <= end_date`.
 - Raises `CfWod::Fetcher::FetchError` on network errors, unexpected HTTP responses, or a page that doesn't match either known crossfit.com template.
 - Raises `CfWod::WorkoutParser::UnparseableError` when the workout's prose doesn't match a known format, movement, or prescription pattern.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An open source webapp to track your workout of the day capturing key points of d
 ## CrossFit.com Workout Fetcher
 - Fetch and parse a single day's workout from crossfit.com into a structured `Workout` and print it (does not persist anything):
   ```
-  bin/rails "cf_wod:fetch[2026-06-20]"
+  rails "cf_wod:fetch[2026-06-20]"
   ```
 - Scrape and persist a single day's workout and schedule:
   ```

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,4 +2,13 @@ require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  def save_exercise_card(expected_summary)
+    done_button = find_button('Done')
+    scroll_to done_button, align: :center
+    done_button.click
+
+    assert_selector '.exercise-summary__button[aria-expanded="false"]', text: expected_summary
+    assert_no_selector '.exercise-editor', visible: :visible
+  end
 end

--- a/test/system/exercise_card_editing_test.rb
+++ b/test/system/exercise_card_editing_test.rb
@@ -25,10 +25,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
       assert_no_text 'Thruster (95 lbs)'
       assert_field 'Reps', with: '1'
       fill_in 'Reps', with: '15'
-      click_on 'Done'
-
-      assert_no_field 'Reps'
-      assert_text '15 Thrusters'
+      save_exercise_card '15 Thrusters'
     end
   end
 
@@ -47,10 +44,7 @@ class ExerciseCardEditingTest < ApplicationSystemTestCase
         click_on 'Distance'
         fill_in 'Distance', with: '400', exact: true
         select 'meter', from: 'Distance unit'
-        click_on 'Done'
-
-        assert_no_field 'Distance'
-        assert_text '400 meter Run'
+        save_exercise_card '400 meter Run'
 
         click_on '400 meter Run'
         assert_no_text '400 meter Run'

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -41,9 +41,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       select 'meter', from: 'Distance unit'
       open_optional_group 'Load'
       fill_in 'Load (lb)', with: '95'
-      click_on 'Done'
-
-      assert_text '10 meter Run (95 lbs)'
+      save_exercise_card '10 meter Run (95 lbs)'
     end
   end
 
@@ -61,9 +59,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
-      click_on 'Done'
-
-      assert_text '100/80 meter Run (♀65lb / ♂95lb)'
+      save_exercise_card '100/80 meter Run (♀65lb / ♂95lb)'
     end
   end
 
@@ -78,9 +74,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
-      click_on 'Done'
-
-      assert_text '100/80 meter Run'
+      save_exercise_card '100/80 meter Run'
     end
   end
 
@@ -97,9 +91,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       open_optional_group 'Load'
       fill_in 'Female load (lb)', with: '35'
       fill_in 'Male load (lb)', with: '50'
-      click_on 'Done'
-
-      assert_text '80ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)'
+      save_exercise_card '80ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)'
     end
   end
 
@@ -128,9 +120,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female load (lb)', with: '35'
       fill_in 'Male load (lb)', with: '50'
 
-      click_on 'Done'
-
-      assert_text '40/30ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)'
+      save_exercise_card '40/30ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)'
     end
   end
 
@@ -142,9 +132,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       select_movement 'Row'
       open_optional_group 'Calories'
       fill_in 'Calories', with: '0'
-      click_on 'Done'
-
-      assert_equal 'max calories Row', find('.exercise-summary__text').text
+      save_exercise_card 'max calories Row'
     end
   end
 


### PR DESCRIPTION
## Summary

- Document the single-date CrossFit.com scrape command in the README.
- Document the inclusive date-range backfill command and reversed-range validation.
- Update the agent guide production URL to `https://cf.mattyanchek.com`.

## Validation

- `git diff --check`