### PR TITLE
Escape the lazy-loaded turbo frame on history feed item links

### DIFF
--- a/app/views/logs/_log.html.slim
+++ b/app/views/logs/_log.html.slim
@@ -1,8 +1,8 @@
 .card.mb-2.position-relative
   .card-body.d-flex.justify-content-between.align-items-start.py-2
     div
-      = link_to log.workout.name, log.workout, class: 'fw-semibold text-decoration-none position-relative', style: 'z-index: 1'
+      = link_to log.workout.name, log.workout, class: 'fw-semibold text-decoration-none position-relative', style: 'z-index: 1', data: { turbo_frame: '_top' }
       .text-muted.small = local_time log.created_at, '%b %-d, %Y'
     .text-end.ms-3
       .fw-semibold = log_score_msg(log)
-      = link_to 'View log', log_path(log), class: 'stretched-link', 'aria-label': "View #{log.workout.name} log"
+      = link_to 'View log', log_path(log), class: 'stretched-link', 'aria-label': "View #{log.workout.name} log", data: { turbo_frame: '_top' }

--- a/test/system/workout_history_test.rb
+++ b/test/system/workout_history_test.rb
@@ -18,4 +18,13 @@ class WorkoutHistoryTest < ApplicationSystemTestCase
     assert_selector '.card', text: workouts(:murph).name
     assert_link workouts(:murph).name, href: workout_path(workouts(:murph))
   end
+
+  test 'clicking a history item navigates to the log instead of showing a missing turbo frame' do
+    visit logs_url
+
+    find(%(a[aria-label="View #{workouts(:murph).name} log"])).click
+
+    assert_current_path log_path(logs(:matt_murph))
+    assert_no_text 'Content missing'
+  end
 end


### PR DESCRIPTION
## Summary
This is the actual root cause of "logs linking to unavailable workouts" reported in the history feed — turned out to have nothing to do with data integrity. #1824/#1825 were a wrong turn based on an initial (unverified) hypothesis; see follow-up PR reverting #1824.

- The history feed's infinite scroll (`app/views/logs/_page.html.slim`) wraps each page of logs in `turbo_frame_tag "logs_page_N"` for lazy loading.
- Links inside that frame (workout name, "View log") get captured by Turbo. Turbo tries to find a matching `logs_page_N` frame in the destination page's response (`/workouts/:id`, `/logs/:id`), can't, and renders its built-in `<strong>Content missing</strong>` fallback in place — without even navigating the URL.
- `app/views/workouts/_workout.html.slim` (the workouts index infinite scroll, #1818) already solved this identical problem with `data: { turbo_frame: "_top" }`. The history feed (#1820), built afterward, never got that attribute.

## Fix
Add `data: { turbo_frame: '_top' }` to both links in `app/views/logs/_log.html.slim` so they escape the frame and navigate the full page, matching the established pattern.

## Test plan
- [x] New system test in `test/system/workout_history_test.rb` clicks a history item and asserts it navigates to the log page instead of showing "Content missing" — confirmed it fails without the fix and passes with it.
- [x] `bin/rails test test/system/workout_history_test.rb test/controllers/logs_controller_test.rb test/models/log_test.rb test/routing/logs_routing_test.rb`
- [x] `bundle exec rubocop test/system/workout_history_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)