### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   verify:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/Yanchek99/wod-tracker/security/code-scanning/1](https://github.com/Yanchek99/wod-tracker/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/main.yml` so the workflow does not rely on inherited defaults.

Best single fix without changing functionality: define workflow-level minimal permissions right after the `on:` section (before `jobs:`), starting with `contents: read` as CodeQL suggests. This applies to all jobs unless overridden and documents least-privilege intent. In this specific file, add:

- `permissions:`
- `  contents: read`

This is sufficient to resolve the reported issue and is the minimal safe baseline for this CI workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
