### PR TITLE
fix: match Devise's mailer_sender to the verified Resend domain

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -23,7 +23,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'no-reply@wod-tracker.com'
+  config.mailer_sender = 'noreply@cf.mattyanchek.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Follow-up to #1803: the from-address fix I made in `app/mailers/application_mailer.rb` didn't actually apply to Devise's password-reset emails, because `Devise::Mailer` uses its own `config.mailer_sender` (in `config/initializers/devise.rb`), which takes precedence over `ApplicationMailer`'s `default from:`. Confirmed via production logs after merging #1803 — forgot-password still 500'd, this time with `Resend::Error: The wod-tracker.com domain is not verified`, since `config.mailer_sender` was still pointing at the old `wod-tracker.com` address.

Updates it to `noreply@cf.mattyanchek.com`, matching the domain you just verified with Resend.