### PR TITLE
Add Log.orphaned scope with RailsAdmin visibility

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -8,6 +8,8 @@ class Log < ApplicationRecord
 
   accepts_nested_attributes_for :movement_logs, allow_destroy: true
 
+  scope :orphaned, -> { where.missing(:workout) }
+
   enum :score_type, Metric.measurements, prefix: :score
 
   validates :score_type, presence: true

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -48,4 +48,10 @@ RailsAdmin.config do |config|
       field :created_at
     end
   end
+
+  config.model 'Log' do
+    list do
+      scopes [nil, :orphaned]
+    end
+  end
 end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -226,4 +226,14 @@ class LogTest < ActiveSupport::TestCase
     movement_log = log.movement_logs.find { |ml| ml.movement_id == movements(:thruster).id }
     assert_nil movement_log.implement_count
   end
+
+  test 'orphaned scope finds logs whose workout row no longer exists' do
+    workout = Workout.create!(name: 'Temporary Orphan Workout', score_type: :time)
+    orphaned_log = workout.logs.create!(user: users(:mathew), score_type: :time, score_value: 200)
+    kept_log = workouts(:fran).logs.create!(user: users(:mathew), score_type: :time, score_value: 200)
+    Workout.where(id: workout.id).delete_all
+
+    assert_equal [orphaned_log], Log.orphaned.to_a
+    assert_not_includes Log.orphaned, kept_log
+  end
 end


### PR DESCRIPTION
## Summary
- Add `Log.orphaned` scope (`where.missing(:workout)`) to find logs whose `workout_id` no longer resolves to a workout row — these have been surfacing as broken links in the production history feed.
- Wire the scope into RailsAdmin as a list scope on `Log` so orphans can be reviewed and deleted from the admin UI (delete goes through `.destroy`, cleaning up `movement_logs` too).

## Test plan
- [x] `bin/rails test test/models/log_test.rb`
- [x] `bundle exec rubocop app/models/log.rb config/initializers/rails_admin.rb test/models/log_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)