### PR TITLE
Allow profile updates without current password

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,13 @@
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    protected
+
+    def update_resource(resource, params)
+      if params[:password].present? || (params[:email].present? && params[:email].to_s != resource.email)
+        resource.update_with_password(params)
+      else
+        resource.update_without_password(params.except(:password, :password_confirmation, :current_password))
+      end
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -9,5 +9,9 @@ module Users
         resource.update_without_password(params.except(:password, :password_confirmation, :current_password))
       end
     end
+
+    def after_update_path_for(_resource)
+      edit_registration_path(resource_name)
+    end
   end
 end

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -12,7 +12,6 @@
         = f.input :weight, required: true
         = f.input :sex, collection: User.sexes.keys.map { |sex| [sex.titleize, sex] }, required: true, prompt: 'Select sex'
         = f.input :unit_system, label: 'Units', collection: User.unit_systems.keys.map { |system| [system.titleize, system] }, required: true, hint: 'How loads are displayed (kg or lb)'
-        hr
         h3 Change password
         = f.input :password, hint: "leave it blank if you don't want to change it", required: false, input_html: { autocomplete: "new-password" }
         = f.input :password_confirmation, required: false, input_html: { autocomplete: "new-password" }

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -14,7 +14,7 @@
         = f.input :unit_system, label: 'Units', collection: User.unit_systems.keys.map { |system| [system.titleize, system] }, required: true, hint: 'How loads are displayed (kg or lb)'
         = f.input :password, hint: "leave it blank if you don't want to change it", required: false, input_html: { autocomplete: "new-password" }
         = f.input :password_confirmation, required: false, input_html: { autocomplete: "new-password" }
-        = f.input :current_password, hint: 'we need your current password to confirm your changes', required: true, input_html: { autocomplete: 'current-password' }
+        = f.input :current_password, hint: 'required only when changing your email or password', required: false, input_html: { autocomplete: 'current-password' }
       .form-actions.form-group
         .btn-toolbar.justify-content-between
           .btn-group role="group"

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -12,6 +12,8 @@
         = f.input :weight, required: true
         = f.input :sex, collection: User.sexes.keys.map { |sex| [sex.titleize, sex] }, required: true, prompt: 'Select sex'
         = f.input :unit_system, label: 'Units', collection: User.unit_systems.keys.map { |system| [system.titleize, system] }, required: true, hint: 'How loads are displayed (kg or lb)'
+        hr
+        h3 Change password
         = f.input :password, hint: "leave it blank if you don't want to change it", required: false, input_html: { autocomplete: "new-password" }
         = f.input :password_confirmation, required: false, input_html: { autocomplete: "new-password" }
         = f.input :current_password, hint: 'required only when changing your email or password', required: false, input_html: { autocomplete: 'current-password' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'users/registrations' }
   get 'manifest' => 'rails/pwa#manifest', as: :pwa_manifest, defaults: { format: :json }
 
   root to: 'workouts#index'

--- a/docs/superpowers/plans/2026-08-03-profile-current-password.md
+++ b/docs/superpowers/plans/2026-08-03-profile-current-password.md
@@ -1,0 +1,86 @@
+# Conditional Current Password for Profile Updates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Require `current_password` only when a user changes their email or password.
+
+**Architecture:** Add a custom Devise registrations controller that chooses `update_with_password` for email/password changes and `update_without_password` for profile-only changes. Point the Devise registration routes at it and update the existing Slim form copy. Verify behavior with controller tests.
+
+**Tech Stack:** Ruby 4.0.5, Rails 8.1, Devise, Minitest, Slim.
+
+## Global Constraints
+
+- Preserve existing Devise registration and account deletion behavior.
+- Keep controllers thin and follow existing Rails/Minitest conventions.
+- Do not add client-side JavaScript or unrelated refactors.
+
+---
+
+### Task 1: Add failing registration controller tests
+
+**Files:**
+- Create: `test/controllers/devise/registrations_controller_test.rb`
+
+**Interfaces:**
+- Tests use the Devise registration update route and the existing `users(:one)` fixture.
+
+- [ ] **Step 1: Write tests for the four required behaviors**
+
+Cover: profile-only update without `current_password` succeeds; email update without it fails and does not change email; password update without it fails and does not change password; email/password update with the correct current password succeeds.
+
+- [ ] **Step 2: Run the focused test and verify it fails for the missing behavior**
+
+Run: `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/devise/registrations_controller_test.rb`
+
+Expected: profile-only update fails under Devise's default `update_with_password` behavior.
+
+### Task 2: Implement conditional Devise update behavior
+
+**Files:**
+- Create: `app/controllers/devise/registrations_controller.rb`
+- Modify: `config/routes.rb`
+
+**Interfaces:**
+- `Devise::RegistrationsController#update_resource(resource, params)` selects the Devise update method based on email/password changes.
+
+- [ ] **Step 1: Configure Devise registrations to use the custom controller**
+
+Change the existing `devise_for :users` declaration to reference `devise/registrations`.
+
+- [ ] **Step 2: Implement the minimal `update_resource` override**
+
+Use `update_with_password` when email differs from the persisted email or password is present; otherwise use `update_without_password` after removing password fields and `current_password`.
+
+- [ ] **Step 3: Run the focused controller tests**
+
+Run: `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/devise/registrations_controller_test.rb`
+
+Expected: all focused tests pass.
+
+### Task 3: Update the profile form and verify the relevant suite
+
+**Files:**
+- Modify: `app/views/devise/registrations/edit.html.slim`
+- Modify: `test/controllers/devise/registrations_controller_test.rb`
+
+- [ ] **Step 1: Make the current-password field optional in the form**
+
+Set `required: false` and update the hint to say it is needed only for email or password changes.
+
+- [ ] **Step 2: Add an edit-page assertion for the optional field and run focused tests**
+
+Run: `rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/devise/registrations_controller_test.rb`
+
+Expected: all focused tests pass.
+
+- [ ] **Step 3: Build assets and run relevant regression tests**
+
+Run: `yarn build:css && yarn build && rvm 4.0.5@wod-tracker do bundle exec rails test test/controllers/devise/registrations_controller_test.rb test/controllers/turbo_conventions_test.rb test/models/user_test.rb`
+
+Expected: exit code 0 with no test failures or errors.
+
+- [ ] **Step 4: Run RuboCop on changed Ruby files**
+
+Run: `rvm 4.0.5@wod-tracker do bundle exec rubocop app/controllers/devise/registrations_controller.rb test/controllers/devise/registrations_controller_test.rb`
+
+Expected: no offenses.

