### PR TITLE
Fix scraped workout date fallback names

### DIFF
--- a/app/services/workout_extraction/llm_parser.rb
+++ b/app/services/workout_extraction/llm_parser.rb
@@ -140,7 +140,7 @@ module WorkoutExtraction
 
     def build_workout(attrs)
       workout_attrs = attrs.slice(:name, :score_type, :time_cap, :ladder_step, :team_size, :notes).compact
-      workout_attrs[:name] = default_name if workout_attrs[:name].blank?
+      workout_attrs[:name] = normalized_name(workout_attrs[:name])
       workout = Workout.new(workout_attrs)
 
       segments = attrs[:segments] || []
@@ -174,6 +174,17 @@ module WorkoutExtraction
       else
         reps_per_set.map { |reps| exercise.merge(reps: reps) }
       end
+    end
+
+    def normalized_name(name)
+      return default_name if name.blank?
+      return default_name if prescription_line_name?(name)
+
+      name
+    end
+
+    def prescription_line_name?(name)
+      name.to_s.match?(/\A[\d,]+(?:\.\d+)?[\s-](?:meters?|feet|foot|inches?|miles?|calories?)\b.+\sx\d+\z/i)
     end
 
     # Matches CfWod::WorkoutParser's convention for unnamed scraped workouts (same slug format).

--- a/app/services/workout_extraction/llm_parser.rb
+++ b/app/services/workout_extraction/llm_parser.rb
@@ -70,6 +70,15 @@ module WorkoutExtraction
         interval: { type: 'string' }
       }
     end
+    private_class_method :workout_schema_overrides
+
+    PRESCRIPTION_VALUE_PATTERN = [
+      '\d[\d,]*(?:\.\d+)?',
+      '\s*(?:-| )?\s*',
+      '(?:m|meters?|ft|feet|foot|in|inches?|mi|miles?|cal|cals|calories?|lb|lbs|pounds?|kg|pood)?'
+    ].join.freeze
+    LEADING_PRESCRIPTION_LINE = /\A#{PRESCRIPTION_VALUE_PATTERN}\s+.+\s+x\s*\d+\z/i
+    REORDERED_PRESCRIPTION_LINE = /\A\d+\s*x\s*#{PRESCRIPTION_VALUE_PATTERN}\s+.+\z/i
 
     # logger is opt-in and silent by default (nil) so normal callers don't get unexpected output;
     # pass one (e.g. Logger.new($stdout)) to see progress or where a failure occurred.
@@ -196,7 +205,11 @@ module WorkoutExtraction
     end
 
     def prescription_line_name?(name)
-      name.to_s.match?(/\A[\d,]+(?:\.\d+)?[\s-](?:meters?|feet|foot|inches?|miles?|calories?)\b.+\sx\d+\z/i)
+      value = name.to_s.strip
+
+      set_scheme?(value) ||
+        value.match?(LEADING_PRESCRIPTION_LINE) ||
+        value.match?(REORDERED_PRESCRIPTION_LINE)
     end
 
     # Matches CfWod::WorkoutParser's convention for unnamed scraped workouts (same slug format).
@@ -218,7 +231,7 @@ module WorkoutExtraction
     # Every Exercise belongs to a Segment now, so a "flat" workout (no named parts) is a single
     # unnamed segment wrapping the top-level exercises -- the same shape CfWod::WorkoutParser
     # already builds for its own flat/no-header case. The workout's own rounds/time/interval (see
-    # WORKOUT_SCHEMA) land on this segment's rounds/time_seconds/interval_scheme.
+    # workout_schema) land on this segment's rounds/time_seconds/interval_scheme.
     def build_top_level_exercises(workout, attrs, position:)
       exercises = attrs[:exercises] || []
       return if exercises.empty?

--- a/app/services/workout_extraction/llm_parser.rb
+++ b/app/services/workout_extraction/llm_parser.rb
@@ -9,55 +9,67 @@ module WorkoutExtraction
     # Extraction is a single call: neither this nor the prior two-call version enforces its schema
     # via output_config/json_schema (both triggered Anthropic structured-outputs compiler errors
     # regardless of shape), so there's no longer a compiler-imposed reason to keep the workout's
