### PR TITLE
Fix GHD sit-up movement lookup

### DIFF
--- a/app/services/cf_wod/movement_lookup.rb
+++ b/app/services/cf_wod/movement_lookup.rb
@@ -1,10 +1,5 @@
 module CfWod
   class MovementLookup
-    # Minor connector words the catalog's own naming leaves lowercase mid-phrase (e.g. "Clean and
-    # Jerk", "Power Clean and Split Jerk") -- standard English title-case convention, not specific
-    # to this app. Still capitalized as the first word of a name.
-    CONNECTOR_WORDS = %w[and to of the a an or].freeze
-
     def self.call(name) = new(name).lookup
 
     def initialize(name)
@@ -12,12 +7,17 @@ module CfWod
     end
 
     def lookup
-      Movement.find_by(name: normalized_name(/\s+/)) || Movement.find_by(name: normalized_name(/[\s-]+/))
+      find_by_normalized_name(/\s+/) || find_by_normalized_name(/[\s-]+/)
     end
 
     private
 
     attr_reader :name
+
+    def find_by_normalized_name(word_separator)
+      # Movement validates case-insensitive name uniqueness, so this can match at most one row.
+      Movement.find_by('LOWER(name) = ?', normalized_name(word_separator))
+    end
 
     # The catalog is inconsistent about whether a compound term is hyphenated (e.g. "Wall-ball
     # Shot") or fully spaced (e.g. "Toes to Bar"), while prose always hyphenates compounds like
@@ -26,13 +26,7 @@ module CfWod
     # hyphens too, so a fully-spaced catalog entry can still be found.
     def normalized_name(word_separator)
       base = name.to_s.strip.delete_suffix('.').downcase.singularize
-      base.split(word_separator).each_with_index.map { |word, index| titlecase_word(word, first: index.zero?) }.join(' ')
-    end
-
-    def titlecase_word(word, first:)
-      return word if !first && CONNECTOR_WORDS.include?(word)
-
-      word.sub(/\A\w/, &:upcase)
+      base.split(word_separator).join(' ')
     end
   end
 end

--- a/test/services/cf_wod/movement_lookup_test.rb
+++ b/test/services/cf_wod/movement_lookup_test.rb
@@ -19,7 +19,7 @@ module CfWod
       assert_nil MovementLookup.call('a completely unrecognized movement phrase')
     end
 
-    test 'keeps connector words lowercase except as the first word' do
+    test 'matches connector-word names case insensitively' do
       clean_and_jerk = Movement.find_or_create_by(name: 'Clean and Jerk')
       assert_equal clean_and_jerk, MovementLookup.call('clean and jerks')
     end
@@ -27,6 +27,11 @@ module CfWod
     test 'falls back to treating a hyphenated compound as space-separated words' do
       toes_to_bar = Movement.find_or_create_by(name: 'Toes to Bar')
       assert_equal toes_to_bar, MovementLookup.call('toes-to-bars')
+    end
+
+    test 'matches catalog acronyms case insensitively' do
+      ghd_sit_up = Movement.find_or_create_by(name: 'GHD Sit-up')
+      assert_equal ghd_sit_up, MovementLookup.call('GHD sit-ups')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes workout scraping for movement names like `GHD sit-ups` by making `CfWod::MovementLookup` compare normalized candidate names against catalog movement names case-insensitively.

## Root Cause

The scraper normalized `GHD sit-ups` to a titlecased candidate like `Ghd Sit-up`, then performed a case-sensitive lookup. That missed the catalog entry `GHD Sit-up`, causing `unrecognized movement: "GHD sit-ups"`.

## Impact

Acronym-styled catalog movement names can now be matched from scraped prose without adding one-off aliases.

## Verification

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/services/cf_wod/movement_lookup_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/services/cf_wod/workout_parser_test.rb test/services/cf_wod/workout_parser_corpus_test.rb test/services/workout_extraction/llm_parser_test.rb`
- `git diff --check HEAD~1 HEAD`