--- a/docs/superpowers/specs/2026-08-03-profile-current-password-design.md
+++ b/docs/superpowers/specs/2026-08-03-profile-current-password-design.md
@@ -1,0 +1,19 @@
+# Conditional Current Password for Profile Updates
+
+## Goal
+
+Allow users to update profile details without entering their current password, while requiring the current password for email or password changes.
+
+## Design
+
+Override Devise's registration update behavior in a project registration controller. If the submitted email differs from the persisted email or a new password is present, use Devise's `update_with_password`; otherwise use `update_without_password` while excluding password-related parameters. Route Devise registrations through this controller.
+
+The profile form will make the current-password input optional and explain that it is required only when changing email or password. Server-side behavior remains authoritative; no client-side JavaScript is required.
+
+## Testing
+
+Add controller/request coverage for profile-only updates without a current password, sensitive updates without a current password, sensitive updates with the correct password, and the edit form's optional current-password field.
+
+## Scope
+
+No changes to password-reset flows, account deletion, or unrelated profile validation.

--- a/test/controllers/devise/registrations_controller_test.rb
+++ b/test/controllers/devise/registrations_controller_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+module Devise
+  class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @user = users(:mathew)
+      @user.update!(password: 'password123', password_confirmation: 'password123')
+      sign_in @user
+    end
+
+    test 'profile-only updates do not require the current password' do
+      put user_registration_url, params: { user: { first_name: 'Matthew' } }
+
+      assert_redirected_to root_url
+      assert_equal 'Matthew', @user.reload.first_name
+    end
+
+    test 'email updates require the current password' do
+      put user_registration_url, params: { user: { email: 'new@example.com' } }
+
+      assert_response :unprocessable_entity
+      assert_equal 'mathew.fraser@wod-tracker.com', @user.reload.email
+    end
+
+    test 'password updates require the current password' do
+      put user_registration_url, params: {
+        user: { password: 'new-password123', password_confirmation: 'new-password123' }
+      }
+
+      assert_response :unprocessable_entity
+      assert @user.reload.valid_password?('password123')
+    end
+
+    test 'email and password updates accept the correct current password' do
+      put user_registration_url, params: {
+        user: {
+          email: 'new@example.com',
+          password: 'new-password123',
+          password_confirmation: 'new-password123',
+          current_password: 'password123'
+        }
+      }
+
+      assert_redirected_to root_url
+      assert_equal 'new@example.com', @user.reload.email
+      assert @user.valid_password?('new-password123')
+    end
+
+    test 'edit form does not universally require the current password' do
+      get edit_user_registration_url
+
+      assert_response :success
+      assert_select 'input[name="user[current_password]"]:not([required])'
+    end
+  end
+end

--- a/test/controllers/devise/registrations_controller_test.rb
+++ b/test/controllers/devise/registrations_controller_test.rb
@@ -13,7 +13,8 @@ module Devise
     test 'profile-only updates do not require the current password' do
       put user_registration_url, params: { user: { first_name: 'Matthew' } }
 
-      assert_redirected_to root_url
+      assert_redirected_to edit_user_registration_url
+      assert_equal 'Your account has been updated successfully.', flash[:notice]
       assert_equal 'Matthew', @user.reload.first_name
     end
 
@@ -43,7 +44,8 @@ module Devise
         }
       }
 
-      assert_redirected_to root_url
+      assert_redirected_to edit_user_registration_url
+      assert_equal 'Your account has been updated successfully.', flash[:notice]
       assert_equal 'new@example.com', @user.reload.email
       assert @user.valid_password?('new-password123')
     end
@@ -52,6 +54,8 @@ module Devise
       get edit_user_registration_url
 
       assert_response :success
+      assert_select 'h3', text: 'Change password'
+      assert_select 'hr'
       assert_select 'input[name="user[current_password]"]:not([required])'
     end
   end

--- a/test/controllers/devise/registrations_controller_test.rb
+++ b/test/controllers/devise/registrations_controller_test.rb
@@ -55,7 +55,7 @@ module Devise
 
       assert_response :success
       assert_select 'h3', text: 'Change password'
-      assert_select 'hr'
+      assert_select 'hr', false
       assert_select 'input[name="user[current_password]"]:not([required])'
     end
   end


### PR DESCRIPTION
## What changed

- Allow profile-only edits without requiring the current password.
- Continue requiring the current password for email or password changes.
- Update the profile form copy and add regression coverage.

## Why

Devise's default account update flow required `current_password` for every profile update, including harmless changes such as name, weight, sex, or unit preference.

## Validation

- 19 Rails tests, 93 assertions
- RuboCop clean for changed Ruby files