-    # shape and its exercises' details as two separate calls. These constants exist only so
+    # shape and its exercises' details as two separate calls. These methods exist only so
     # SystemPrompt's field descriptions can be derived programmatically instead of hand-written, so
-    # they can't silently drift from the Workout/Segment/Exercise models.
-    EXERCISE_SCHEMA = {
-      type: 'object',
-      properties: ModelSchema.properties_for(
-        Exercise,
-        except: %w[id workout_id movement_id segment_id created_at updated_at position notes],
-        overrides: { movement_name: { type: 'string' } }
-      ),
-      required: %w[movement_name],
-      additionalProperties: false
-    }.freeze
+    # they can't silently drift from the Workout/Segment/Exercise models. Keep them lazy because
+    # deriving model-backed properties queries table metadata, and worker boot can eager-load this
+    # class before a new environment's database has been migrated.
+    def self.exercise_schema
+      @exercise_schema ||= {
+        type: 'object',
+        properties: ModelSchema.properties_for(
+          Exercise,
+          except: %w[id workout_id movement_id segment_id created_at updated_at position notes],
+          overrides: { movement_name: { type: 'string' } }
+        ),
+        required: %w[movement_name],
+        additionalProperties: false
+      }.freeze
+    end
 
-    SEGMENT_SCHEMA = {
-      type: 'object',
-      properties: ModelSchema.properties_for(Segment, except: %w[id workout_id created_at updated_at position])
-                             .merge(exercises: { type: 'array', items: EXERCISE_SCHEMA }),
-      required: %w[name],
-      additionalProperties: false
-    }.freeze
+    def self.segment_schema
+      @segment_schema ||= {
+        type: 'object',
+        properties: ModelSchema.properties_for(Segment, except: %w[id workout_id created_at updated_at position])
+                               .merge(exercises: { type: 'array', items: exercise_schema }),
+        required: %w[name],
+        additionalProperties: false
+      }.freeze
+    end
 
-    WORKOUT_SCHEMA = {
-      type: 'object',
-      properties: ModelSchema.properties_for(
-        Workout,
-        except: %w[id created_at updated_at content_key time_cap_seconds],
-        overrides: {
-          # Narrower than Workout's full score_type enum: only these 5 values are valid workout scores.
-          score_type: { type: 'string', enum: Metric.workout_measurements.map(&:to_s) },
-          time_cap: { type: 'string' }, # virtual setter (accepts "MM:SS"), not the time_cap_seconds column
-          notes: { type: 'string' }, # Workout#notes is ActionText, not a plain column
-          # Workout no longer stores its own scheme -- every Exercise belongs to a Segment, and a
-          # "flat" (no named parts) workout is represented as one implicit segment wrapping its
-          # top-level "exercises" (see build_workout). These three route to that segment's
-          # rounds/time_seconds/interval_scheme rather than to a Workout column.
-          rounds: { type: 'integer' },
-          time: { type: 'integer' },
-          interval: { type: 'string' }
-        }
-      ).merge(
-        segments: { type: 'array', items: SEGMENT_SCHEMA },
-        exercises: { type: 'array', items: EXERCISE_SCHEMA },
-        extractable: { type: 'boolean' },
-        gap_reason: { type: 'string' }
-      ),
-      required: %w[extractable],
-      additionalProperties: false
-    }.freeze
+    def self.workout_schema
+      @workout_schema ||= {
+        type: 'object',
+        properties: ModelSchema.properties_for(
+          Workout,
+          except: %w[id created_at updated_at content_key time_cap_seconds],
+          overrides: workout_schema_overrides
+        ).merge(
+          segments: { type: 'array', items: segment_schema },
+          exercises: { type: 'array', items: exercise_schema },
+          extractable: { type: 'boolean' },
+          gap_reason: { type: 'string' }
+        ),
+        required: %w[extractable],
+        additionalProperties: false
+      }.freeze
+    end
+
+    def self.workout_schema_overrides
+      {
+        # Narrower than Workout's full score_type enum: only these 5 values are valid workout scores.
+        score_type: { type: 'string', enum: Metric.workout_measurements.map(&:to_s) },
+        time_cap: { type: 'string' }, # virtual setter (accepts "MM:SS"), not the time_cap_seconds column
+        notes: { type: 'string' }, # Workout#notes is ActionText, not a plain column
+        # Workout no longer stores its own scheme -- every Exercise belongs to a Segment, and a
+        # "flat" (no named parts) workout is represented as one implicit segment wrapping its
+        # top-level "exercises" (see build_workout). These three route to that segment's
+        # rounds/time_seconds/interval_scheme rather than to a Workout column.
+        rounds: { type: 'integer' },
+        time: { type: 'integer' },
+        interval: { type: 'string' }
+      }
+    end
 
     # logger is opt-in and silent by default (nil) so normal callers don't get unexpected output;
     # pass one (e.g. Logger.new($stdout)) to see progress or where a failure occurred.

