### PR TITLE
Fix Open 24.2 row scoring

### DIFF
--- a/app/models/concerns/log_scoring.rb
+++ b/app/models/concerns/log_scoring.rb
@@ -102,8 +102,6 @@ module LogScoring
   end
 
   def submitted_distance_score_reps(metric, distance_units_per_rep)
-    return nil if (metric.value % distance_units_per_rep).nonzero?
-
     metric.value / distance_units_per_rep
   end
 end

--- a/db/seeds/open_workouts.rb
+++ b/db/seeds/open_workouts.rb
@@ -1062,7 +1062,8 @@ end
 Workout.find_or_create_by(name: 'Open 24.2') do |workout|
   segment = workout.segments.build(time_seconds: 1200, position: 1)
   workout.score_type = :rep
-  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 300, distance_unit: :meter)
+  segment.exercises.build(movement: row, position: 1, reps: 1, distance: 300, distance_unit: :meter,
+                          distance_units_per_rep: 10)
   segment.exercises.build(movement: deadlift, position: 2, reps: 10, female_load: 125, male_load: 185, load_unit: :lb)
   segment.exercises.build(movement: double_under, position: 3, reps: 50)
 end

--- a/test/models/log_amrap_test.rb
+++ b/test/models/log_amrap_test.rb
@@ -39,6 +39,18 @@ class LogAmrapTest < ActiveSupport::TestCase
     assert_equal 15, log.reps_per_round
   end
 
+  test 'rounds down submitted distance when calculating distance-to-rep scoring' do
+    log = workouts(:amrap_mixed).logs.build(user: users(:mathew), score_type: :rep, score_value: '2+5')
+    log.build_movement_logs
+
+    row_recording = log.movement_logs.find { |movement_log| movement_log.movement == movements(:row) }
+    row_recording.distance = 237
+
+    assert log.valid?
+    assert_equal 53, log.reps_per_round
+    assert_equal 111, log.score_value
+  end
+
   test 'accepts raw total reps' do
     log = workouts(:amrap_couplet).logs.build(user: users(:mathew), score_type: :rep, score_value: '202')
 


### PR DESCRIPTION
## Summary

- configure Open 24.2 rowing as 10 meters per scored rep
- floor partial distance submissions, matching the official 24.2 scoring rule
- cover a 237-meter row as 23 reps

## Root cause

The seed omitted the row conversion, and submitted partial distances were rejected instead of rounded down.

## Validation

- `rvm 4.0.6@wod-tracker do bundle exec rails test test/models/log_amrap_test.rb`
- `rvm 4.0.6@wod-tracker do bundle exec rubocop app/models/concerns/log_scoring.rb test/models/log_amrap_test.rb`
- `rvm 4.0.6@wod-tracker do ruby -c db/seeds/open_workouts.rb`

The full suite was started but not completed because duplicate system-test runs were terminated.