### PR TITLE
Show calculated load score while logging

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("ladder-step", LadderStepController)
 import LogExerciseController from "./log_exercise_controller.js"
 application.register("log-exercise", LogExerciseController)
 
+import LiftingScoreController from "./lifting_score_controller.js"
+application.register("lifting-score", LiftingScoreController)
+
 import SegmentCardController from "./segment_card_controller.js"
 application.register("segment-card", SegmentCardController)
 

--- a/app/javascript/controllers/lifting_score_controller.js
+++ b/app/javascript/controllers/lifting_score_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Mirrors Workout#lifting_score / successful_set_load for immediate display while logging a
+// calculated lifting score. LogScoring still recalculates on submit; this controller is only a
+// preview, so keep it in sync with the server algorithm when scoring rules change.
+export default class extends Controller {
+  static targets = ["score", "set", "reps", "load"]
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    if (!this.hasScoreTarget) return
+
+    const heaviestLoad = this.setTargets.reduce((heaviest, set) => {
+      const prescribedReps = this.numberValue(set.dataset.liftingScorePrescribedReps)
+      const reps = this.numberValue(this.repsTargetFor(set)?.value)
+      const load = this.numberValue(this.loadTargetFor(set)?.value)
+
+      // This is not a validation layer or the submitted source of truth; it only includes sets
+      // that already look complete and successful enough to preview a score.
+      if (prescribedReps === null || reps === null || load === null || reps < prescribedReps) {
+        return heaviest
+      }
+
+      return heaviest === null ? load : Math.max(heaviest, load)
+    }, null)
+
+    this.scoreTarget.value = heaviestLoad === null ? "" : heaviestLoad
+  }
+
+  repsTargetFor(set) {
+    return this.repsTargets.find((target) => set.contains(target))
+  }
+
+  loadTargetFor(set) {
+    return this.loadTargets.find((target) => set.contains(target))
+  }
+
+  numberValue(value) {
+    if (value === undefined || value === null || value === "") return null
+
+    const number = Number(value)
+    return Number.isNaN(number) ? null : number
+  }
+}

--- a/app/views/logs/_form.html.slim
+++ b/app/views/logs/_form.html.slim
@@ -1,4 +1,5 @@
-= simple_form_for [@workout, @log], wrapper: :input_group do |f|
+- form_data = @workout.calculated_lifting_score? ? { controller: 'lifting-score' } : {}
+= simple_form_for [@workout, @log], wrapper: :input_group, html: { data: form_data } do |f|
   = f.error_notification
   .row.mt-3.g-2
     .col
@@ -13,7 +14,8 @@
   .row.g-2
     = f.input :score_type, as: :hidden
     - if @workout.calculated_lifting_score?
-      .col
+      .col aria-live="polite"
+        = f.input :score_value, as: :group, prepend: @log.score_measurement, label: false, disabled: true, input_html: { value: load_input_value(@log.score_value), data: { 'lifting-score-target': 'score' }, aria: { label: 'Calculated score' } }
         p.form-text Score will be calculated from the heaviest successful load.
     - else
       .col = f.input :score_value, as: :group, prepend: @log.score_measurement, label: false
@@ -24,18 +26,19 @@
     - exercise = exercises[ml_form.index]
     - relevant = exercise && @log.metrics_for_movement_log(exercise).map(&:measurement)
     - load_hidden = relevant && (relevant & %w[lb kg weight]).empty?
+    - prescribed_reps = exercise&.prescription_metrics&.find(&:rep?)&.value
     - distance_unit = ml.distance_unit || 'meter'
     - distance_unit_label = { 'meter' => 'm', 'foot' => 'ft', 'inch' => 'in' }.fetch(distance_unit, distance_unit)
-    .card.mb-3 data-controller="implement-count log-exercise" data-action="change->implement-count#toggle" data-implement-count-movement-ids-value=implement_count_movement_ids.to_json
+    .card.mb-3 data-controller="implement-count log-exercise" data-action="change->implement-count#toggle" data-implement-count-movement-ids-value=implement_count_movement_ids.to_json data-lifting-score-target=(@workout.calculated_lifting_score? ? 'set' : nil) data-lifting-score-prescribed-reps=prescribed_reps
       .card-body
         = ml_form.input :movement_id, collection: Movement.all, prompt: 'Select Movement', input_html: { class: 'movement', data: { controller: 'movement-select', action: 'change->log-exercise#reveal', 'implement-count-target': 'movementSelect' } }, label: false
         .row.g-2
           .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[rep]).empty?)