--- a/app/services/workout_extraction/system_prompt.rb
+++ b/app/services/workout_extraction/system_prompt.rb
@@ -112,16 +112,16 @@ module WorkoutExtraction
     end
 
     def self.exercise_field_lines
-      field_lines(WorkoutExtraction::LlmParser::EXERCISE_SCHEMA[:properties].except(:movement_name))
+      field_lines(WorkoutExtraction::LlmParser.exercise_schema[:properties].except(:movement_name))
     end
 
     def self.workout_field_lines
-      field_lines(WorkoutExtraction::LlmParser::WORKOUT_SCHEMA[:properties]
+      field_lines(WorkoutExtraction::LlmParser.workout_schema[:properties]
         .except(:extractable, :gap_reason, :segments, :exercises))
     end
 
     def self.segment_field_lines
-      field_lines(WorkoutExtraction::LlmParser::SEGMENT_SCHEMA[:properties].except(:name, :exercises))
+      field_lines(WorkoutExtraction::LlmParser.segment_schema[:properties].except(:name, :exercises))
     end
   end
 end

--- a/test/services/workout_extraction/llm_parser_schema_test.rb
+++ b/test/services/workout_extraction/llm_parser_schema_test.rb
@@ -7,41 +7,51 @@ module WorkoutExtraction
         %i[reps duration_seconds load female_load male_load implement_count distance female_distance
            male_distance distance_unit distance_units_per_rep calories female_calories male_calories
            ladder_step_every ladder_exempt movement_name].sort,
-        LlmParser::EXERCISE_SCHEMA[:properties].keys.sort
+        LlmParser.exercise_schema[:properties].keys.sort
       )
       assert_equal(
         %i[name rounds time_seconds interval_scheme rest_seconds notes exercises].sort,
-        LlmParser::SEGMENT_SCHEMA[:properties].keys.sort
+        LlmParser.segment_schema[:properties].keys.sort
       )
       assert_equal(
         %i[name rounds time interval ladder_step team_size score_type time_cap notes segments
            exercises extractable gap_reason].sort,
-        LlmParser::WORKOUT_SCHEMA[:properties].keys.sort
+        LlmParser.workout_schema[:properties].keys.sort
       )
     end
 
+    test 'schemas are exposed through lazy accessors instead of eager boot-time constants' do
+      assert_respond_to LlmParser, :exercise_schema
+      assert_respond_to LlmParser, :segment_schema
+      assert_respond_to LlmParser, :workout_schema
+
+      assert_not_includes LlmParser.constants(false), :EXERCISE_SCHEMA
+      assert_not_includes LlmParser.constants(false), :SEGMENT_SCHEMA
+      assert_not_includes LlmParser.constants(false), :WORKOUT_SCHEMA
+    end
+
     test 'distance_unit is auto-constrained to the enum values and stays plainly optional' do
-      assert_equal({ type: 'string', enum: %w[meter foot inch] }, LlmParser::EXERCISE_SCHEMA[:properties][:distance_unit])
-      assert_not_includes LlmParser::EXERCISE_SCHEMA[:required], 'distance_unit'
+      assert_equal({ type: 'string', enum: %w[meter foot inch] }, LlmParser.exercise_schema[:properties][:distance_unit])
+      assert_not_includes LlmParser.exercise_schema[:required], 'distance_unit'
     end
 
     test 'score_type stays constrained to the workout-valid subset, not the full 12-value enum' do
-      enum = LlmParser::WORKOUT_SCHEMA[:properties][:score_type][:enum]
+      enum = LlmParser.workout_schema[:properties][:score_type][:enum]
 
       assert_equal(%w[calorie rep round time weight].sort, enum.sort)
     end
 
     test 'extractable and movement_name are the only strictly required fields in their schemas' do
