### PR TITLE
Align notes position between workout show and schedule views

### DIFF
--- a/app/views/exercises/_exercises.html.slim
+++ b/app/views/exercises/_exercises.html.slim
@@ -1,9 +1,13 @@
-- if workout.segments.any? { |segment| segment.exercises.any? }
-  - workout.segments.each_with_index do |segment, index|
-    - # The governing segment's own scheme is already conveyed by workout_objective
-    - # wherever this partial is rendered; showing it again here would be redundant.
-    - objective = segment == workout.governing_segment ? nil : segment_objective(segment, then_prefix: index.positive?)
-    - if objective
-      li = objective
+- set_based_line = lifting_sets_line(workout)
+- workout.segments.each_with_index do |segment, index|
+  - governing = segment == workout.governing_segment
+  - # The governing segment's own scheme is already conveyed by workout_objective
+  - # wherever this partial is rendered; showing it again here would be redundant.
+  - objective = governing ? nil : segment_objective(segment, then_prefix: index.positive?)
+  - if objective
+    li = objective
+  - if governing && set_based_line
+    li = set_based_line
+  - else
     - segment.exercises.each do |exercise|
       li class=(objective ? 'ms-4' : nil) #{measurable_message(exercise)}

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -12,14 +12,13 @@
           = schedule.workout.name
         i.col.text-end
           = link_to schedule.program.name, schedule.program
-      - if schedule.workout.notes.present?
-        .row
-          .col = schedule.workout.notes
       .row
         p.col #{workout_objective schedule.workout}
       .row
         ul.list-unstyled.col
           = render partial: 'exercises/exercises', locals: { workout: schedule.workout }
+      .row
+        .col = render partial: 'workouts/notes', locals: { workout: schedule.workout }
       .row
         .col-12
           .d-grid

--- a/app/views/workouts/_notes.html.slim
+++ b/app/views/workouts/_notes.html.slim
@@ -1,0 +1,3 @@
+- if workout.notes.present?
+  b Notes
+  .notes = workout.notes

--- a/app/views/workouts/show.html.slim
+++ b/app/views/workouts/show.html.slim
@@ -22,26 +22,12 @@
   .row
     .col
       ul.list-unstyled.mb-3
-        - set_based_line = lifting_sets_line(@workout)
-        - @workout.segments.each_with_index do |segment, index|
-          - governing = segment == @workout.governing_segment
-          - # The governing segment's own scheme is already conveyed by workout_objective above;
-          - # showing it again here would be redundant (e.g. Fran: "21-15-9 for time" then "21-15-9 of").
-          - objective = governing ? nil : segment_objective(segment, then_prefix: index.positive?)
-          - if objective
-            li = objective
-          - if governing && set_based_line
-            li = set_based_line
-          - else
-            - segment.exercises.each do |exercise|
-              li class=(objective ? 'ms-4' : nil) #{measurable_message(exercise)}
+        = render partial: 'exercises/exercises', locals: { workout: @workout }
       - if @workout.time_cap_seconds.present?
         p
           b Time cap:
           span  #{@workout.time_cap}
-      - if @workout.notes.present?
-        b Notes
-        .notes = @workout.notes
+      = render 'notes', workout: @workout
       .d-grid.gap-2
         = link_to 'Schedule', nil, class: 'btn btn-secondary', "data-bs-toggle": "modal", "data-bs-target": "#scheduleModal" if can? :create, Schedule
         = link_to 'Log', new_workout_log_path(@workout), class: 'btn btn-outline-primary'


### PR DESCRIPTION
## Summary
- Notes rendered before the objective on the schedule view, but after the exercise list on the workout show view — this made the two look inconsistent for the same workout.
- Extracted the segment/exercise rendering (including the lifting-sets-line logic added in #1813) out of `show.html.slim` and into the shared `exercises/_exercises` partial, which `schedules/index` and `programs/show` already used but with duplicated, less complete logic.
- Added a shared `workouts/_notes` partial and moved notes to render after the exercise list on the schedule view, matching the show view's order.

## Test plan
- [x] `bundle exec rails test test/controllers/schedules_controller_test.rb test/controllers/workouts_controller_test.rb` — 24 runs, 0 failures
- [x] `bundle exec rails test test/system/lifting_workouts_test.rb` — 2 runs, 0 failures (covers the show page's set-based-line rendering, now via the shared partial)
- [x] Reviewed diff for `programs/show.html.slim`'s incidental benefit (gains the lifting-sets-line logic for free since it uses the same partial); no changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)