### PR TITLE
Fix male/female symbol misalignment on mobile

### DIFF
--- a/app/helpers/measurable_helper.rb
+++ b/app/helpers/measurable_helper.rb
@@ -102,7 +102,7 @@ module MeasurableHelper
     female_values = ordered_metrics.map { |metric| sex_specific_metric_value_msg(metric, metric.female_value) }
     male_values = ordered_metrics.map { |metric| sex_specific_metric_value_msg(metric, metric.male_value) }
 
-    "♀#{female_values.join(' + ')} / ♂#{male_values.join(' + ')}"
+    "♀︎#{female_values.join(' + ')} / ♂︎#{male_values.join(' + ')}"
   end
 
   def sex_specific_metric_value_msg(metric, value)

--- a/app/helpers/metrics_helper.rb
+++ b/app/helpers/metrics_helper.rb
@@ -87,14 +87,14 @@ module MetricsHelper
 
   def sex_specific_metric_unit_msg(metric)
     if load_metric?(metric)
-      return "♀#{load_input_value(metric.female_value)}#{load_display_unit} / " \
-             "♂#{load_input_value(metric.male_value)}#{load_display_unit}"
+      return "♀︎#{load_input_value(metric.female_value)}#{load_display_unit} / " \
+             "♂︎#{load_input_value(metric.male_value)}#{load_display_unit}"
     end
 
     unit = metric.measurement.singularize
     separator = Metric::LOAD_MEASUREMENTS.include?(unit) ? '' : '-'
 
-    "♀#{metric.female_value}#{separator}#{unit} / ♂#{metric.male_value}#{separator}#{unit}"
+    "♀︎#{metric.female_value}#{separator}#{unit} / ♂︎#{metric.male_value}#{separator}#{unit}"
   end
 
   def additional_metric_display_order(metric)

--- a/app/javascript/controllers/exercise_card_controller.js
+++ b/app/javascript/controllers/exercise_card_controller.js
@@ -232,7 +232,7 @@ export default class extends Controller {
     const femaleValues = orderedMetrics.map((metric) => this.sexSpecificMetricValueText(metric, metric.femaleValue))
     const maleValues = orderedMetrics.map((metric) => this.sexSpecificMetricValueText(metric, metric.maleValue))
 
-    return `♀${femaleValues.join(" + ")} / ♂${maleValues.join(" + ")}`
+    return `♀︎${femaleValues.join(" + ")} / ♂︎${maleValues.join(" + ")}`
   }
 
   metricUnitText(metric) {
@@ -248,7 +248,7 @@ export default class extends Controller {
     const unit = this.singularUnit(metric.measurement)
     const separator = this.loadMeasurement(unit) ? "" : "-"
 
-    return `♀${metric.femaleValue}${separator}${unit} / ♂${metric.maleValue}${separator}${unit}`
+    return `♀︎${metric.femaleValue}${separator}${unit} / ♂︎${metric.maleValue}${separator}${unit}`
   }
 
   sexSpecificMetricValueText(metric, value) {

--- a/test/helpers/measurable_helper_test.rb
+++ b/test/helpers/measurable_helper_test.rb
@@ -11,7 +11,7 @@ class MeasurableHelperTest < ActionView::TestCase
     exercise = exercises(:fran_pullup)
     exercise.update!(load_unit: :lb, female_load: 65, male_load: 95, notes: 'Carry a plate.')
 
-    assert_equal 'Pull Up (♀65lb / ♂95lb) ** Carry a plate.', measurable_message(exercise)
+    assert_equal 'Pull Up (♀︎65lb / ♂︎95lb) ** Carry a plate.', measurable_message(exercise)
   end
 
   test 'renders multi-implement dumbbell load with a count prefix' do
@@ -20,7 +20,7 @@ class MeasurableHelperTest < ActionView::TestCase
                                                                 load_unit: :lb, female_load: 35, male_load: 50,
                                                                 implement_count: 2)
 
-    assert_equal '10 Dumbbell Thrusters (2×♀35lb / ♂50lb)', measurable_message(exercise)
+    assert_equal '10 Dumbbell Thrusters (2×♀︎35lb / ♂︎50lb)', measurable_message(exercise)
   end
 
   test 'renders 30 Box Jumps (♀20-inch / ♂24-inch)' do
@@ -28,7 +28,7 @@ class MeasurableHelperTest < ActionView::TestCase
     exercise = workouts(:fran).segments.first.exercises.create!(movement: box_jump, position: 3, reps: 30,
                                                                 female_distance: 20, male_distance: 24, distance_unit: :inch)
 
-    assert_equal '30 Box Jumps (♀20-inch / ♂24-inch)', measurable_message(exercise)
+    assert_equal '30 Box Jumps (♀︎20-inch / ♂︎24-inch)', measurable_message(exercise)
   end
 
   test 'groups multiple sex-specific additional exercise metrics by sex' do
@@ -37,7 +37,7 @@ class MeasurableHelperTest < ActionView::TestCase
                                                                 load_unit: :lb, female_load: 14, male_load: 20,
                                                                 distance_unit: :foot, female_distance: 9, male_distance: 10)
 