-      assert_equal({ type: 'boolean' }, LlmParser::WORKOUT_SCHEMA[:properties][:extractable])
-      assert_equal(%w[extractable], LlmParser::WORKOUT_SCHEMA[:required])
-      assert_equal({ type: 'string' }, LlmParser::EXERCISE_SCHEMA[:properties][:movement_name])
-      assert_equal(%w[movement_name], LlmParser::EXERCISE_SCHEMA[:required])
-      assert_equal(%w[name], LlmParser::SEGMENT_SCHEMA[:required])
+      assert_equal({ type: 'boolean' }, LlmParser.workout_schema[:properties][:extractable])
+      assert_equal(%w[extractable], LlmParser.workout_schema[:required])
+      assert_equal({ type: 'string' }, LlmParser.exercise_schema[:properties][:movement_name])
+      assert_equal(%w[movement_name], LlmParser.exercise_schema[:required])
+      assert_equal(%w[name], LlmParser.segment_schema[:required])
     end
 
     test 'gap_reason is plainly optional, not required or nullable' do
-      assert_equal({ type: 'string' }, LlmParser::WORKOUT_SCHEMA[:properties][:gap_reason])
-      assert_not_includes LlmParser::WORKOUT_SCHEMA[:required], 'gap_reason'
+      assert_equal({ type: 'string' }, LlmParser.workout_schema[:properties][:gap_reason])
+      assert_not_includes LlmParser.workout_schema[:required], 'gap_reason'
     end
 
     # Neither call enforces its schema via output_config/json_schema anymore -- extraction is a
@@ -50,7 +60,7 @@ module WorkoutExtraction
     # source SystemPrompt's field descriptions are derived from, so Anthropic's structured-outputs
     # property-count limits no longer apply -- kept here only as a style check, not a compiled-limit check.
     test 'no schema uses anyOf/nullable types anywhere, matching the plain required/optional style used throughout' do
-      schemas = [LlmParser::WORKOUT_SCHEMA, LlmParser::SEGMENT_SCHEMA, LlmParser::EXERCISE_SCHEMA]
+      schemas = [LlmParser.workout_schema, LlmParser.segment_schema, LlmParser.exercise_schema]
 
       schemas.each do |schema|
         assert_empty(schema[:properties].select { |_, prop| prop.key?(:anyOf) }, "#{schema} has an anyOf-typed property")

--- a/test/services/workout_extraction/llm_parser_schema_test.rb
+++ b/test/services/workout_extraction/llm_parser_schema_test.rb
@@ -24,6 +24,7 @@ module WorkoutExtraction
       assert_respond_to LlmParser, :exercise_schema
       assert_respond_to LlmParser, :segment_schema
       assert_respond_to LlmParser, :workout_schema
+      assert_not_respond_to LlmParser, :workout_schema_overrides
 
       assert_not_includes LlmParser.constants(false), :EXERCISE_SCHEMA
       assert_not_includes LlmParser.constants(false), :SEGMENT_SCHEMA

--- a/test/services/workout_extraction/llm_parser_test.rb
+++ b/test/services/workout_extraction/llm_parser_test.rb
@@ -54,6 +54,43 @@ module WorkoutExtraction
       assert_equal 'CF-260727', workout.name
     end
 
