### PR TITLE
Add infinite scroll to workouts index

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -6,7 +6,7 @@ class WorkoutsController < ApplicationController
   # GET /workouts
   # GET /workouts.json
   def index
-    @workouts = Workout.search_by_name(params[:query]).order(created_at: :desc)
+    @workouts = Workout.search_by_name(params[:query]).order(created_at: :desc).page(params[:page])
   end
 
   # GET /workouts/1

--- a/app/views/workouts/_page.html.slim
+++ b/app/views/workouts/_page.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag "workouts_page_#{workouts.current_page}" do
-  .list-group.my-3
+  .list-group
     = render workouts
   - if workouts.next_page
-    = turbo_frame_tag "workouts_page_#{workouts.next_page}", loading: :lazy, src: workouts_path(page: workouts.next_page, query: params[:query])
+    = turbo_frame_tag "workouts_page_#{workouts.next_page}", loading: :lazy, src: workouts_path(page: workouts.next_page, query: query)

--- a/app/views/workouts/_page.html.slim
+++ b/app/views/workouts/_page.html.slim
@@ -1,0 +1,5 @@
+= turbo_frame_tag "workouts_page_#{workouts.current_page}" do
+  .list-group.my-3
+    = render workouts
+  - if workouts.next_page
+    = turbo_frame_tag "workouts_page_#{workouts.next_page}", loading: :lazy, src: workouts_path(page: workouts.next_page, query: params[:query])

--- a/app/views/workouts/_workouts.html.slim
+++ b/app/views/workouts/_workouts.html.slim
@@ -1,2 +1,2 @@
-= turbo_frame_tag 'workouts' do
-  = render 'page', workouts: workouts
+= turbo_frame_tag 'workouts', class: 'my-3' do
+  = render 'page', workouts: workouts, query: params[:query]

--- a/app/views/workouts/_workouts.html.slim
+++ b/app/views/workouts/_workouts.html.slim
@@ -1,2 +1,2 @@
-= turbo_frame_tag 'workouts', class: 'list-group my-3' do
-  = render workouts
+= turbo_frame_tag 'workouts' do
+  = render 'page', workouts: workouts

--- a/app/views/workouts/index.html+turbo_frame.slim
+++ b/app/views/workouts/index.html+turbo_frame.slim
@@ -1,2 +1,1 @@
-= turbo_frame_tag 'workouts', class: 'list-group my-3' do
-  = render @workouts
+= render 'workouts', workouts: @workouts

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -26,7 +26,8 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
   test 'index last page renders no further lazy frame' do
     30.times { |i| Workout.create!(name: "Filler WOD #{i}", score_type: :time) }
 
-    get workouts_url(page: 2)
+    last_page = (Workout.count.to_f / Kaminari.config.default_per_page).ceil
+    get workouts_url(page: last_page)
 
     assert_response :success
     assert_select 'turbo-frame[loading="lazy"]', count: 0

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -13,6 +13,34 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'index page one renders a lazy frame chaining to the next page' do
+    30.times { |i| Workout.create!(name: "Filler WOD #{i}", score_type: :time) }
+
+    get workouts_url
+
+    assert_response :success
+    assert_select 'turbo-frame#workouts_page_1'
+    assert_select 'turbo-frame#workouts_page_2[loading="lazy"][src=?]', workouts_path(page: 2)
+  end
+
+  test 'index last page renders no further lazy frame' do
+    30.times { |i| Workout.create!(name: "Filler WOD #{i}", score_type: :time) }
+
+    get workouts_url(page: 2)
+
+    assert_response :success
+    assert_select 'turbo-frame[loading="lazy"]', count: 0
+  end
+
+  test 'search carries the query into the next-page lazy frame' do
+    30.times { |i| Workout.create!(name: "Cindy Variant #{i}", score_type: :round) }
+
+    get workouts_url(query: 'Cindy')
+
+    assert_response :success
+    assert_select 'turbo-frame#workouts_page_2[src=?]', workouts_path(page: 2, query: 'Cindy')
+  end
+
   test 'should get new' do
     get new_workout_url
     assert_response :success

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -74,6 +74,12 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
+
+      # Typing into the sex-specific distance fields toggles derived distance UI before the
+      # card can be saved. Wait for the final field value to settle so the Done click is not
+      # racing the exercise-form controller update in CI.
+      assert_field 'Male distance', with: '100'
+
       save_exercise_card '100/80 meter Run'
     end
   end


### PR DESCRIPTION
## Summary

- Paginate `workouts#index` with Kaminari while preserving the existing search query and ordering.
- Add nested lazy Turbo Frames so page 2+ loads on scroll without custom JavaScript.
- Share the same partial structure for full-page, search-frame, and scroll-frame responses.

## Validation

- `rvm 4.0.5@wod-tracker do bin/rails test:all` — 528 runs, 1635 assertions, 0 failures, 0 errors
- `rvm 4.0.5@wod-tracker do bundle exec rubocop --parallel` — 172 files inspected, no offenses

Closes #1816
