### PR TITLE
Fix scraper failure on rounds-of-AMRAP workout headers

### DIFF
--- a/app/services/cf_wod/part_splitter.rb
+++ b/app/services/cf_wod/part_splitter.rb
@@ -6,7 +6,11 @@ module CfWod
       # Recurring rep-partitioning boilerplate (e.g. "Partition the pull-up and deadlift reps
       # any way." / "Partition the reps any way you like."): tells athletes how to split reps
       # already specified on the exercise lines, so it adds no exercise data of its own.
-      /\Apartition (?:the |your )?(?:.+ )?reps any way(?:\s+you\s+\w+)?\.?\z/i
+      /\Apartition (?:the |your )?(?:.+ )?reps any way(?:\s+you\s+\w+)?\.?\z/i,
+      # Recurring rest-interval boilerplate on rounds-of-AMRAP workouts (e.g. "Rest 1 minute
+      # between rounds."): describes the rest between rounds already captured by the segment's
+      # rounds/time scheme, so it adds no exercise data of its own.
+      /\ARest\s+\d+\s+minutes?\s+between\s+rounds\.?\z/i
     ].freeze
 
     TIME_WINDOW = /\A(\d{1,2}:\d{2})-(\d{1,2}:\d{2}):\z/

--- a/app/services/cf_wod/workout_format_classifier.rb
+++ b/app/services/cf_wod/workout_format_classifier.rb
@@ -3,6 +3,7 @@ module CfWod
     FOR_TIME = /\Afor time:?\z/i
     FOR_LOAD = /\Afor load:?\z/i
     AMRAP = /\A(?:complete )?as many (?:rounds(?: and reps)?|reps) as possible in (\d+) minutes? of:?\z/i
+    ROUNDS_AMRAP = /\Afor (\d+) rounds,\s*(?:complete )?as many (?:rounds(?: and reps)?|reps) as possible in (\d+) minutes? of:?\z/i
     EVERY_MINUTE = /\Aevery minute on the minute for (\d+) minutes?:?\z/i
     REP_LADDER = /\A(\d+(?:-\d+)+) reps for time of:?\z/i
     FIND_MAX = /\Afind a 1-rep-max (.+?)\.?\z/i
@@ -15,6 +16,7 @@ module CfWod
       [FOR_TIME, :for_time_attributes],
       [FOR_LOAD, :for_load_attributes],
       [AMRAP, :amrap_attributes],
+      [ROUNDS_AMRAP, :rounds_amrap_attributes],
       [EVERY_MINUTE, :emom_attributes],
       [REP_LADDER, :rep_ladder_attributes],
       [FIND_MAX, :find_max_attributes],
@@ -53,6 +55,11 @@ module CfWod
 
     def amrap_attributes
       { score_type: :rep, time: header_line.match(AMRAP)[1].to_i }
+    end
+
+    def rounds_amrap_attributes
+      rounds, minutes = header_line.match(ROUNDS_AMRAP).captures
+      { score_type: :rep, rounds: rounds.to_i, time: minutes.to_i }
     end
 
     def emom_attributes

--- a/test/services/cf_wod/workout_format_classifier_test.rb
+++ b/test/services/cf_wod/workout_format_classifier_test.rb
@@ -20,6 +20,11 @@ module CfWod
       assert_equal({ score_type: :rep, time: 10 }, result)
     end
 
+    test 'classifies a rounds-of-AMRAP header, extracting rounds and time' do
+      result = WorkoutFormatClassifier.call('For 5 rounds, as many reps as possible in 3 minutes of:')
+      assert_equal({ score_type: :rep, rounds: 5, time: 3 }, result)
+    end
+
     test 'classifies an every-minute-on-the-minute header, extracting rounds and time' do
       result = WorkoutFormatClassifier.call('Every minute on the minute for 10 minutes:')
       assert_equal({ score_type: :rep, time: 10, rounds: 10 }, result)

--- a/test/services/cf_wod/workout_parser_corpus_test.rb
+++ b/test/services/cf_wod/workout_parser_corpus_test.rb
@@ -14,6 +14,8 @@ module CfWod
     def wall_ball_shot = Movement.find_or_create_by(name: 'Wall-ball Shot')
     def muscle_up = Movement.find_or_create_by(name: 'Muscle-up')
     def bike = Movement.find_or_create_by(name: 'Bike')
+    def alternating_dumbbell_hang_snatch = Movement.find_or_create_by(name: 'Alternating Dumbbell Hang Snatch')
+    def dumbbell_facing_burpee = Movement.find_or_create_by(name: 'Dumbbell-facing Burpee')
 
     # Exercises are built via `segment.exercises.build(...)` (see CfWod::WorkoutParser), not
     # `workout.exercises.build(segment:)`, because a has_many :through :segments association
@@ -279,6 +281,30 @@ module CfWod
       workout = WorkoutParser.call(page)
 
       assert_equal named, workout
+    end
+
+    test '260729: a rounds-of-AMRAP header with rest boilerplate between rounds' do
+      body = "For 5 rounds, as many reps as possible in 3 minutes of:\n" \
+             "15/20-calorie row\n20 alternating dumbbell hang snatches\nMax dumbbell-facing burpees\n" \
+             "Rest 1 minute between rounds.\n\n♀ 35-lb dumbbell\n♂ 50-lb dumbbell\n\nPost reps to comments."
+      page = wod_page(slug: '260729', body_text: body)
+      hang_snatch = alternating_dumbbell_hang_snatch
+      burpee = dumbbell_facing_burpee
+
+      workout = WorkoutParser.call(page)
+
+      assert workout.valid?
+      assert_equal 'rep', workout.score_type
+      assert_equal 5, workout.governing_segment.rounds
+      assert_equal 180, workout.governing_segment.time_seconds
+      assert_equal 3, workout_exercises(workout).length
+
+      row_exercise, snatch_exercise, burpee_exercise = workout_exercises(workout).sort_by(&:position)
+      assert_equal [movements(:row), 1], [row_exercise.movement, row_exercise.reps]
+      assert_equal [1, 15, 20], [row_exercise.reps, row_exercise.female_calories, row_exercise.male_calories]
+      assert_equal [hang_snatch, 20], [snatch_exercise.movement, snatch_exercise.reps]
+      assert_equal [burpee, 0], [burpee_exercise.movement, burpee_exercise.reps]
+      assert_equal [35, 50], [snatch_exercise.female_load, snatch_exercise.male_load]
     end
 
     test "260101: a bare-number rerun doesn't loosely match a trailing-letter catalog variant" do


### PR DESCRIPTION
## Summary
- The scraper failed on today's workout with `unrecognized format header: "For 5 rounds, as many reps as possible in 3 minutes of:"` — the classifier only handled the single-round AMRAP phrasing, not the "For N rounds, ..." variant.
- Added a `ROUNDS_AMRAP` pattern/handler in `WorkoutFormatClassifier` that maps to the segment `rounds`+`time` scheme the model already supports (see the existing "renders timed rep-scored rounds as round amraps" helper test).
- Fixing the header exposed a second failure on this same workout: the trailing `"Rest 1 minute between rounds."` line wasn't recognized as boilerplate by `PartSplitter`, so it raised `unrecognized exercise line`. Added it alongside the existing "Post ... to comments." / "Partition ... reps" boilerplate patterns.

## Test plan
- [x] `bundle exec rails test test/services/cf_wod/ test/helpers/workouts_helper_test.rb` — 129 runs, 0 failures
- [x] New classifier unit test for the "For N rounds, ..." header
- [x] New corpus test reproducing the exact reported workout text end-to-end
- [x] `bundle exec rubocop` on changed files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)