### PR TITLE
Retry Done click in save_exercise_card to fix flaky system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,7 +8,17 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     scroll_to done_button, align: :center
     done_button.click
 
-    assert_selector '.exercise-summary__button[aria-expanded="false"]', text: expected_summary
+    begin
+      assert_selector '.exercise-summary__button[aria-expanded="false"]', text: expected_summary
+    rescue Minitest::Assertion
+      # Selenium's click on Done occasionally doesn't register even though the button is stable and
+      # correctly positioned (reproduced locally by shrinking Capybara's wait time -- the click call
+      # itself never raises, but the exercise-card#save Stimulus action never fires). Retrying once
+      # is a safe no-op if the first click actually worked, since Done would no longer be present.
+      click_on 'Done'
+      assert_selector '.exercise-summary__button[aria-expanded="false"]', text: expected_summary
+    end
+
     assert_no_selector '.exercise-editor', visible: :visible
   end
 end


### PR DESCRIPTION
## Summary
- `ExerciseCardEditingTest#test_edits_a_segment_exercise_through_a_summary_card` fails intermittently in CI (surfaced on #1833's build, though that PR only touches `.github/workflows/main.yml` and isn't the cause)
- Root cause: Selenium's click on the exercise card's "Done" button occasionally never reaches the `exercise-card#save` Stimulus action, even though the click call itself succeeds and the button is stable/correctly positioned. Confirmed via JS instrumentation (raw click listener + Stimulus action logging) that when this happens, all underlying form fields are valid and correctly populated -- the app logic is not at fault.
- Reproduced reliably (~1 in 10-20 runs) by shrinking `Capybara.default_max_wait_time`; passes essentially always at the real 2s default, which is why it's rare in CI.
- Fix: `save_exercise_card` now retries the Done click once if the collapse assertion fails before failing for real. Safe no-op if the first click actually worked, since the Done button disappears from the DOM once the card collapses.

## Test plan
- [x] `bin/rails test test/system/` -- 57 runs, 0 failures
- [x] `bundle exec rubocop` on touched files -- no offenses
- [x] ~100 iterations of the target test at reduced Capybara wait time with the fix in place -- 0 failures (vs. the original ~1-in-10-20 baseline failure rate without it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)