### PR TITLE
Revert "Add Log.orphaned scope with RailsAdmin visibility (#1824)"

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -8,8 +8,6 @@ class Log < ApplicationRecord
 
   accepts_nested_attributes_for :movement_logs, allow_destroy: true
 
-  scope :orphaned, -> { where.missing(:workout) }
-
   enum :score_type, Metric.measurements, prefix: :score
 
   validates :score_type, presence: true

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -48,10 +48,4 @@ RailsAdmin.config do |config|
       field :created_at
     end
   end
-
-  config.model 'Log' do
-    list do
-      scopes [nil, :orphaned]
-    end
-  end
 end

--- a/test/models/log_test.rb
+++ b/test/models/log_test.rb
@@ -226,14 +226,4 @@ class LogTest < ActiveSupport::TestCase
     movement_log = log.movement_logs.find { |ml| ml.movement_id == movements(:thruster).id }
     assert_nil movement_log.implement_count
   end
-
-  test 'orphaned scope finds logs whose workout row no longer exists' do
-    workout = Workout.create!(name: 'Temporary Orphan Workout', score_type: :time)
-    orphaned_log = workout.logs.create!(user: users(:mathew), score_type: :time, score_value: 200)
-    kept_log = workouts(:fran).logs.create!(user: users(:mathew), score_type: :time, score_value: 200)
-    Workout.where(id: workout.id).delete_all
-
-    assert_equal [orphaned_log], Log.orphaned.to_a
-    assert_not_includes Log.orphaned, kept_log
-  end
 end


### PR DESCRIPTION
## Summary
Reverts #1824. That PR was built on an unverified hypothesis: that the history feed's "unavailable workout" links were caused by orphaned `Log` rows (dangling `workout_id`). Checking production's `Log.orphaned` scope after deploying #1824 showed **zero** orphaned logs — the premise was wrong. The actual bug (Turbo swallowing frame-escaping links, see #1826) has nothing to do with data integrity.

Note: #1825 (the `logs` → `workouts` foreign key) is being kept and updated separately to not depend on the `Log.orphaned` scope this reverts — that constraint is still good hygiene independent of this diagnosis (matches the existing `schedules`/`segments` FKs).

## Test plan
- [x] `bin/rails test test/models/log_test.rb`
- [x] Confirmed RailsAdmin still boots cleanly for the `Log` model without the removed scope config

🤖 Generated with [Claude Code](https://claude.com/claude-code)