-    assert_equal 'Wall-ball Shot (♀14lb + 9ft / ♂20lb + 10ft)', measurable_message(exercise)
+    assert_equal 'Wall-ball Shot (♀︎14lb + 9ft / ♂︎20lb + 10ft)', measurable_message(exercise)
   end
 
   test 'renders timed max-rep station movements with duration prefix' do
@@ -47,7 +47,7 @@ class MeasurableHelperTest < ActionView::TestCase
                                                                 load_unit: :lb, female_load: 14, male_load: 20,
                                                                 distance_unit: :foot, female_distance: 9, male_distance: 10)
 
-    assert_equal '1:00 Wall-ball Shots (♀14lb + 9ft / ♂20lb + 10ft)', measurable_message(exercise)
+    assert_equal '1:00 Wall-ball Shots (♀︎14lb + 9ft / ♂︎20lb + 10ft)', measurable_message(exercise)
   end
 
   test 'renders untimed max-rep station movements with max reps prefix' do

--- a/test/helpers/measurable_prescribed_work_helper_test.rb
+++ b/test/helpers/measurable_prescribed_work_helper_test.rb
@@ -51,7 +51,7 @@ class MeasurableLeadingPrescriptionIntegrationTest < ActionView::TestCase
                                                                 reps: 1, distance: 80, distance_unit: :foot,
                                                                 female_load: 35, male_load: 50, load_unit: :lb)
 
-    assert_equal '80ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)', measurable_message(exercise)
+    assert_equal '80ft Dumbbell Overhead Walking Lunge (♀︎35lb / ♂︎50lb)', measurable_message(exercise)
   end
 
   test 'renders 40/30ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)' do
@@ -61,7 +61,7 @@ class MeasurableLeadingPrescriptionIntegrationTest < ActionView::TestCase
                                                                 female_distance: 30, male_distance: 40,
                                                                 female_load: 35, male_load: 50, load_unit: :lb)
 
-    assert_equal '40/30ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)', measurable_message(exercise)
+    assert_equal '40/30ft Dumbbell Overhead Walking Lunge (♀︎35lb / ♂︎50lb)', measurable_message(exercise)
   end
 end
 

--- a/test/helpers/metrics_helper_test.rb
+++ b/test/helpers/metrics_helper_test.rb
@@ -21,7 +21,7 @@ class MetricsHelperTest < ActionView::TestCase
   test 'renders paired female and male load values' do
     metric = Metric.new(measurement: :lb, female_value: 65, male_value: 95)
 
-    assert_equal '♀65lb / ♂95lb', metric_unit_msg(metric)
+    assert_equal '♀︎65lb / ♂︎95lb', metric_unit_msg(metric)
   end
 
   test 'prefixes multi-implement load with the implement count' do
@@ -33,7 +33,7 @@ class MetricsHelperTest < ActionView::TestCase
   test 'prefixes multi-implement sex-specific load with the implement count' do
     metric = Metric.new(measurement: :lb, female_value: 35, male_value: 50, implement_count: 2)
 
-    assert_equal '2×♀35lb / ♂50lb', metric_unit_msg(metric)
+    assert_equal '2×♀︎35lb / ♂︎50lb', metric_unit_msg(metric)
   end
 
   test 'does not prefix single-implement load' do
@@ -46,7 +46,7 @@ class MetricsHelperTest < ActionView::TestCase
     Current.user = users(:brooke).tap { |user| user.unit_system = :metric }
 
     assert_equal '43 kgs', metric_unit_msg(Metric.new(measurement: :lb, value: 95))