-            = ml_form.input :reps, label: 'Reps', input_html: { class: 'recording-value' }
+            = ml_form.input :reps, label: 'Reps', input_html: { class: 'recording-value', data: { 'lifting-score-target': ('reps' if @workout.calculated_lifting_score?), action: ('input->lifting-score#update' if @workout.calculated_lifting_score?) } }
           .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[seconds time]).empty?)
             = ml_form.input :duration_seconds, as: :group, label: 'Duration', append: 's', input_html: { class: 'recording-value' }
           .col-6.col-md data-log-exercise-target="field" data-implement-count-target="loadField" hidden=load_hidden
-            = ml_form.input :load, as: :group, label: 'Load', append: load_display_unit, input_html: { class: 'recording-value', value: load_input_value(ml.load) }
+            = ml_form.input :load, as: :group, label: 'Load', append: load_display_unit, input_html: { class: 'recording-value', value: load_input_value(ml.load), data: { 'lifting-score-target': ('load' if @workout.calculated_lifting_score?), action: ('input->lifting-score#update' if @workout.calculated_lifting_score?) } }
           .col-6.col-md data-implement-count-target="field" hidden=(!ml.movement&.supports_implement_count? || load_hidden)
             = ml_form.input :implement_count, label: 'Implements'
           .col-6.col-md data-log-exercise-target="field" hidden=(relevant && (relevant & %w[distance foot inch meter]).empty?)

--- a/test/system/lifting_workouts_test.rb
+++ b/test/system/lifting_workouts_test.rb
@@ -16,7 +16,8 @@ class LiftingWorkoutsTest < ApplicationSystemTestCase
 
     click_on 'Log'
 
-    assert_no_selector '#log_score_value'
+    assert_selector '#log_score_value:disabled'
+    assert_field 'log_score_value', with: '', disabled: true
     assert_text 'Score will be calculated from the heaviest successful load.'
     assert_selector '.card.mb-3', count: 5
     movement_logs = all('.card.mb-3')
@@ -29,11 +30,43 @@ class LiftingWorkoutsTest < ApplicationSystemTestCase
     [95, 115, 135, 145, 155].each.with_index do |load, index|
       movement_logs[index].all('.recording-value')[1].set(load)
     end
+    assert_field 'log_score_value', with: '155', disabled: true
+
     movement_logs[4].first('.recording-value').set(2)
+    assert_field 'log_score_value', with: '145', disabled: true
 
     click_on 'Save'
 
     assert_current_path %r{/logs/\d+}
     assert_text '145 lbs'
+  end
+
+  test 'calculates lifting score from each exercise prescribed reps' do
+    workout = Workout.create!(name: 'Mixed Heavy Day', score_type: :weight)
+    segment = workout.segments.create!(position: 1, rounds: 1)
+    segment.exercises.create!(movement: movements(:back_squat), position: 1, reps: 5, load: 0)
+    segment.exercises.create!(movement: movements(:deadlift), position: 2, reps: 3, load: 0)
+
+    visit workout_url(workout)
+
+    click_on 'Log'
+
+    movement_logs = all('.card.mb-3')
+    assert_equal(
+      [['5', ''], ['3', '']],
+      movement_logs.map { |movement_log| movement_log.all('.recording-value').map(&:value) }
+    )
+
+    movement_logs[0].all('.recording-value')[1].set(225)
+    movement_logs[1].all('.recording-value')[1].set(315)
+    assert_field 'log_score_value', with: '315', disabled: true
+
+    movement_logs[1].first('.recording-value').set(2)
+    assert_field 'log_score_value', with: '225', disabled: true
+
+    click_on 'Save'
+
+    assert_current_path %r{/logs/\d+}
+    assert_text '225 lbs'
   end
 end


### PR DESCRIPTION
## Summary
- Show a disabled score field for calculated lifting workouts while logging.
- Add a Stimulus controller that mirrors the heaviest successful logged load as set loads and reps change.
- Update the lifting workout system test to cover the visible disabled score field and live recalculation.

## Validation
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/models/log_test.rb`
- `yarn install`
- `yarn build`
- `yarn build:css`
- `rvm 4.0.5@wod-tracker do bundle exec rails test test/system/lifting_workouts_test.rb`
- `git diff --check`

Note: one parallel system-test run hit a PostgreSQL deadlock while another Rails test process was active; rerunning the system test by itself passed.