### PR TITLE
Add foreign key from logs to workouts

### DIFF
--- a/db/migrate/20260727120000_add_foreign_key_to_logs_workout_id.rb
+++ b/db/migrate/20260727120000_add_foreign_key_to_logs_workout_id.rb
@@ -1,0 +1,22 @@
+class AddForeignKeyToLogsWorkoutId < ActiveRecord::Migration[8.1]
+  def up
+    guard_against_orphaned_logs!
+
+    add_foreign_key :logs, :workouts
+  end
+
+  def down
+    remove_foreign_key :logs, :workouts
+  end
+
+  private
+
+  def guard_against_orphaned_logs!
+    orphaned_count = Log.unscoped.orphaned.count
+    return if orphaned_count.zero?
+
+    raise "#{orphaned_count} log(s) reference a workout_id with no matching workout (inspect via " \
+          '`Log.orphaned`, or the "Orphaned" scope in RailsAdmin) -- delete or reassign them before ' \
+          're-running this migration.'
+  end
+end

--- a/db/migrate/20260727120000_add_foreign_key_to_logs_workout_id.rb
+++ b/db/migrate/20260727120000_add_foreign_key_to_logs_workout_id.rb
@@ -12,11 +12,11 @@ class AddForeignKeyToLogsWorkoutId < ActiveRecord::Migration[8.1]
   private
 
   def guard_against_orphaned_logs!
-    orphaned_count = Log.unscoped.orphaned.count
+    orphaned_count = Log.unscoped.where.missing(:workout).count
     return if orphaned_count.zero?
 
     raise "#{orphaned_count} log(s) reference a workout_id with no matching workout (inspect via " \
-          '`Log.orphaned`, or the "Orphaned" scope in RailsAdmin) -- delete or reassign them before ' \
-          're-running this migration.'
+          '`Log.unscoped.where.missing(:workout)`) -- delete or reassign them before re-running ' \
+          'this migration.'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_16_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -331,6 +331,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_16_180000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "exercises", "movements"
   add_foreign_key "exercises", "segments"
+  add_foreign_key "logs", "workouts"
   add_foreign_key "movement_logs", "logs"
   add_foreign_key "movement_logs", "movements"
   add_foreign_key "schedules", "programs"

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -226,4 +226,13 @@ class LogTest < ActiveSupport::TestCase
     movement_log = log.movement_logs.find { |ml| ml.movement_id == movements(:thruster).id }
     assert_nil movement_log.implement_count
   end
+
+  test 'the workouts foreign key blocks deleting a workout that still has logs' do
+    workout = Workout.create!(name: 'Constrained Workout', score_type: :time)
+    workout.logs.create!(user: users(:mathew), score_type: :time, score_value: 200)
+
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      Workout.where(id: workout.id).delete_all
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Stacked on #1827 (the `Log.orphaned` revert) — needs that merged first, or review together.

- Add `add_foreign_key :logs, :workouts` — `schedules` and `segments` already have this constraint, but `logs.workout_id` had nothing enforcing it at the DB level. That gap is how a workout could be deleted out from under its logs via a raw console/SQL delete. (The original motivation was orphaned logs in production, but #1827 found there weren't actually any — this FK is still worth having as defense in depth, independent of that diagnosis.)
- Migration guards against orphaned rows already present with a self-contained query (`Log.unscoped.where.missing(:workout)`, no dependency on the reverted model scope) and raises a clear error instead of a raw Postgres FK violation if any exist when it runs.
- Normal `@workout.destroy` is unaffected — `dependent: :destroy` already removes logs before the workout row goes away.

## Test plan
- [x] `bin/rails db:migrate`
- [x] `bin/rails test test/models/log_test.rb` — new test asserts the FK itself blocks deleting a workout with logs (`ActiveRecord::InvalidForeignKey`)
- [x] `bundle exec rubocop db/migrate/20260727120000_add_foreign_key_to_logs_workout_id.rb test/models/log_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)