### PR TITLE
Split strength-then-metcon workouts into separate segments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,12 @@ Metrics/ClassLength:
     - test/helpers/workouts_helper_test.rb
     - test/jobs/scrape_cf_wod_job_test.rb
 
+Metrics/ModuleLength:
+  Exclude:
+    # Almost entirely a single prose heredoc (the LLM extraction prompt): its length tracks the
+    # amount of extraction guidance, not any code complexity, the same shape as the excludes above.
+    - app/services/workout_extraction/system_prompt.rb
+
 Metrics/MethodLength:
   CountComments: false
   Max: 20

--- a/app/services/workout_extraction/system_prompt.rb
+++ b/app/services/workout_extraction/system_prompt.rb
@@ -62,7 +62,10 @@ module WorkoutExtraction
           "Power clean 3-3-2-2-1-1-1-1 reps"), use "score_type": "weight" and do not set
           "interval". When all sets use the same reps, set top-level "rounds" to the set count and
           include one exercise with that reps value. When reps vary by set, omit "rounds" and list
-          one exercise per set in order, each with that set's reps.
+          one exercise per set in order, each with that set's reps. (When the lifting scheme is only
+          ONE part of a larger workout -- see the strength-then-conditioning rule below -- put its
+          "rounds"/exercise on that part's own segment, and let the workout "score_type" follow the
+          scored conditioning piece rather than "weight".)
         - For an exercise driven by an interval scheme (the workout's own "interval", or its
           segment's "interval_scheme"), set that exercise's plain "reps" -- or plain "calories" for
           a calorie-scored movement like a Calorie Row -- to 1, a structural placeholder, never the
@@ -81,6 +84,15 @@ module WorkoutExtraction
           one list of movements (e.g. "6 rounds of: 1 minute rowing, 1 minute burpees, 1 minute
           rest") is NOT multiple parts -- that's a flat list of top-level exercises, each with its
           own "duration_seconds"; do not wrap them in a segment just to hold a shared note.
+        - A strength/lifting scheme immediately followed by a distinct conditioning piece is TWO
+          parts even with no "Part A/Part B" labels -- the boundary is the change of scheme, often
+          marked by "Then," or a blank line (e.g. "Overhead squat 8-8-8-8 reps" then "AMRAP 6 of:
+          40 overhead squats, 30 deficit push-ups"). Emit one segment for the strength work and a
+          second segment for the conditioning work, each carrying its own
+          rounds/time_seconds/interval_scheme; never fold the strength sets into the conditioning
+          segment (that wrongly counts them as part of the metcon). Set the workout "score_type"
+          from the scored conditioning piece (e.g. "rep" for a closing AMRAP), not "weight" -- the
+          strength segment still lists its own loaded exercise(s) with their loads.
         - "movement_name" must be copied verbatim from this exact list of recognized movements (case and
           spelling matter):
           #{Movement.pluck(:name).sort.join(', ')}

--- a/test/services/workout_extraction/llm_parser_test.rb
+++ b/test/services/workout_extraction/llm_parser_test.rb
@@ -147,6 +147,39 @@ module WorkoutExtraction
       assert_equal [movement], segment.exercises.map(&:movement).uniq
     end
 
+    # Regression guard for CF-260422 (workout 405): a strength scheme ("Overhead squat 8-8-8-8
+    # reps") then "Then," + a separate 6-minute AMRAP is TWO parts, not one. The LLM had merged
+    # them into a single AMRAP segment that swept the strength sets in with the metcon movements.
+    # This locks the two-segment shape the builder must produce from the corrected output.
+    test 'builds a strength piece and a conditioning piece as two separate segments' do
+      overhead_squat = Movement.find_or_create_by!(name: 'Overhead Squat')
+      deficit_push_up = Movement.find_or_create_by!(name: 'Deficit Push-up')
+      ohs = ->(reps) { exercise_payload(movement_name: overhead_squat.name, reps: reps, female_load: 55, male_load: 75) }
+      deficit = exercise_payload(movement_name: deficit_push_up.name, reps: 30, female_distance: 2, male_distance: 4, distance_unit: 'inch')
+      stub_llm_response(
+        extractable: true, name: 'CF-260422', score_type: 'rep',
+        segments: [
+          { name: 'Overhead squat', rounds: 4, exercises: [ohs.call(8)] },
+          { name: nil, time_seconds: 360, exercises: [ohs.call(40), deficit] }
+        ],
+        exercises: []
+      )
+
+      workout = WorkoutExtraction::LlmParser.call('Overhead squat 8-8-8-8, then AMRAP 6', date: DATE)
+
+      assert workout.valid?
+      assert_equal 'rep', workout.score_type
+      strength, amrap = workout.segments.sort_by(&:position)
+      assert_equal 2, workout.segments.size
+      assert_equal 'Overhead squat', strength.name
+      assert_equal 4, strength.rounds
+      assert_equal [overhead_squat], strength.exercises.map(&:movement)
+      assert_equal [8], strength.exercises.map(&:reps)
+      assert_equal 360, amrap.time_seconds
+      assert_equal [overhead_squat, deficit_push_up], amrap.exercises.map(&:movement)
+      assert_equal [40, 30], amrap.exercises.map(&:reps)
+    end
+
     test 'marks only barbell-family movements load-bearing in manually scored weight workouts' do
       barbell_movements = load_bearing_barbell_movements
       pull_up = movements(:pull_up)


### PR DESCRIPTION
## Problem

[Workout 405 (`CF-260422`)](https://cf.mattyanchek.com/workouts/405) was scraped incorrectly — reported by the site owner as "wrong scheme/structure."

The real crossfit.com WOD for 2026-04-22 is **two parts**:

```
Overhead squat 8-8-8-8 reps        ← strength, load-scored
Then,
AMRAP 6 min:                       ← metcon, rep-scored
  40 overhead squats
  30 deficit push-ups
```

Production collapsed it into a **single 6-minute AMRAP** named "Overhead squat" containing the four literal 8-rep strength sets **plus** the 40 OHS + 30 deficit push-ups — the strength work got counted as part of the metcon.

## Root cause

Workout structure comes entirely from the LLM's JSON (`config.workout_parser = :llm`). The system prompt only endorsed segment-splitting for **explicitly labeled** parts ("Part A/Part B", "Buy-in"), so the `Then,` strength→conditioning boundary — a very common CrossFit format — got merged. The one deterministic lifting-set correction only fires when the *whole* workout is `weight`-scored, so it didn't catch this either. The data model already supports the correct two-segment shape (e.g. "City 100", "Dallas 5").

## Change

- **`system_prompt.rb`** — new rule: a strength/lifting scheme immediately followed by a distinct conditioning piece is **two segments** (boundary = change of scheme, often `Then,`/blank line), each carrying its own `rounds`/`time_seconds`/`interval_scheme`; the workout `score_type` follows the scored conditioning piece, not `weight`. Plus a reconciling clause on the existing lifting-set rule for the multi-part case.
- **`llm_parser_test.rb`** — regression test locking the two-segment shape the builder must produce from the corrected output.
- **`.rubocop.yml`** — excluded the prose-only prompt module from `Metrics/ModuleLength` (length tracks extraction guidance, not code complexity), matching the repo's existing length-exclusion pattern.

## Verification

- `llm_parser_test` — 10 runs, 0 failures
- workout-extraction + scrape-job + rake suite — 44 runs, 0 failures
- rubocop — clean

**Note:** the parser test stubs the LLM (as the whole suite does), so it documents/guards the target shape but can't prove the prompt now elicits the split. That needs a live check:

```
bin/rails "cf_wod:fetch[2026-04-22]"
```

Once confirmed, re-scrape prod to fix the data:

```
bin/rails "cf_wod:scrape[2026-04-22]"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)