### PR TITLE
Fix N+1 query slowing workouts infinite scroll

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -7,6 +7,7 @@ class WorkoutsController < ApplicationController
   # GET /workouts.json
   def index
     @workouts = Workout.search_by_name(params[:query]).order(created_at: :desc).page(params[:page])
+    @logged_workout_ids = logged_workout_ids_for(@workouts)
   end
 
   # GET /workouts/1
@@ -111,6 +112,10 @@ class WorkoutsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_workout
     @workout = Workout.includes(segments: :exercises).find(params.expect(:id))
+  end
+
+  def logged_workout_ids_for(workouts)
+    Current.user.logs.where(workout_id: workouts.map(&:id)).distinct.pluck(:workout_id)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/views/workouts/_page.html.slim
+++ b/app/views/workouts/_page.html.slim
@@ -2,4 +2,7 @@
   .list-group
     = render workouts
   - if workouts.next_page
-    = turbo_frame_tag "workouts_page_#{workouts.next_page}", loading: :lazy, src: workouts_path(page: workouts.next_page, query: query)
+    = turbo_frame_tag "workouts_page_#{workouts.next_page}", loading: :lazy, src: workouts_path(page: workouts.next_page, query: query) do
+      .d-flex.justify-content-center.my-3
+        .spinner-border.text-primary role="status"
+          span.visually-hidden Loading…

--- a/app/views/workouts/_workout.html.slim
+++ b/app/views/workouts/_workout.html.slim
@@ -1,1 +1,1 @@
-= link_to workout.name, workout, id: dom_id(workout), class: "list-group-item list-group-item-action #{'list-group-item-success' if Current.user.logged_workout? workout}", data: { turbo_frame: "_top"}
+= link_to workout.name, workout, id: dom_id(workout), class: "list-group-item list-group-item-action #{'list-group-item-success' if @logged_workout_ids.include?(workout.id)}", data: { turbo_frame: "_top"}

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -32,6 +32,7 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'turbo-frame#workouts_page_1'
     assert_select 'turbo-frame#workouts_page_2[loading="lazy"][src=?]', workouts_path(page: 2)
+    assert_select 'turbo-frame#workouts_page_2 .spinner-border'
   end
 
   test 'index last page renders no further lazy frame' do

--- a/test/controllers/workouts_controller_test.rb
+++ b/test/controllers/workouts_controller_test.rb
@@ -13,6 +13,17 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'index batches logged workout lookup for rendered workouts' do
+    30.times { |i| Workout.create!(name: "Filler WOD #{i}", score_type: :time) }
+
+    query_counts = count_matching_queries(logs: /FROM "logs"/) do
+      get workouts_url
+    end
+
+    assert_response :success
+    assert_equal 1, query_counts[:logs]
+  end
+
   test 'index page one renders a lazy frame chaining to the next page' do
     30.times { |i| Workout.create!(name: "Filler WOD #{i}", score_type: :time) }
 
@@ -293,5 +304,18 @@ class WorkoutsControllerTest < ActionDispatch::IntegrationTest
       distance_units_per_rep: nil, calories: nil, female_calories: nil, male_calories: nil,
       ladder_step_every: nil, ladder_exempt: nil
     }.merge(overrides)
+  end
+
+  def count_matching_queries(patterns, &)
+    counts = patterns.transform_values { 0 }
+    callback = lambda do |_name, _started, _finished, _unique_id, payload|
+      next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+      patterns.each { |name, pattern| counts[name] += 1 if payload[:sql].match?(pattern) }
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &)
+
+    counts
   end
 end


### PR DESCRIPTION
## Summary
- The infinite-scroll workouts index (#1818) re-runs the `index` action per lazy-loaded page. Each row called `Current.user.logged_workout?(workout)`, which issues its own joined query — 25 extra queries per page fetch, on top of the page's own query.
- Batches the lookup into a single query per request (`Current.user.logs.where(workout_id: ...).distinct.pluck(:workout_id)`), mirroring the existing pattern already used on the schedules index.

## Test plan
- [x] `bundle exec rails test test/controllers/workouts_controller_test.rb` — added a regression test asserting exactly 1 `logs` query renders a page (was 25 before the fix)
- [x] `bundle exec rails test` — full suite, 479 runs, 0 failures
- [x] `bundle exec rubocop --parallel` on changed Ruby files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)