-    assert_equal '♀29kg / ♂43kg', metric_unit_msg(Metric.new(measurement: :lb, female_value: 65, male_value: 95))
+    assert_equal '♀︎29kg / ♂︎43kg', metric_unit_msg(Metric.new(measurement: :lb, female_value: 65, male_value: 95))
   ensure
     Current.user = nil
   end
@@ -54,6 +54,6 @@ class MetricsHelperTest < ActionView::TestCase
   test 'renders paired female and male height values' do
     metric = Metric.new(measurement: :inch, female_value: 20, male_value: 24)
 
-    assert_equal '♀20-inch / ♂24-inch', metric_unit_msg(metric)
+    assert_equal '♀︎20-inch / ♂︎24-inch', metric_unit_msg(metric)
   end
 end

--- a/test/system/exercise_card_summary_formatting_test.rb
+++ b/test/system/exercise_card_summary_formatting_test.rb
@@ -59,7 +59,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female distance', with: '80'
       fill_in 'Male distance', with: '100'
       select 'meter', from: 'Distance unit'
-      save_exercise_card '100/80 meter Run (♀65lb / ♂95lb)'
+      save_exercise_card '100/80 meter Run (♀︎65lb / ♂︎95lb)'
     end
   end
 
@@ -97,7 +97,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       open_optional_group 'Load'
       fill_in 'Female load (lb)', with: '35'
       fill_in 'Male load (lb)', with: '50'
-      save_exercise_card '80ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)'
+      save_exercise_card '80ft Dumbbell Overhead Walking Lunge (♀︎35lb / ♂︎50lb)'
     end
   end
 
@@ -126,7 +126,7 @@ class ExerciseCardSummaryFormattingTest < ApplicationSystemTestCase
       fill_in 'Female load (lb)', with: '35'
       fill_in 'Male load (lb)', with: '50'
 
-      save_exercise_card '40/30ft Dumbbell Overhead Walking Lunge (♀35lb / ♂50lb)'
+      save_exercise_card '40/30ft Dumbbell Overhead Walking Lunge (♀︎35lb / ♂︎50lb)'
     end
   end
 

--- a/test/system/sex_specific_workout_values_test.rb
+++ b/test/system/sex_specific_workout_values_test.rb
@@ -30,7 +30,7 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
       fill_in 'Female load (lb)', with: '65'
       fill_in 'Male load (lb)', with: '95'
       click_on 'Done'
-      assert_text 'Thruster (♀65lb / ♂95lb)'
+      assert_text 'Thruster (♀︎65lb / ♂︎95lb)'
       assert_no_field 'Female load'
     end
 
@@ -38,6 +38,6 @@ class SexSpecificWorkoutValuesTest < ApplicationSystemTestCase
 
     assert_current_path %r{/workouts/\d+}
     assert_text 'Sex Specific System Test Workout'
-    assert_text 'Thruster (♀65lb / ♂95lb)'
+    assert_text 'Thruster (♀︎65lb / ♂︎95lb)'
   end
 end


### PR DESCRIPTION
## Summary
- ♀ (U+2640) and ♂ (U+2642) are dual-presentation Unicode characters; iOS renders them with the larger, differently-baselined emoji-style glyph instead of the text-style glyph that matches surrounding body text, causing visible misalignment (see attached screenshot on the workout show page).
- `font-variant-emoji: text` (the modern CSS fix) has no Safari/iOS support, so this appends the U+FE0E text-presentation variation selector after each symbol wherever it's rendered, forcing the text-style glyph on all platforms.
- Applied to both Ruby helpers (`measurable_helper.rb`, `metrics_helper.rb`) and the mirrored JS live-preview logic in `exercise_card_controller.js` for consistency between the builder and the rendered page.

## Test plan
- [x] `bin/rails test test/helpers/measurable_helper_test.rb test/helpers/metrics_helper_test.rb test/helpers/measurable_prescribed_work_helper_test.rb` — 40 runs, 0 failures
- [x] `bin/rails test test/system/sex_specific_workout_values_test.rb test/system/exercise_card_summary_formatting_test.rb` — 7 runs, 0 failures
- [x] `bundle exec rubocop` on changed files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)