### PR TITLE
Reconcile case-mismatched movement names blocking seed run

### DIFF
--- a/script/normalize_official_movement_names.rb
+++ b/script/normalize_official_movement_names.rb
@@ -4,7 +4,10 @@ class OfficialMovementNameNormalizer
     'Kettlebell Swings' => 'Kettlebell Swing',
     'Pistol' => 'Single-leg Squat (Pistol)',
     'Strict Toes to Bar' => 'Strict Toes-to-bar',
-    'Bike' => 'Air Bike'
+    'Bike' => 'Air Bike',
+    'Chest-to-bar pull-up' => 'Chest-to-bar Pull-up',
+    'Toes To Bar' => 'Toes to Bar',
+    'Ground To Overhead' => 'Ground to Overhead'
   }.freeze
 
   BAD_MOVEMENTS = ['Press Jerk', 'Butterfly Sit-up', 'Inchworm Push-up', 'Suitcase Deadlift', 'Wall Climb'].freeze


### PR DESCRIPTION
## Summary
- Production deploy was failing with `ActiveRecord::RecordInvalid: Validation failed: Name has already been taken` at `db/seeds.rb:91`.
- Root cause: `db/seeds.rb` does exact-case `Movement.find_or_initialize_by(name: ...)` lookups, but `Movement` enforces case-insensitive name uniqueness (`app/models/movement.rb:71`). Three production rows had drifted in casing from the seed script's canonical text:
  - `Chest-to-bar pull-up` vs seed's `Chest-to-bar Pull-up`
  - `Toes To Bar` vs seed's `Toes to Bar`
  - `Ground To Overhead` vs seed's `Ground to Overhead`
  - These misses caused seeds.rb to try inserting "new" rows that collided case-insensitively with the existing ones.
- Extended `script/normalize_official_movement_names.rb`'s `RENAMES` table with the three entries (consistent with how the existing legacy-name reconciliations in that script are handled).
- Already ran the script against the production database directly (via `rails runner`) to unblock the current deploy; this PR captures the same fix in source so it's re-runnable against any other environment and isn't lost.

## Test plan
- [x] Verified against a live query that all 233 seed movement names now match production casing exactly (0 mismatches)
- [x] Ran `script/normalize_official_movement_names.rb` against production; confirmed the 3 target renames applied successfully
- [ ] Confirm next production deploy's `db:seed` step completes without the `Name has already been taken` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)