+    test 'falls back when the leaked prescription line uses other common CrossFit formats' do
+      deadlift = movements(:deadlift)
+      examples = {
+        '95-lb Thruster x21' => exercise_payload(movement_name: @movement.name, reps: 21, load: 95),
+        '225-pound Deadlift x5' => exercise_payload(movement_name: deadlift.name, reps: 5, load: 225),
+        '800m Run x4' => exercise_payload(movement_name: movements(:run).name, distance: 800, distance_unit: 'meter'),
+        '4 x 400m Run' => exercise_payload(movement_name: movements(:run).name, distance: 400, distance_unit: 'meter'),
+        '21-15-9' => exercise_payload(movement_name: @movement.name, reps: 1)
+      }
+
+      examples.each do |name, exercise|
+        stub_llm_response(
+          extractable: true, name: name, score_type: 'time', rounds: nil, time: nil, interval: nil,
+          time_cap: nil, ladder_step: nil, team_size: nil, notes: nil, gap_reason: nil, segments: [],
+          exercises: [exercise]
+        )
+
+        workout = WorkoutExtraction::LlmParser.call(name, date: Date.new(2026, 7, 27))
+
+        assert_equal 'CF-260727', workout.name, "#{name.inspect} should use the date fallback"
+      end
+    end
+
+    test 'preserves legitimate short names with leading numbers' do
+      ['Open 26.1', '5K Gone Bad'].each do |name|
+        stub_llm_response(
+          extractable: true, name: name, score_type: 'time', rounds: nil, time: nil, interval: nil,
+          time_cap: nil, ladder_step: nil, team_size: nil, notes: nil, gap_reason: nil, segments: [],
+          exercises: [exercise_payload(movement_name: @movement.name, reps: 1)]
+        )
+
+        workout = WorkoutExtraction::LlmParser.call(name, date: DATE)
+
+        assert_equal name, workout.name
+      end
+    end
+
     test 'wraps a flat workout in one implicit unnamed segment carrying its scheme' do
       stub_llm_response(
         extractable: true, name: 'Cindy', score_type: 'round', rounds: nil, time: 1200, interval: nil,

--- a/test/services/workout_extraction/llm_parser_test.rb
+++ b/test/services/workout_extraction/llm_parser_test.rb
@@ -42,6 +42,18 @@ module WorkoutExtraction
       assert_equal 'CF-260115', workout.name
     end
 
+    test 'falls back to a date-based name when the LLM uses the first prescription line as the name' do
+      stub_llm_response(
+        extractable: true, name: '1,600-meter run x2', score_type: 'time', rounds: nil, time: nil, interval: nil,
+        time_cap: nil, ladder_step: nil, team_size: nil, notes: nil, gap_reason: nil, segments: [],
+        exercises: [exercise_payload(movement_name: movements(:run).name, distance: 1600, distance_unit: 'meter')]
+      )
+
+      workout = WorkoutExtraction::LlmParser.call('For time: 1,600-meter run x2', date: Date.new(2026, 7, 27))
+
+      assert_equal 'CF-260727', workout.name
+    end
+
     test 'wraps a flat workout in one implicit unnamed segment carrying its scheme' do
       stub_llm_response(
         extractable: true, name: 'Cindy', score_type: 'round', rounds: nil, time: 1200, interval: nil,


### PR DESCRIPTION
## Summary

- Treat LLM-provided workout names that look like repeated prescription lines, such as `1,600-meter run x2`, as missing names.
- Preserve the existing scraped nameless workout fallback convention: `CF-YYMMDD`.
- Add a regression test for the July 27, 2026 failure shape so the workout becomes `CF-260727` instead of using the first exercise line as the name.
- Lazy-load the workout extraction schema definitions so worker boot does not query model table metadata before a fresh PR environment has run migrations.

## Root Cause

The LLM parser trusted any nonblank `name` field from the extraction response. When the model copied the first prescription line into `name`, that exercise text was persisted as the workout title instead of falling back to the date-based CrossFit.com name.

The first PR build also failed Railway's worker deploy because `WorkoutExtraction::LlmParser` built schema constants at class load time. The worker eager-loads jobs during boot, which loaded `LlmParser` and queried the `exercises` table before the PR database had tables. Moving schema generation behind memoized class methods keeps boot from requiring those tables.

## Validation

- `rvm 4.0.5@wod-tracker do bundle exec rails test test/services/cf_wod test/services/workout_extraction test/jobs/scrape_cf_wod_job_test.rb test/jobs/backfill_crossfit_wods_job_test.rb test/tasks/cf_wod_rake_test.rb`
- `rvm 4.0.5@wod-tracker do bundle exec rails runner 'puts WorkoutExtraction::LlmParser.constants(false).grep(/SCHEMA/).inspect'`
- `rvm 4.0.5@wod-tracker do bundle exec rubocop app/services/workout_extraction/llm_parser.rb app/services/workout_extraction/system_prompt.rb test/services/workout_extraction/llm_parser_test.rb test/services/workout_extraction/llm_parser_schema_test.rb`
- `git diff --check`